### PR TITLE
[VBLOCKS-146] Fix double register during `Device.updateOptions`.

### DIFF
--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -751,12 +751,7 @@ class Device extends EventEmitter {
     this._setupPublisher();
 
     if (hasChunderURIsChanged && this._streamConnectedPromise) {
-      const shouldReRegister = this.state === Device.State.Registered;
-      this._setupStream().then(async () => {
-        if (shouldReRegister) {
-          await this.register();
-        }
-      });
+      this._setupStream();
     }
 
     // Setup close protection and make sure we clean up ongoing calls on unload.
@@ -1288,7 +1283,7 @@ class Device extends EventEmitter {
     this._stream.addListener('offline', this._onSignalingOffline);
     this._stream.addListener('ready', this._onSignalingReady);
 
-    return this._streamConnectedPromise = new Promise<this>(resolve =>
+    return this._streamConnectedPromise = new Promise<IPStream>(resolve =>
       this._stream.once('connected', () => {
         resolve(this._stream);
       }),

--- a/tests/integration/mutableOptions.ts
+++ b/tests/integration/mutableOptions.ts
@@ -45,6 +45,33 @@ describe('mutable options', function() {
     });
   });
 
+  it('should not throw during re-registration', async function() {
+    this.timeout(10000);
+
+    const dev = device = new Device(token, { edge: 'sydney' });
+
+    await dev.register();
+
+    const regCalls: Array<Promise<any>> = [];
+
+    dev.register = () => {
+      const regCall = Device.prototype.register.call(dev);
+      regCalls.push(regCall);
+      return regCall;
+    };
+
+    const registeredPromise = new Promise(resolve => {
+      dev.once(Device.EventName.Registered, resolve);
+    });
+
+    dev.updateOptions({ edge: 'ashburn' });
+
+    await registeredPromise;
+
+    assert(regCalls.length);
+    await Promise.all(regCalls);
+  });
+
   context('ongoing calls', function() {
     this.timeout(30000);
 

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -377,6 +377,30 @@ describe('Device', function() {
           sinon.assert.calledOnce(setupStreamSpy);
         });
 
+        it('should not throw during re-registration', async () => {
+          await registerDevice();
+
+          const regCalls: Array<Promise<any>> = [];
+
+          device.register = () => {
+            const regCall = Device.prototype.register.call(device);
+            regCalls.push(regCall);
+            return regCall;
+          };
+
+          device.updateOptions({ edge: 'sydney' });
+
+          pstream.emit('offline');
+          await clock.tickAsync(0);
+          pstream.emit('connected', { region: 'EU_IRELAND' });
+          await clock.tickAsync(0);
+          pstream.emit('ready');
+          await clock.tickAsync(0);
+
+          assert(regCalls.length);
+          await Promise.all(regCalls);
+        });
+
         describe('log', () => {
           let setDefaultLevelStub: any;
 


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [VBLOCKS-146](https://issues.corp.twilio.com/browse/VBLOCKS-146)

### Description

Fix double register during `Device.updateOptions`.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [x] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [x] Got one or more +1s
* [x] Squashed erroneous commits if necessary
* [x] Re-tested if necessary
