### PR TITLE
VBLOCKS-1086 Use voice-js DNS names directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.sw*
+.env
 .idea
 .nyc_output/
 config.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+2.2.0 (In Progress)
+===================
+
+Changes
+-------
+
+This release includes updated DNS names for [Twilio Edge Locations](https://www.twilio.com/docs/global-infrastructure/edge-locations). The Voice JS SDK uses these Edge Locations to connect to Twilio’s infrastructure via the parameter `Device.Options.edge`. The current usage of this parameter does not change as the SDK automatically maps the edge value to the new DNS names.
+
+Additionally, you need to update your [Content Security Policies (CSP)](README.md#content-security-policy-csp) if you have it enabled for your application. You also need to update your network configuration such as firewalls, if necessary, to allow connections to the new [DNS names and IP addresses](https://www.twilio.com/docs/voice/sdks/network-connectivity-requirements).
+
+
 2.1.1 (February 18, 2022)
 =========================
 

--- a/README.md
+++ b/README.md
@@ -137,27 +137,27 @@ Use the following policy directives to enable [CSP](https://developer.mozilla.or
 ```
 script-src https://media.twiliocdn.com https://sdk.twilio.com
 media-src mediastream https://media.twiliocdn.com https://sdk.twilio.com
-connect-src https://eventgw.twilio.com wss://chunderw-vpc-gll.twilio.com https://media.twiliocdn.com https://sdk.twilio.com
+connect-src https://eventgw.twilio.com wss://voice-js.roaming.twilio.com https://media.twiliocdn.com https://sdk.twilio.com
 ```
 
-If you are providing a non-default value for `Device.ConnectOptions.edge` parameter, you need to add the Signaling URI `wss://chunderw-vpc-gll-{regionId}.twilio.com` in your `connect-src` directive where `regionId` is the `Region ID` as defined in this [page](https://www.twilio.com/docs/global-infrastructure/edge-locations/legacy-regions). See examples below.
+If you are providing a non-default value for `Device.ConnectOptions.edge` parameter, you need to add the Signaling URI `wss://voice-js.{edgeId}.twilio.com` in your `connect-src` directive where `edgeId` is the `Edge ID` as defined in this [page](https://www.twilio.com/docs/global-infrastructure/edge-locations). See examples below.
 
 **If `Device.ConnectOptions.edge` is `ashburn`**
 
 ```
-connect-src https://eventgw.twilio.com https://media.twiliocdn.com https://sdk.twilio.com wss://chunderw-vpc-gll-us1.twilio.com
+connect-src https://eventgw.twilio.com https://media.twiliocdn.com https://sdk.twilio.com wss://voice-js.ashburn.twilio.com
 ```
 
 **If `Device.ConnectOptions.edge` is `['ashburn', 'sydney', 'roaming']`**
 
 ```
-connect-src https://eventgw.twilio.com https://media.twiliocdn.com https://sdk.twilio.com wss://chunderw-vpc-gll-us1.twilio.com wss://chunderw-vpc-gll-au1.twilio.com wss://chunderw-vpc-gll.twilio.com
+connect-src https://eventgw.twilio.com https://media.twiliocdn.com https://sdk.twilio.com wss://voice-js.ashburn.twilio.com wss://voice-js.sydney.twilio.com wss://voice-js.roaming.twilio.com
 ```
 
 If you are providing a home region grant into your [Twilio access token](https://www.twilio.com/docs/iam/access-tokens), you need to add the insights endpoint in your `connect-src` directive using `eventgw.{homeRegion}.twilio.com` format. Below is an example if your home region grant is `sg1`.
 
 ```
-connect-src https://eventgw.sg1.twilio.com wss://chunderw-vpc-gll.twilio.com https://media.twiliocdn.com https://sdk.twilio.com
+connect-src https://eventgw.sg1.twilio.com wss://voice-js.roaming.twilio.com https://media.twiliocdn.com https://sdk.twilio.com
 ```
 
 License

--- a/lib/twilio/call.ts
+++ b/lib/twilio/call.ts
@@ -922,15 +922,10 @@ class Call extends EventEmitter {
       call_sid: this.parameters.CallSid,
       dscp: !!this._options.dscp,
       sdk_version: C.RELEASE_VERSION,
-      selected_region: this._options.selectedRegion,
     };
 
     if (this._options.gateway) {
       payload.gateway = this._options.gateway;
-    }
-
-    if (this._options.region) {
-      payload.region = this._options.region;
     }
 
     payload.direction = this._direction;
@@ -1665,11 +1660,6 @@ namespace Call {
     reconnectToken?: string;
 
     /**
-     * The Region currently connected to.
-     */
-    region?: string;
-
-    /**
      * An RTCConfiguration to pass to the RTCPeerConnection constructor.
      */
     rtcConfiguration?: RTCConfiguration;
@@ -1679,11 +1669,6 @@ namespace Call {
      * The format of this object depends on browser.
      */
     rtcConstraints?: MediaStreamConstraints;
-
-    /**
-     * The region passed to {@link Device} on setup.
-     */
-    selectedRegion?: string;
 
     /**
      * Whether the disconnect sound should be played.

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -736,11 +736,7 @@ class Device extends EventEmitter {
       : Array.isArray(this._options.chunderw) && this._options.chunderw;
 
     const newChunderURIs = this._chunderURIs = (
-      chunderw || getChunderURIs(
-        this._options.edge,
-        undefined,
-        this._log.warn.bind(this._log),
-      )
+      chunderw || getChunderURIs(this._options.edge)
     ).map(createSignalingEndpointURL);
 
     let hasChunderURIsChanged =
@@ -1107,11 +1103,7 @@ class Device extends EventEmitter {
     }
     this._home = payload.home;
 
-    const preferredURIs = getChunderURIs(
-      this._edge as Edge,
-      undefined,
-      this._log.warn.bind(this._log),
-    );
+    const preferredURIs = getChunderURIs(this._edge as Edge);
     if (preferredURIs.length > 0) {
       const [preferredURI] = preferredURIs;
       this._preferredURI = createSignalingEndpointURL(preferredURI);

--- a/lib/twilio/regions.ts
+++ b/lib/twilio/regions.ts
@@ -179,7 +179,7 @@ export function getChunderURIs(edge?: string[] | string): string[] {
 
   if (edge) {
     const edgeParams = Array.isArray(edge) ? edge : [edge];
-    uris = edgeParams.map((param: Edge) =>createChunderEdgeURI(param));
+    uris = edgeParams.map((param: Edge) => createChunderEdgeURI(param));
   } else {
     uris = [createChunderEdgeURI(defaultEdge)];
   }

--- a/lib/twilio/regions.ts
+++ b/lib/twilio/regions.ts
@@ -6,20 +6,6 @@
 import { InvalidArgumentError } from './errors';
 
 /**
- * Valid deprecated regions.
- * @private
- */
-export enum DeprecatedRegion {
-  Au = 'au',
-  Br = 'br',
-  Ie = 'ie',
-  Jp = 'jp',
-  Sg = 'sg',
-  UsOr = 'us-or',
-  UsVa = 'us-va',
-}
-
-/**
  * Valid edges.
  * @private
  */
@@ -88,26 +74,6 @@ export enum Region {
 }
 
 /**
- * All valid regions
- * @private
- */
-export type ValidRegion = Region | DeprecatedRegion;
-
-/**
- * Deprecated regions. Maps the deprecated region to its equivalent up-to-date region.
- * @private
- */
-export const deprecatedRegions: Record<DeprecatedRegion, Region> = {
-  [DeprecatedRegion.Au]: Region.Au1,
-  [DeprecatedRegion.Br]: Region.Br1,
-  [DeprecatedRegion.Ie]: Region.Ie1,
-  [DeprecatedRegion.Jp]: Region.Jp1,
-  [DeprecatedRegion.Sg]: Region.Sg1,
-  [DeprecatedRegion.UsOr]: Region.Us1,
-  [DeprecatedRegion.UsVa]: Region.Us1,
-};
-
-/**
  * Region shortcodes. Maps the full region name from AWS to the Twilio shortcode.
  * @private
  */
@@ -120,60 +86,6 @@ export const regionShortcodes: { [index: string]: Region } = {
   SOUTH_AMERICA_SAO_PAULO: Region.Br1,
   US_EAST_VIRGINIA: Region.Us1,
   US_WEST_OREGON: Region.Us2,
-};
-
-/**
- * Region URIs. Maps the Twilio shortcode to its Twilio endpoint URI.
- * @private
- */
-const regionURIs: Record<Region, string> = {
-  [Region.Au1]: 'chunderw-vpc-gll-au1.twilio.com',
-  [Region.Au1Ix]: 'chunderw-vpc-gll-au1-ix.twilio.com',
-  [Region.Br1]: 'chunderw-vpc-gll-br1.twilio.com',
-  [Region.De1]: 'chunderw-vpc-gll-de1.twilio.com',
-  [Region.De1Ix]: 'chunderw-vpc-gll-de1-ix.twilio.com',
-  [Region.Gll]: 'chunderw-vpc-gll.twilio.com',
-  [Region.Ie1]: 'chunderw-vpc-gll-ie1.twilio.com',
-  [Region.Ie1Ix]: 'chunderw-vpc-gll-ie1-ix.twilio.com',
-  [Region.Ie1Tnx]: 'chunderw-vpc-gll-ie1-tnx.twilio.com',
-  [Region.Jp1]: 'chunderw-vpc-gll-jp1.twilio.com',
-  [Region.Jp1Ix]: 'chunderw-vpc-gll-jp1-ix.twilio.com',
-  [Region.Sg1]: 'chunderw-vpc-gll-sg1.twilio.com',
-  [Region.Sg1Ix]: 'chunderw-vpc-gll-sg1-ix.twilio.com',
-  [Region.Sg1Tnx]: 'chunderw-vpc-gll-sg1-tnx.twilio.com',
-  [Region.Us1]: 'chunderw-vpc-gll-us1.twilio.com',
-  [Region.Us1Ix]: 'chunderw-vpc-gll-us1-ix.twilio.com',
-  [Region.Us1Tnx]: 'chunderw-vpc-gll-us1-tnx.twilio.com',
-  [Region.Us2]: 'chunderw-vpc-gll-us2.twilio.com',
-  [Region.Us2Ix]: 'chunderw-vpc-gll-us2-ix.twilio.com',
-  [Region.Us2Tnx]: 'chunderw-vpc-gll-us2-tnx.twilio.com',
-};
-
-/**
- * Edge to region mapping, as part of Phase 1 Regional (CLIENT-7519).
- * Temporary.
- * @private
- */
-export const edgeToRegion: Record<Edge, Region> = {
-  [Edge.Sydney]: Region.Au1,
-  [Edge.SaoPaulo]: Region.Br1,
-  [Edge.Dublin]: Region.Ie1,
-  [Edge.Frankfurt]: Region.De1,
-  [Edge.Tokyo]: Region.Jp1,
-  [Edge.Singapore]: Region.Sg1,
-  [Edge.Ashburn]: Region.Us1,
-  [Edge.Umatilla]: Region.Us2,
-  [Edge.Roaming]: Region.Gll,
-  /**
-   * Interconnect edges
-   */
-  [Edge.AshburnIx]: Region.Us1Ix,
-  [Edge.SanJoseIx]: Region.Us2Ix,
-  [Edge.LondonIx]: Region.Ie1Ix,
-  [Edge.FrankfurtIx]: Region.De1Ix,
-  [Edge.SingaporeIx]: Region.Sg1Ix,
-  [Edge.SydneyIx]: Region.Au1Ix,
-  [Edge.TokyoIx]: Region.Jp1Ix,
 };
 
 /**
@@ -211,14 +123,6 @@ export const regionToEdge: Record<Region, Edge> = {
 };
 
 /**
- * The default region to connect to and create a chunder uri from if region is
- * not defined.
- * @constant
- * @private
- */
-export const defaultRegion: string = 'gll';
-
-/**
  * The default edge to connect to and create a chunder uri from, if the edge
  * parameter is not specified during setup in `Device`.
  * @constant
@@ -226,28 +130,11 @@ export const defaultRegion: string = 'gll';
 export const defaultEdge: Edge = Edge.Roaming;
 
 /**
- * The default chunder URI to connect to, should map to region `gll`.
- * @constant
- * @private
- */
-export const defaultChunderRegionURI: string = 'chunderw-vpc-gll.twilio.com';
-
-/**
  * The default event gateway URI to publish to.
  * @constant
  * @private
  */
 const defaultEventGatewayURI: string = 'eventgw.twilio.com';
-
-/**
- * String template for a region chunder URI
- * @param region - The region.
- */
-function createChunderRegionURI(region: string): string {
-  return region === defaultRegion
-    ? defaultChunderRegionURI
-    : `chunderw-vpc-gll-${region}.twilio.com`;
-}
 
 /**
  * String template for an edge chunder URI
@@ -276,81 +163,25 @@ export function createSignalingEndpointURL(uri: string): string {
 }
 
 /**
- * Get the URI associated with the passed region or edge. If both are passed,
- * then we want to fail `Device` setup, so we throw an error.
- * As of CLIENT-7519, Regions are deprecated in favor of edges as part of
- * Phase 1 Regional.
- *
+ * Get the URI associated with the passed edge.
  * @private
  * @param edge - A string or an array of edge values
- * @param region - The region shortcode.
- * @param [onDeprecated] - A callback containing the deprecation message to be
- *   warned when the passed parameters are deprecated.
  * @returns An array of chunder URIs
  */
-export function getChunderURIs(
-  edge: string[] | string | undefined,
-  region: string | undefined,
-  onDeprecated?: (message: string) => void,
-): string[] {
-  if (!!region && typeof region !== 'string') {
-    throw new InvalidArgumentError(
-      'If `region` is provided, it must be of type `string`.',
-    );
-  }
-
+export function getChunderURIs(edge?: string[] | string): string[] {
   if (!!edge && typeof edge !== 'string' && !Array.isArray(edge)) {
     throw new InvalidArgumentError(
       'If `edge` is provided, it must be of type `string` or an array of strings.',
     );
   }
 
-  const deprecatedMessages: string[] = [];
   let uris: string[];
 
-  if (region && edge) {
-    throw new InvalidArgumentError(
-      'You cannot specify `region` when `edge` is specified in' +
-      '`Twilio.Device.Options`.',
-    );
-  } else if (region) {
-    let chunderRegion = region;
-
-    deprecatedMessages.push(
-      'Regions are deprecated in favor of edges. Please see this page for ' +
-      'documentation: https://www.twilio.com/docs/voice/client/edges.',
-    );
-
-    const isDeprecatedRegion: boolean =
-      (Object.values(DeprecatedRegion) as string[]).includes(chunderRegion);
-    if (isDeprecatedRegion) {
-      chunderRegion = deprecatedRegions[chunderRegion as DeprecatedRegion];
-    }
-
-    const isKnownRegion: boolean =
-      (Object.values(Region) as string[]).includes(chunderRegion);
-    if (isKnownRegion) {
-      const preferredEdge = regionToEdge[chunderRegion as Region];
-      deprecatedMessages.push(
-        `Region "${chunderRegion}" is deprecated, please use \`edge\` ` +
-        `"${preferredEdge}".`,
-      );
-    }
-
-    uris = [createChunderRegionURI(chunderRegion)];
-  } else if (edge) {
-    const edgeValues = Object.values(Edge) as string[];
+  if (edge) {
     const edgeParams = Array.isArray(edge) ? edge : [edge];
-
-    uris = edgeParams.map((param: Edge) => edgeValues.includes(param)
-      ? createChunderRegionURI(edgeToRegion[param])
-      : createChunderEdgeURI(param));
+    uris = edgeParams.map((param: Edge) =>createChunderEdgeURI(param));
   } else {
-    uris = [defaultChunderRegionURI];
-  }
-
-  if (onDeprecated && deprecatedMessages.length) {
-    setTimeout(() => onDeprecated(deprecatedMessages.join('\n')));
+    uris = [createChunderEdgeURI(defaultEdge)];
   }
 
   return uris;

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -489,12 +489,12 @@ describe('Device', function() {
 
         it('should update the preferred uri', () => {
           pstream.emit('connected', { region: 'EU_IRELAND', edge: Edge.Dublin });
-          assert.equal(device['_preferredURI'], ['wss://chunderw-vpc-gll-ie1.twilio.com/signal']);
+          assert.equal(device['_preferredURI'], ['wss://voice-js.dublin.twilio.com/signal']);
         });
 
         it('should update the preferred uri from the first edge', () => {
           pstream.emit('connected', { region: 'EU_IRELAND', edge: [Edge.Dublin, Edge.Frankfurt] });
-          assert.equal(device['_preferredURI'], ['wss://chunderw-vpc-gll-ie1.twilio.com/signal']);
+          assert.equal(device['_preferredURI'], ['wss://voice-js.dublin.twilio.com/signal']);
         });
 
         it('should set the identity', () => {
@@ -1135,7 +1135,7 @@ describe('Device', function() {
         sinon.assert.calledOnceWithExactly(
           PStream,
           token,
-          ['wss://chunderw-vpc-gll.twilio.com/signal'],
+          ['wss://voice-js.roaming.twilio.com/signal'],
           {
             backoffMaxMs: undefined,
             maxPreferredDurationMs: 0,
@@ -1148,7 +1148,7 @@ describe('Device', function() {
         sinon.assert.calledOnceWithExactly(
           PStream,
           token,
-          ['wss://chunderw-vpc-gll-sg1.twilio.com/signal'],
+          ['wss://voice-js.singapore.twilio.com/signal'],
           {
             backoffMaxMs: undefined,
             maxPreferredDurationMs: 0,
@@ -1162,8 +1162,8 @@ describe('Device', function() {
           PStream,
           token,
           [
-            'wss://chunderw-vpc-gll-sg1.twilio.com/signal',
-            'wss://chunderw-vpc-gll-au1.twilio.com/signal',
+            'wss://voice-js.singapore.twilio.com/signal',
+            'wss://voice-js.sydney.twilio.com/signal',
           ],
           {
             backoffMaxMs: undefined,
@@ -1177,7 +1177,7 @@ describe('Device', function() {
         sinon.assert.calledOnceWithExactly(
           PStream,
           token,
-          ['wss://chunderw-vpc-gll.twilio.com/signal'],
+          ['wss://voice-js.roaming.twilio.com/signal'],
           {
             backoffMaxMs: undefined,
             maxPreferredDurationMs: 5,

--- a/tests/unit/regions.ts
+++ b/tests/unit/regions.ts
@@ -4,14 +4,11 @@ import {
   createEventGatewayURI,
   createSignalingEndpointURL,
   defaultEdge,
-  defaultRegion,
-  deprecatedRegions,
-  edgeToRegion,
+  Edge,
   getChunderURIs,
   getRegionShortcode,
   Region,
   regionShortcodes,
-  regionToEdge,
 } from '../../lib/twilio/regions';
 
 describe('regions', () => {
@@ -29,204 +26,72 @@ describe('regions', () => {
     });
   });
 
-  describe('getChunderURI', () => {
-    let onDeprecated: sinon.SinonSpy;
-
-    beforeEach(() => {
-      onDeprecated = sinon.spy();
-    });
-
+  describe('getChunderURIs', () => {
     describe('with invalid parameter typings', async () => {
       [
-        ['foo', {}],
-        ['foo', []],
-        ['foo', 2],
-        [{}, 'bar'],
-      ].forEach(([edge, region]) => {
-        describe(`edge "${edge}" and region "${region}"`, () => {
+        {},
+        2,
+      ].forEach((edge) => {
+        describe(`edge "${edge}"`, () => {
           it('should throw', () => {
             assert.throws(() => {
-              getChunderURIs(edge as any, region as any);
+              getChunderURIs(edge as any);
             });
           });
         });
       });
     });
 
-    it('should work with or without the deprecation handler', async () => {
-      const uri = [
-        getChunderURIs(undefined, undefined, onDeprecated),
-        getChunderURIs(undefined, undefined),
-      ];
-      assert.deepEqual(uri[0], uri[1]);
-      assert.deepEqual(uri[0], ['chunderw-vpc-gll.twilio.com']);
-    });
-
-    describe('without edge or region', () => {
-      it('should not call the deprecation handler', async () => {
-        getChunderURIs(undefined, undefined, onDeprecated);
-        await new Promise(resolve => setTimeout(() => {
-          assert.equal(onDeprecated.callCount, 0);
-          resolve();
-        }));
-      });
-
+    describe('without edge', () => {
       it('should return the default chunder uri', () => {
-        const uris = getChunderURIs(undefined, undefined);
-        assert.deepEqual(uris, ['chunderw-vpc-gll.twilio.com']);
+        const uris = getChunderURIs(undefined);
+        assert.deepEqual(uris, ['voice-js.roaming.twilio.com']);
       });
     });
 
-    describe('without edge and with region', () => {
-      describe('for deprecated known regions', () => {
-        Object.entries(deprecatedRegions).forEach(([deprecatedRegion, preferredRegion]) => {
-          describe(deprecatedRegion, () => {
-            it('should call the deprecation handler and recommend an edge', async () => {
-              const preferredEdge = regionToEdge[preferredRegion];
-              getChunderURIs(undefined, deprecatedRegion, onDeprecated);
-
-              await new Promise(resolve => setTimeout(() => {
-                assert(onDeprecated.calledOnce);
-                assert(onDeprecated.args[0][0].match(new RegExp(`please use \`edge\` "${preferredEdge}"`)));
-                resolve();
-              }));
-            });
-
-            it('should return the right chunder uri', () => {
-              const uris = getChunderURIs(undefined, deprecatedRegion, onDeprecated);
-              assert.deepEqual(uris, [`chunderw-vpc-gll-${preferredRegion}.twilio.com`]);
-            });
-          });
-        });
-      });
-
-      describe('for nondeprecated known regions', () => {
-        Object.values(Region).filter(r => r !== defaultRegion).forEach(region => {
-          describe(region, () => {
-            it('should call the deprecation handler and recommend an edge', async () => {
-              const preferredEdge = regionToEdge[region];
-              getChunderURIs(undefined, region, onDeprecated);
-              await new Promise(resolve => setTimeout(() => {
-                assert(onDeprecated.calledOnce);
-                assert(onDeprecated.args[0][0].match(new RegExp(`please use \`edge\` "${preferredEdge}"`)));
-                resolve();
-              }));
-            });
-
-            it('should return the right chunder uri', () => {
-              const uris = getChunderURIs(undefined, region, onDeprecated);
-              assert.deepEqual(uris, [`chunderw-vpc-gll-${region}.twilio.com`]);
-            });
-          });
-        });
-      });
-
-      describe('for an unknown region', () => {
-        it('should call the deprecation handler, but not recommend an edge', async () => {
-          getChunderURIs(undefined, 'foo', onDeprecated);
-          await new Promise(resolve => setTimeout(() => {
-            assert(onDeprecated.calledOnce);
-            assert.equal(onDeprecated.args[0][0].match(new RegExp('edge', 'g')).length, 2);
-            assert.equal(onDeprecated.args[0][0].match(new RegExp('please use', 'g')), null);
-            resolve();
-          }));
-        });
-
-        it('should return the right chunder uri', () => {
-          const uris = getChunderURIs(undefined, 'foo', onDeprecated);
-          assert.deepEqual(uris, ['chunderw-vpc-gll-foo.twilio.com']);
-        });
-      });
-
-      describe('for the default (gll) region', () => {
-        it('should call the deprecation handler and recommend an edge', async () => {
-          getChunderURIs(undefined, 'gll', onDeprecated);
-          await new Promise(resolve => setTimeout(() => {
-            assert(onDeprecated.calledOnce);
-            assert.equal(onDeprecated.args[0][0].match(new RegExp('edge', 'g')).length, 3);
-            assert.equal(onDeprecated.args[0][0].match(new RegExp(`please use \`edge\` "roaming"`, 'g')).length, 1);
-            resolve();
-          }));
-        });
-
-        it('should return the right chunder uri', () => {
-          const uris = getChunderURIs(undefined, 'gll', onDeprecated);
-          assert.deepEqual(uris, ['chunderw-vpc-gll.twilio.com']);
-        });
-      });
-    });
-
-    describe('with edge and without region', () => {
+    describe('with edge', () => {
       describe('for known edges', () => {
-        Object.entries(edgeToRegion).filter(([e]) => e !== defaultEdge).forEach(([edge, region]) => {
+        Object.values(Edge).forEach((edge) => {
           describe(edge, () => {
-            it('should not call the deprecation handler', async () => {
-              getChunderURIs(edge, undefined, onDeprecated);
-              await new Promise(resolve => setTimeout(() => {
-                assert(onDeprecated.notCalled);
-                resolve();
-              }));
-            });
-
             it('should return the right chunder uri', () => {
-              const uris = getChunderURIs(edge, undefined, onDeprecated);
-              assert.deepEqual(uris, [`chunderw-vpc-gll-${region}.twilio.com`]);
+              const uris = getChunderURIs(edge);
+              assert.deepEqual(uris, [`voice-js.${edge}.twilio.com`]);
             });
           });
         });
       });
 
       describe('for unknown edges', () => {
-        it('should not call the deprecation handler', async () => {
-          getChunderURIs('foo', undefined, onDeprecated);
-          await new Promise(resolve => setTimeout(() => {
-            assert(onDeprecated.notCalled);
-            resolve();
-          }));
-        });
-
         it('should transform the uri properly', () => {
-          const uris = getChunderURIs('foo', undefined, onDeprecated);
+          const uris = getChunderURIs('foo');
           assert.deepEqual(uris, ['voice-js.foo.twilio.com']);
         });
       });
 
       describe('for default (roaming) edge', () => {
-        it('should not call the deprecation handler', async () => {
-          getChunderURIs('roaming', undefined, onDeprecated);
-          await new Promise(resolve => setTimeout(() => {
-            assert(onDeprecated.notCalled);
-            resolve();
-          }));
-        });
-
         it('should transform the uri properly', () => {
-          const uris = getChunderURIs('roaming', undefined, onDeprecated);
-          assert.deepEqual(uris, ['chunderw-vpc-gll.twilio.com']);
+          const uris = getChunderURIs('roaming');
+          assert.deepEqual(uris, ['voice-js.roaming.twilio.com']);
         });
       });
 
       describe('for multiple edges', () => {
         it('should return the right chunder uris', () => {
-          const uris = getChunderURIs(['singapore', 'sydney'], undefined, onDeprecated);
+          const uris = getChunderURIs(['singapore', 'sydney']);
           assert.deepEqual(uris, [
-            'chunderw-vpc-gll-sg1.twilio.com',
-            'chunderw-vpc-gll-au1.twilio.com',
+            'voice-js.singapore.twilio.com',
+            'voice-js.sydney.twilio.com',
           ]);
         });
 
         it('should not throw if roaming is provided in the edge array', () => {
-          assert(getChunderURIs(['roaming'], undefined));
+          assert(getChunderURIs(['roaming']));
         });
 
         it('should not throw if roaming is provided as a string', () => {
-          assert(getChunderURIs('roaming', undefined));
+          assert(getChunderURIs('roaming'));
         });
       });
-    });
-
-    it('should throw an error with both', () => {
-      assert.throws(() => getChunderURIs('foo', 'bar', onDeprecated));
     });
   });
 


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

Removed the region->edge mapping and now using the edge locations directly. Also removing Device.Options.region code paths since this options has been removed in 2.x

TODO: Add tests

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
