### PR TITLE
VBLOCKS-1371 | Remove handlers for rejected calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+2.4.0 (In Progress)
+===================
+
+Changes
+-------
+
+- Updated the description of [Device.updateToken](https://twilio.github.io/twilio-voice.js/classes/voice.device.html#updatetoken) API. It is recommended to call this API after [Device.tokenWillExpireEvent](https://twilio.github.io/twilio-voice.js/classes/voice.device.html#tokenwillexpireevent) is emitted, and before or after a call to prevent a potential ~1s audio loss during the update process.
+
+Bug Fixes
+---------
+
+- Fixed an [issue](https://github.com/twilio/twilio-voice.js/issues/100) where a `TypeError` is thrown after rejecting a call then invoking `updateToken`.
+
 2.3.2 (February 27, 2023)
 ===================
 

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -812,6 +812,8 @@ class Device extends EventEmitter {
 
   /**
    * Update the token used by this {@link Device} to connect to Twilio.
+   * It is recommended to call this API after [[Device.tokenWillExpireEvent]] is emitted,
+   * and before or after a call to prevent a potential ~1s audio loss during the update process.
    * @param token
    */
   updateToken(token: string) {


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

Some of the call methods that destroys the call such as `reject`and `ignore`, does not actually perform cleanups after they are invoked unlike disconnect method. This causes errors on future pstream events as described in #100 and jira ticket.
However, we don't want to cleanup on some, such as `ignore` method. If we perform cleanup, other clients who are also receiving the calls will get disconnected. But in the case of `reject`, this causes disconnection on all clients so it's ok to perform the cleanup process. This PR is adding that cleanup process on `reject`.

Additionally, I'm also updating the description of the updateToken. See changelog.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [x] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
