### PR TITLE
Add EventName enum to Call namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@
 New Features
 ------------
 
+- ### Call Event Enum
+
+The Twilio `Call` entity now includes an EventName enum. You can access each event type off of the enum. These are used when specifying events off of the `Call` entity. For more information, see [this page](https://www.twilio.com/docs/voice/sdks/javascript/twiliocall#events).
+
+```
+export enum EventName {
+  Accept = 'accept',
+  Cancel = 'cancel',
+  Disconnect = 'disconnect',
+  Error = 'error',
+  Mute = 'mute',
+  Reject = 'reject',
+  Sample = 'sample',
+  Volume = 'volume',
+} 
+```
+
 - ### Twilio Regional Support
 
 The Twilio Voice JS SDK now supports Twilio Regional. To use a home region, please specify the desired home region in the access token before passing the token to the Twilio `Device`. This home region parameter should be matched with the appropriate `edge` parameter when instantiating a Twilio `Device`. The home region determines the location of your Insights data, as opposed to the `edge` that your call connects to Twilio through.

--- a/lib/twilio/call.ts
+++ b/lib/twilio/call.ts
@@ -1337,6 +1337,20 @@ namespace Call {
    */
   declare function sampleEvent(sample: RTCSample): void;
 
+   /**
+   * Possible states of the {@link Call}.
+   */
+    export enum EventName {
+      Accept = 'accept',
+      Cancel = 'cancel',
+      Disconnect = 'disconnect',
+      Error = 'error',
+      Mute = 'mute',
+      Reject = 'reject',
+      Sample = 'sample',
+      Volume = 'volume',
+    } 
+
   /**
    * Possible states of the {@link Call}.
    */

--- a/lib/twilio/call.ts
+++ b/lib/twilio/call.ts
@@ -1338,7 +1338,7 @@ namespace Call {
   declare function sampleEvent(sample: RTCSample): void;
 
    /**
-   * Possible states of the {@link Call}.
+   * Possible events of the {@link Call}.
    */
     export enum EventName {
       Accept = 'accept',


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

Add EventName enum to Call namespace.

```
    export enum EventName {
      Accept = 'accept',
      Cancel = 'cancel',
      Disconnect = 'disconnect',
      Error = 'error',
      Mute = 'mute',
      Reject = 'reject',
      Sample = 'sample',
      Volume = 'volume',
    } 
```

This is based on documentation [here](https://www.twilio.com/docs/voice/sdks/javascript/twiliocall#events).

### JIRA link(s):

- [CLIENT-0000](https://issues.corp.twilio.com/browse/CLIENT-0000)

### Description

Add EventName enum to Call namespace.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
