### PR TITLE
[VBLOCKS-329] Update edge after successful connection.

### DIFF
--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -24,6 +24,7 @@ import Log from './log';
 import { PreflightTest } from './preflight/preflight';
 import {
   createEventGatewayURI,
+  Edge,
   getChunderURIs,
   getRegionShortcode,
   Region,
@@ -1059,7 +1060,7 @@ class Device extends EventEmitter {
    */
   private _onSignalingConnected = (payload: Record<string, any>) => {
     const region = getRegionShortcode(payload.region);
-    this._edge = regionToEdge[region as Region] || payload.region;
+    this._edge = payload.edge || regionToEdge[region as Region] || payload.region;
     this._region = region || payload.region;
     this._publisher?.setHost(createEventGatewayURI(payload.home));
     if (payload.token) {
@@ -1072,7 +1073,7 @@ class Device extends EventEmitter {
     this._home = payload.home;
 
     this._stream.updateURIs(getChunderURIs(
-      this._edge,
+      this._edge as Edge,
       undefined,
       this._log.warn.bind(this._log),
     ));

--- a/lib/twilio/pstream.js
+++ b/lib/twilio/pstream.js
@@ -241,6 +241,7 @@ PStream.prototype.destroy = function() {
 
 PStream.prototype.updateURIs = function(uris) {
   this._uris = uris;
+  this.transport.updateURIs(this._uris);
 };
 
 PStream.prototype.publish = function(type, payload) {

--- a/lib/twilio/wstransport.ts
+++ b/lib/twilio/wstransport.ts
@@ -236,7 +236,7 @@ export default class WSTransport extends EventEmitter {
 
   /**
    * Update acceptable URIs to reconnect to. Useful for Call signaling reconnection, which requires
-   * connecting on the same edge.
+   * connecting on the same edge. Resets the URI index to 0.
    */
   updateURIs(uris: string[] | string) {
     if (typeof uris === 'string') {
@@ -244,6 +244,7 @@ export default class WSTransport extends EventEmitter {
     }
 
     this._uris = uris;
+    this._uriIndex = 0;
   }
 
   /**

--- a/tests/network/reconnection.ts
+++ b/tests/network/reconnection.ts
@@ -89,7 +89,7 @@ describe('Reconnection', function() {
    * NOTE(mhuynh): Firefox websockets have indeterminate signaling loss
    * behavior.
    */
-  (isFirefox() ? describe.skip : describe)('signaling reconnection', function() {
+  (isFirefox() ? describe : describe)('signaling reconnection', function() {
     this.timeout(USE_CASE_TIMEOUT);
 
     before(async () => {
@@ -113,6 +113,24 @@ describe('Reconnection', function() {
 
       await waitFor(reconnectPromises, 20000);
 
+      assert([call1, call2].every(call => call.status() === Call.State.Open));
+    });
+
+    it('should reconnect to signaling multiple times', async () => {
+      await runDockerCommand('disconnectFromAllNetworks');
+      let reconnectPromises = Promise.all([call1, call2].map(
+        call => new Promise(res => call.on('reconnected', res)),
+      ));
+      setTimeout(() => runDockerCommand('resetNetwork'), 8000);
+      await waitFor(reconnectPromises, 20000);
+      assert([call1, call2].every(call => call.status() === Call.State.Open));
+
+      await runDockerCommand('disconnectFromAllNetworks');
+      reconnectPromises = Promise.all([call1, call2].map(
+        call => new Promise(res => call.on('reconnected', res)),
+      ));
+      setTimeout(() => runDockerCommand('resetNetwork'), 8000);
+      await waitFor(reconnectPromises, 20000);
       assert([call1, call2].every(call => call.status() === Call.State.Open));
     });
 

--- a/tests/pstream.js
+++ b/tests/pstream.js
@@ -9,6 +9,7 @@ const EXPECTED_PSTREAM_VERSION = '1.6';
 
 describe('PStream', () => {
   let pstream;
+
   beforeEach(() => {
     pstream = new PStream('foo', ['wss://foo.bar/signal'], {
       TransportFactory
@@ -158,6 +159,18 @@ describe('PStream', () => {
       pstream.transport.emit('message', { data: JSON.stringify({ type: 'close' })});
       pstream.transport.emit('message', { data: JSON.stringify({ type: 'close' })});
       assert.equal(count, 1);
+    });
+  });
+
+  describe('updateURIs', () => {
+    it('should update the uris', () => {
+      pstream.updateURIs(['foo', 'bar']);
+      assert.deepEqual(pstream._uris, ['foo', 'bar']);
+    });
+
+    it('should update the wstransport uris', () => {
+      pstream.updateURIs(['foo', 'bar']);
+      sinon.assert.calledOnce(pstream.transport.updateURIs);
     });
   });
 

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -3,6 +3,7 @@ import CallType from '../../lib/twilio/call';
 import Device from '../../lib/twilio/device';
 import { GeneralErrors } from '../../lib/twilio/errors';
 import {
+  Edge,
   Region,
   regionShortcodes,
   regionToEdge,
@@ -484,6 +485,12 @@ describe('Device', function() {
           await clock.tickAsync(0);
 
           sinon.assert.calledOnce(spy);
+        });
+
+        it('should update the pstream edge', () => {
+          const spy = pstream.updateURIs = sinon.spy(pstream.updateURIs);
+          pstream.emit('connected', { region: 'EU_IRELAND', edge: Edge.Dublin });
+          sinon.assert.calledOnceWithExactly(spy, ['chunderw-vpc-gll-ie1.twilio.com']);
         });
       });
 

--- a/tests/unit/wstransport.ts
+++ b/tests/unit/wstransport.ts
@@ -241,6 +241,18 @@ describe('WSTransport', () => {
     });
   });
 
+  describe('#updateURIs', () => {
+    it('should update the URIs', () => {
+      transport.updateURIs(['foo', 'bar']);
+      assert.deepEqual(transport['_uris'], ['foo', 'bar']);
+    });
+
+    it('should reset the URI index', () => {
+      transport.updateURIs(['foo', 'bar']);
+      assert.equal(transport['_uriIndex'], 0);
+    });
+  });
+
   describe('onSocketMessage', () => {
     beforeEach(() => {
       transport.open();


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [VBLOCKS-329](https://issues.corp.twilio.com/browse/VBLOCKS-329)

### Description

This PR updates the internal edge references after making a successful connection to the Twilio backend.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
