### PR TITLE
VBLOCKS-1534 | Stop using deprecated RTCIceCandidateStats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Changes
 
 - Updated the description of [Device.updateToken](https://twilio.github.io/twilio-voice.js/classes/voice.device.html#updatetoken) API. It is recommended to call this API after [Device.tokenWillExpireEvent](https://twilio.github.io/twilio-voice.js/classes/voice.device.html#tokenwillexpireevent) is emitted, and before or after a call to prevent a potential ~1s audio loss during the update process.
 
+- Updated stats reporting to stop using deprecated `RTCIceCandidateStats` - `ip` and `deleted`.
+
 Bug Fixes
 ---------
 

--- a/lib/twilio/rtc/icecandidate.ts
+++ b/lib/twilio/rtc/icecandidate.ts
@@ -10,6 +10,7 @@
  */
 interface RTCIceCandidatePayload {
   candidate_type: string;
+  // Deprecated by newer browsers. Will likely not show on most recent versions of browsers.
   deleted: boolean;
   ip: string;
   is_remote: boolean;

--- a/lib/twilio/rtc/stats.js
+++ b/lib/twilio/rtc/stats.js
@@ -204,8 +204,9 @@ function createRTCSample(statsReport) {
   }
 
   Object.assign(sample, {
-    localAddress: localCandidate && localCandidate.ip,
-    remoteAddress: remoteCandidate && remoteCandidate.ip,
+    // ip is deprecated. use address first then ip if on older versions of browser
+    localAddress: localCandidate && (localCandidate.address || localCandidate.ip),
+    remoteAddress: remoteCandidate && (remoteCandidate.address || remoteCandidate.ip),
   });
 
   return sample;

--- a/tests/payloads/rtcstatsreport-edge.json
+++ b/tests/payloads/rtcstatsreport-edge.json
@@ -46,8 +46,7 @@
     "port": 52513,
     "protocol": "udp",
     "candidateType": "prflx",
-    "priority": 1853824767,
-    "deleted": false
+    "priority": 1853824767
   },
   {
     "id": "RTCIceCandidate_yB1+bJsu",
@@ -59,8 +58,7 @@
     "port": 11270,
     "protocol": "udp",
     "candidateType": "host",
-    "priority": 2130714367,
-    "deleted": false
+    "priority": 2130714367
   },
   {
     "id": "RTCInboundRTPAudioStream_774468856",

--- a/tests/payloads/rtcstatsreport-with-transport.json
+++ b/tests/payloads/rtcstatsreport-with-transport.json
@@ -284,8 +284,7 @@
     "port": 53585,
     "protocol": "udp",
     "candidateType": "srflx",
-    "priority": 1686052607,
-    "deleted": false
+    "priority": 1686052607
   },
   {
     "id": "RTCIceCandidate_Di/J4tEz",
@@ -297,8 +296,7 @@
     "port": 19282,
     "protocol": "udp",
     "candidateType": "host",
-    "priority": 2130706431,
-    "deleted": false
+    "priority": 2130706431
   },
   {
     "id": "RTCIceCandidate_UqrtRLJZ",
@@ -312,8 +310,7 @@
     "protocol": "udp",
     "relayProtocol": "udp",
     "candidateType": "relay",
-    "priority": 41754879,
-    "deleted": false
+    "priority": 41754879
   },
   {
     "id": "RTCIceCandidate_e3FLKFoG",
@@ -326,8 +323,7 @@
     "port": 52497,
     "protocol": "udp",
     "candidateType": "srflx",
-    "priority": 1685921535,
-    "deleted": false
+    "priority": 1685921535
   },
   {
     "id": "RTCIceCandidate_oYROhau8",
@@ -341,8 +337,7 @@
     "protocol": "udp",
     "relayProtocol": "udp",
     "candidateType": "relay",
-    "priority": 41885951,
-    "deleted": false
+    "priority": 41885951
   },
   {
     "id": "RTCIceCandidate_qQRsdncV",
@@ -355,8 +350,7 @@
     "port": 50951,
     "protocol": "udp",
     "candidateType": "host",
-    "priority": 2122194687,
-    "deleted": false
+    "priority": 2122194687
   },
   {
     "id": "RTCInboundRTPAudioStream_976775258",

--- a/tests/payloads/rtcstatsreport.json
+++ b/tests/payloads/rtcstatsreport.json
@@ -162,12 +162,11 @@
     "type": "local-candidate",
     "transportId": "RTCTransport_audio_1",
     "isRemote": false,
-    "ip": "107.20.226.156",
+    "address": "107.20.226.156",
     "port": 52513,
     "protocol": "udp",
     "candidateType": "prflx",
-    "priority": 1853824767,
-    "deleted": false
+    "priority": 1853824767
   },
   {
     "id": "RTCIceCandidate_yB1+bJsu",
@@ -179,8 +178,7 @@
     "port": 11270,
     "protocol": "udp",
     "candidateType": "host",
-    "priority": 2130714367,
-    "deleted": false
+    "priority": 2130714367
   },
   {
     "id": "RTCInboundRTPAudioStream_774468856",

--- a/tests/spec/rtcicecandidates-with-transport.json
+++ b/tests/spec/rtcicecandidates-with-transport.json
@@ -11,8 +11,7 @@
       "port": 53585,
       "protocol": "udp",
       "candidateType": "srflx",
-      "priority": 1686052607,
-      "deleted": false
+      "priority": 1686052607
     },
     {
       "id": "RTCIceCandidate_UqrtRLJZ",
@@ -26,8 +25,7 @@
       "protocol": "udp",
       "relayProtocol": "udp",
       "candidateType": "relay",
-      "priority": 41754879,
-      "deleted": false
+      "priority": 41754879
     },
     {
       "id": "RTCIceCandidate_e3FLKFoG",
@@ -40,8 +38,7 @@
       "port": 52497,
       "protocol": "udp",
       "candidateType": "srflx",
-      "priority": 1685921535,
-      "deleted": false
+      "priority": 1685921535
     },
     {
       "id": "RTCIceCandidate_oYROhau8",
@@ -55,8 +52,7 @@
       "protocol": "udp",
       "relayProtocol": "udp",
       "candidateType": "relay",
-      "priority": 41885951,
-      "deleted": false
+      "priority": 41885951
     },
     {
       "id": "RTCIceCandidate_qQRsdncV",
@@ -69,8 +65,7 @@
       "port": 50951,
       "protocol": "udp",
       "candidateType": "host",
-      "priority": 2122194687,
-      "deleted": false
+      "priority": 2122194687
     },
     {
       "id": "RTCIceCandidate_Di/J4tEz",
@@ -82,8 +77,7 @@
       "port": 19282,
       "protocol": "udp",
       "candidateType": "host",
-      "priority": 2130706431,
-      "deleted": false
+      "priority": 2130706431
     }
   ],
   "selectedIceCandidatePairStats": {
@@ -98,8 +92,7 @@
       "port": 53585,
       "protocol": "udp",
       "candidateType": "srflx",
-      "priority": 1686052607,
-      "deleted": false
+      "priority": 1686052607
     },
     "remoteCandidate": {
       "id": "RTCIceCandidate_Di/J4tEz",
@@ -111,8 +104,7 @@
       "port": 19282,
       "protocol": "udp",
       "candidateType": "host",
-      "priority": 2130706431,
-      "deleted": false
+      "priority": 2130706431
     }
   }
 }


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

[VBLOCKS-1534](https://issues.corp.twilio.com/browse/VBLOCKS-1534)

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [x] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
