### PR TITLE
fix: event publisher no longer working after having called `Device.updateOptions`

### DIFF
--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -26,6 +26,7 @@ import {
   createEventGatewayURI,
   createSignalingEndpointURL,
   Edge,
+  defaultEventGatewayURI,
   getChunderURIs,
   getRegionShortcode,
   Region,
@@ -1329,7 +1330,9 @@ class Device extends EventEmitter {
    * Create and set a publisher for the {@link Device} to use.
    */
   private _setupPublisher(): IPublisher {
+    let host = defaultEventGatewayURI;
     if (this._publisher) {
+      host = this._publisher._host;
       this._log.info('Found existing publisher; destroying...');
       this._destroyPublisher();
     }
@@ -1341,6 +1344,7 @@ class Device extends EventEmitter {
         app_name: this._options.appName,
         app_version: this._options.appVersion,
       },
+      host
     } as any;
 
     if (this._options.eventgw) {

--- a/lib/twilio/regions.ts
+++ b/lib/twilio/regions.ts
@@ -237,7 +237,7 @@ export const defaultChunderRegionURI: string = 'chunderw-vpc-gll.twilio.com';
  * @constant
  * @private
  */
-const defaultEventGatewayURI: string = 'eventgw.twilio.com';
+export const defaultEventGatewayURI: string = 'eventgw.twilio.com';
 
 /**
  * String template for a region chunder URI


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-0000](https://issues.corp.twilio.com/browse/CLIENT-0000)

### Description

When `Device.updateOptions` is called, that creates a new Publisher instance.
And this new instance is not working correctly given the `host` property is missing if the `eventgw` option is not defined.

This leads to the "Metrics" tab of the Console to be completely empty, as you can see on that screenshot:
![image (1)](https://user-images.githubusercontent.com/426749/197556895-4460fb5d-fafe-48f0-8525-1d41cc0dc084.png)

This PR introduces a change in that logic. The `host` property would now be defined given we're getting the value from the previous Publisher instance, or falling back to the default.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
