### PR TITLE
GH44 VBLOCKS-471

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Bug Fixes
 
 - Ignoring a call will now properly stop the ringing sound
 - NPM versioning has been fixed to specify >=12 rather than exactly 12
+- Use DOMException instead oof DOMError, which has been deprecated
 
 2.1.0 (December 16, 2021) - Release
 ===================================

--- a/lib/twilio/preflight/preflight.ts
+++ b/lib/twilio/preflight/preflight.ts
@@ -61,7 +61,7 @@ export declare interface PreflightTest {
    * @example `preflight.on('failed', error => console.log(error))`
    * @event
    */
-  failedEvent(error: TwilioError | DOMError): void;
+  failedEvent(error: TwilioError | DOMException): void;
 
   /**
    * Raised when the [[Call]] gets a webrtc sample object. This event is published every second.
@@ -429,7 +429,7 @@ export class PreflightTest extends EventEmitter {
    * Called when there is a fatal error
    * @param error
    */
-  private _onFailed(error: TwilioError | DOMError): void {
+  private _onFailed(error: TwilioError | DOMException): void {
     clearTimeout(this._echoTimer);
     clearTimeout(this._signalingTimeoutTimer);
     this._releaseHandlers();


### PR DESCRIPTION
#44 

Emit DOMException rather than DOMError

TODO: Update CHANGELOG after rebasing on master.