### PR TITLE
Add instructions to README for getting code from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ aspects of the API may change before GA. If you'd prefer, you can use the
 
 If you're interested in testing out the 2.0 pilot, see our [migration guide](https://www.twilio.com/docs/voice/client/migrating-to-js-voice-sdk-20).
 
-Until the JavaScript Voice SDK goes GA, we recommend installing the SDK by using this Github repository.
+Until the JavaScript Voice SDK goes GA, we recommend installing the SDK by using this GitHub repository.
 Once version 2.0 goes GA, we recommend installing the SDK as usual through the `npm` package `@twilio/voice-sdk`.
 
 ```
@@ -55,6 +55,42 @@ const Device = require('@twilio/voice-sdk').Device;
 
 ### CDN
 As of 2.0, the Twilio Voice SDK is no longer hosted via CDN.
+
+### GitHub
+
+Although we recommend using `npm` to add the Voice SDK as a dependency, you can also get the Twilio Voice SDK code
+from GitHub and include it in your project directly. To do so, navigate to
+["Releases"](https://github.com/twilio/twilio-voice.js/releases) and find the most recent release, or
+the particular release version you'd like to use.
+
+> **Note:** releases tagged with "-rc" are "Release Candidate" versions
+> and are still being tested. Unless you specifically know that you want to use a release candidate
+> version, you should not use a release with "-rc" in the name.
+
+Download either the `zip` or the `tar.gz` and then extract the files. For example, if you downloaded the
+tarball for the `2.0.0` release, you could then extract the files with the `tar` command:
+
+```
+tar -xvzf twilio-voice.js-2.0.0.tar.gz
+cd twilio-voice.js-2.0.0
+```
+
+Once you've extracted the folder, the `twilio.js` and `twilio.min.js` files that
+you can include in your project will be in the `/dist` directory. `twilio.min.js` is the
+minified version of the code.
+
+You can copy either the `twilio.js` or the `twilio.min.js` file into your project and
+then provide a link to it in your html. For example:
+
+```
+<script type="text/javascript" src="twilio.min.js"></script>
+```
+
+Using this method, you can access the SDK through the browser global:
+
+```
+const Device = Twilio.Device;
+```
 
 Testing
 -------


### PR DESCRIPTION
PR in place of https://github.com/twilio/twilio-voice.js/pull/4
This adds a section for how to pull in the sdk code from github. Because the CDN is no longer available, we want to show an option for how to get the code without node or npm (for example, if someone is just testing the sdk with a server in a different language, and doesn't want to download node to run this).

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
