### PR TITLE
Updating documentation to prevent setRemoteDescription error

### DIFF
--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -1746,6 +1746,41 @@ namespace Device {
 
     /**
      * Overrides the native RTCPeerConnection class.
+     *
+     * By default, the SDK will use the `unified-plan` SDP format if the browser supports it.
+     * Unexpected behavior may happen if the `RTCPeerConnection` parameter uses an SDP format
+     * that is different than what the SDK uses.
+     *
+     * For example, if the browser supports `unified-plan` and the `RTCPeerConnection`
+     * parameter uses `plan-b` by default, the SDK will use `unified-plan`
+     * which will cause conflicts with the usage of the `RTCPeerConnection`.
+     *
+     * In order to avoid this issue, you need to explicitly set the SDP format that you want
+     * the SDK to use with the `RTCPeerConnection` via [[Device.ConnectOptions.rtcConfiguration]] for outgoing calls.
+     * Or [[Call.AcceptOptions.rtcConfiguration]] for incoming calls.
+     *
+     * See the example below. Assuming the `RTCPeerConnection` you provided uses `plan-b` by default, the following
+     * code sets the SDP format to `unified-plan` instead.
+     *
+     * ```ts
+     * // Outgoing calls
+     * const call = await device.connect({
+     *   rtcConfiguration: {
+     *     sdpSemantics: 'unified-plan'
+     *   }
+     *   // Other options
+     * });
+     *
+     * // Incoming calls
+     * device.on('incoming', call => {
+     *   call.accept({
+     *     rtcConfiguration: {
+     *       sdpSemantics: 'unified-plan'
+     *     }
+     *     // Other options
+     *   });
+     * });
+     * ```
      */
     RTCPeerConnection?: any;
 


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

See https://issues.corp.twilio.com/browse/VBLOCKS-1538

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [x] Updated affected documentation
* [ ] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
