### PR TITLE
fix(incoming-sound): stop incoming sound when the call gets disconnected

### DIFF
--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -1042,6 +1042,12 @@ class Device extends EventEmitter {
       }
       this._removeCall(call);
       maybeUnsetPreferredUri();
+      /**
+       * NOTE(kamalbennani): We need to stop the incoming sound when the call is
+       * disconnected right after the user has accepted the call (activeCall.accept()), and before
+       * the call has been fully connected (i.e. before the `pstream.answer` event)
+       */
+      this._maybeStopIncomingSound();
     });
 
     call.once('reject', () => {

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -776,6 +776,14 @@ describe('Device', function() {
             call.emit('accept');
             sinon.assert.calledOnce(spy);
           });
+
+          it('should stop playing incoming sound', () => {
+            const spy: any = { stop: sinon.spy() };
+            device['_soundcache'].set(Device.SoundName.Incoming, spy);
+            const call = device.calls[0];
+            call.emit("disconnect");
+            sinon.assert.calledOnce(spy.stop);
+          })
         });
 
         describe('on call.error', () => {

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -732,7 +732,11 @@ describe('Device', function() {
       });
 
       describe('with a pending incoming call', () => {
+        let spyIncomingSound: any;
         beforeEach(async () => {
+          spyIncomingSound = { play: sinon.spy(), stop: sinon.spy() };
+          device['_soundcache'].set(Device.SoundName.Incoming, spyIncomingSound);
+
           const incomingPromise = new Promise(resolve =>
             device.once(Device.EventName.Incoming, () => {
               device.emit = sinon.spy();
@@ -762,28 +766,30 @@ describe('Device', function() {
           });
 
           it('should not play outgoing sound', () => {
+            sinon.assert.calledOnce(spyIncomingSound.play);
             const spy: any = { play: sinon.spy() };
             device['_soundcache'].set(Device.SoundName.Outgoing, spy);
             device.calls[0].emit('accept');
             sinon.assert.notCalled(spy.play);
+            sinon.assert.calledOnce(spyIncomingSound.stop);
           });
 
           it('should update the preferred uri', () => {
+            sinon.assert.calledOnce(spyIncomingSound.play);
             pstream.emit('connected', { edge: 'sydney' });
             const spy: any = device['_stream'].updatePreferredURI =
               sinon.spy(device['_stream'].updatePreferredURI);
             const call = device.calls[0];
             call.emit('accept');
             sinon.assert.calledOnce(spy);
+            sinon.assert.calledOnce(spyIncomingSound.stop);
           });
 
           it('should stop playing incoming sound', () => {
-            const spy: any = { stop: sinon.spy() };
-            device['_soundcache'].set(Device.SoundName.Incoming, spy);
-            const call = device.calls[0];
-            call.emit("disconnect");
-            sinon.assert.calledOnce(spy.stop);
-          })
+            sinon.assert.calledOnce(spyIncomingSound.play);
+            device.calls[0].emit("disconnect");
+            sinon.assert.calledOnce(spyIncomingSound.stop);
+          });
         });
 
         describe('on call.error', () => {
@@ -800,6 +806,13 @@ describe('Device', function() {
             device.calls[0].emit('error');
             sinon.assert.calledOnceWithExactly(spy, null);
           });
+
+          it('should stop playing incoming sound', () => {
+            sinon.assert.calledOnce(spyIncomingSound.play);
+            device.calls[0].status = () => CallType.State.Closed;
+            device.calls[0].emit('error');
+            sinon.assert.calledOnce(spyIncomingSound.stop);
+          });
         });
 
         describe('on call.transportClose', () => {
@@ -812,6 +825,12 @@ describe('Device', function() {
             device.calls[0].status = () => CallType.State.Open;
             device.calls[0].emit('transportClose');
             assert.equal(device.calls.length, 1);
+          });
+          it('should stop playing incoming sound', () => {
+            sinon.assert.calledOnce(spyIncomingSound.play);
+            device.calls[0].status = () => CallType.State.Pending;
+            device.calls[0].emit('transportClose');
+            sinon.assert.calledOnce(spyIncomingSound.stop);
           });
         });
 
@@ -832,6 +851,12 @@ describe('Device', function() {
             device.calls[0].emit('disconnect');
             sinon.assert.calledOnceWithExactly(spy, null);
           });
+
+          it('should stop playing incoming sound', () => {
+            sinon.assert.calledOnce(spyIncomingSound.play);
+            device.calls[0].emit('disconnect');
+            sinon.assert.calledOnce(spyIncomingSound.stop);
+          });
         });
 
         describe('on call.reject', () => {
@@ -845,6 +870,12 @@ describe('Device', function() {
               sinon.spy(device['_stream'].updatePreferredURI);
             device.calls[0].emit('reject');
             sinon.assert.calledOnceWithExactly(spy, null);
+          });
+
+          it('should stop playing incoming sound', () => {
+            sinon.assert.calledOnce(spyIncomingSound.play);
+            device.calls[0].emit('reject');
+            sinon.assert.calledOnce(spyIncomingSound.stop);
           });
         });
       });


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

The goal of this PR is to fix the issue described in [here](https://github.com/twilio/twilio-voice.js/issues/133)

### Description

When the user receives an incoming sound and calls `call.accept()` and just afterwards `call.disconnect`, the incoming sound keeps playing forever.

To overcome this issue, I just had to call `_maybeStopIncomingSound` which will stop the sound if there are any calls left.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
