### PR TITLE
VBLOCKS-326 | Add Device._forceSignalingReconnect

### DIFF
--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -932,6 +932,14 @@ class Device extends EventEmitter {
   }
 
   /**
+   * Force a signaling reconnection
+   * @private
+   */
+  private _forceSignalingReconnect(): void {
+    this._stream.forceReconnect();
+  }
+
+  /**
    * Create a new {@link Call}.
    * @param twimlParams - A flat object containing key:value pairs to be sent to the TwiML app.
    * @param options - Options to be used to instantiate the {@link Call}.

--- a/lib/twilio/pstream.js
+++ b/lib/twilio/pstream.js
@@ -167,6 +167,10 @@ PStream.prototype._handleTransportOpen = function() {
 PStream.toString = () => '[Twilio.PStream class]';
 PStream.prototype.toString = () => '[Twilio.PStream instance]';
 
+PStream.prototype.forceReconnect = function() {
+  this.transport.forceReconnect();
+};
+
 PStream.prototype.setToken = function(token) {
   this._log.info('Setting token and publishing listen');
   this.token = token;

--- a/lib/twilio/wstransport.ts
+++ b/lib/twilio/wstransport.ts
@@ -217,6 +217,18 @@ export default class WSTransport extends EventEmitter {
   }
 
   /**
+   * Close the websocket and force a signaling reconnection
+   */
+  forceReconnect(): void {
+    if (this._socket && (
+        this._socket.readyState === WebSocket.CONNECTING ||
+        this._socket.readyState === WebSocket.OPEN)
+    ) {
+      this._socket.close();
+    }
+  }
+
+  /**
    * Attempt to open a WebSocket connection.
    */
   open(): void {


### PR DESCRIPTION
Creates an internal function, `Device._forceSignalingReconnect', that we can use internally for testing. cc @ajansson76 