### PR TITLE
Check if stream exists before unsetting preferred URI

### DIFF
--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -982,7 +982,7 @@ class Device extends EventEmitter {
     }, options);
 
     const maybeUnsetPreferredUri = () => {
-      if (this._activeCall === null && this._calls.length === 0) {
+      if (this._stream && this._activeCall === null && this._calls.length === 0) {
         this._stream.updatePreferredURI(null);
       }
     };

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@types/node": "13.1.8",
     "@types/sinon": "9.0.5",
     "@types/ws": "7.2.0",
+    "@types/mime": "2.0.3",
     "babel-cli": "6.26.0",
     "babel-eslint": "10.0.3",
     "babel-plugin-envify": "1.2.1",

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -813,6 +813,16 @@ describe('Device', function() {
             device.calls[0].emit('error');
             sinon.assert.calledOnce(spyIncomingSound.stop);
           });
+
+          it('should not unset the preferred uri if stream is null', () => {
+            const spy: any = device['_stream'].updatePreferredURI =
+              sinon.spy(device['_stream'].updatePreferredURI);
+
+            device['_stream'] = null;
+            device.calls[0].status = () => CallType.State.Closed;
+            device.calls[0].emit('error');
+            sinon.assert.notCalled(spy);
+          });
         });
 
         describe('on call.transportClose', () => {


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

https://github.com/twilio/twilio-voice.js/issues/95

maybeUnsetPreferredUri function was added in this commit:
https://github.com/twilio/twilio-voice.js/commit/b2b65437681ce6aa69870505a40d9f42323d7c9e

This caused unhandled error for some flows, such as when user
denies microphone access.

To fix this, we should check if the stream even exists before
attempting to calling updatePreferredURI on it.

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [x] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [x] Squashed erroneous commits if necessary
* [x] Re-tested if necessary