### PR TITLE
Stop current sounds when updating

### DIFF
--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -744,13 +744,11 @@ class Device extends EventEmitter {
         maxDuration: soundDef.maxDuration,
         shouldLoop: soundDef.shouldLoop,
       });
-      
-      const currentSound = this._soundcache.get(name as Device.SoundName);
-      if (currentSound?.isPlaying) {
-        currentSound.stop();
-        sound.play();
-      }
 
+      const currentSound = this._soundcache.get(name as Device.SoundName)
+      if (currentSound) {
+        currentSound.stop()
+      }
       this._soundcache.set(name as Device.SoundName, sound);
     }
 

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -744,6 +744,12 @@ class Device extends EventEmitter {
         maxDuration: soundDef.maxDuration,
         shouldLoop: soundDef.shouldLoop,
       });
+      
+      const currentSound = this._soundcache.get(name as Device.SoundName);
+      if (currentSound?.isPlaying) {
+        currentSound.stop();
+        sound.play();
+      }
 
       this._soundcache.set(name as Device.SoundName, sound);
     }


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

### Description

Stops currently playing sound when updating device sounds.

## Burndown

In current version if you get an incoming call and update the sounds before answering the old sound will keep playing. This PR stops the current cached sound.

Note: I tried to play the new sound when updating sounds if the isPlaying property is true, but it seems like this property is true in some cases when sounds isn't playing so I couldn't rely on this property in this case.

### Before review
* ~[ ] Updated CHANGELOG.md if necessary~
* ~[ ] Added unit tests if necessary~
* ~[ ] Updated affected documentation~
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
