### PR TITLE
Add status event, corresponding unit tests, and update documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+2.1.2 (???? ??, 2022)
+=========================
+
+New Features
+---------
+
+### Call status event
+The SDK now allows you to subscribe to changes to the `Call` object's state using the `status` event.
+
+```ts
+const call = await device.connect(...);
+call.on('status', (status: Call.State) => { ... });
+```
+
 2.1.1 (February 18, 2022)
 =========================
 


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### Description

Adds a status event to the Call object that fires whenever the `_status` private variable is updated. This is important for implementation in React projects so that your UI can be updated when the status changes without requiring manual checks in an interval.

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [x] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
