### PR TITLE
VBLOCKS-1301 Remove ws and xmlhttprequest dependencies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 Changes
 -------
 
+- The `ws` package has been moved to `devDependencies`.
+- The SDK no longer depends on the `xmlhttprequest` npm package.
 - The SDK now builds on NodeJS versions 16 and above without the `--legacy-peer-deps` flag.
 - Removed usage of NodeJS modules from the SDK and some dependencies. With this change, the SDK should now work with some of the latest frameworks that use the latest versions of bundlers such as Vite and Webpack.
 - Removed unnecessary files from the generated npm package.

--- a/browser/ws.js
+++ b/browser/ws.js
@@ -1,2 +1,0 @@
-'use strict';
-module.exports = WebSocket;

--- a/browser/xmlhttprequest.js
+++ b/browser/xmlhttprequest.js
@@ -1,2 +1,0 @@
-'use strict';
-module.exports = { XMLHttpRequest: XMLHttpRequest };

--- a/lib/twilio/request.ts
+++ b/lib/twilio/request.ts
@@ -7,14 +7,13 @@
 
 function request(method, params, callback) {
   const body = JSON.stringify(params.body || {});
-  const fetchUrl = options.fetch || fetch;
   const headers = new Headers();
 
   params.headers = params.headers || [];
   Object.entries(params.headers).forEach(([headerName, headerBody]) =>
     headers.append(headerName, headerBody));
 
-  fetchUrl(params.url, { body, headers, method })
+  fetch(params.url, { body, headers, method })
     .then(response => response.text(), callback)
     .then(responseText => callback(null, responseText), callback);
 }

--- a/lib/twilio/request.ts
+++ b/lib/twilio/request.ts
@@ -4,30 +4,19 @@
  * @internalapi
  */
 // @ts-nocheck
-import { XMLHttpRequest as XHR } from 'xmlhttprequest';
 
 function request(method, params, callback) {
-  const options = {};
-  options.XMLHttpRequest = options.XMLHttpRequest || XHR;
-  const xhr = new options.XMLHttpRequest();
+  const body = JSON.stringify(params.body || {});
+  const fetchUrl = options.fetch || fetch;
+  const headers = new Headers();
 
-  xhr.open(method, params.url, true);
-  xhr.onreadystatechange = function onreadystatechange() {
-    if (xhr.readyState !== 4) { return; }
+  params.headers = params.headers || [];
+  Object.entries(params.headers).forEach(([headerName, headerBody]) =>
+    headers.append(headerName, headerBody));
 
-    if (200 <= xhr.status && xhr.status < 300) {
-      callback(null, xhr.responseText);
-      return;
-    }
-
-    callback(new Error(xhr.responseText));
-  };
-  // tslint:disable-next-line
-  for (const headerName in params.headers) {
-    xhr.setRequestHeader(headerName, params.headers[headerName]);
-  }
-
-  xhr.send(JSON.stringify(params.body));
+  fetchUrl(params.url, { body, headers, method })
+    .then(response => response.text(), callback)
+    .then(responseText => callback(null, responseText), callback);
 }
 /**
  * Use XMLHttpRequest to get a network resource.

--- a/lib/twilio/wstransport.ts
+++ b/lib/twilio/wstransport.ts
@@ -5,10 +5,11 @@
  */
 
 import { EventEmitter } from 'events';
-import * as WebSocket from 'ws';
 import Backoff from './backoff';
 import { SignalingErrors } from './errors';
 import Log from './log';
+
+const WebSocket = globalThis.WebSocket;
 
 const CONNECT_SUCCESS_TIMEOUT = 10000;
 const CONNECT_TIMEOUT = 5000;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,7 @@
         "events": "3.3.0",
         "loglevel": "1.6.7",
         "md5": "2.3.0",
-        "rtcpeerconnection-shim": "1.2.8",
-        "ws": "7.4.6",
-        "xmlhttprequest": "1.8.0"
+        "rtcpeerconnection-shim": "1.2.8"
       },
       "devDependencies": {
         "@types/mime": "3.0.0",
@@ -71,7 +69,8 @@
         "typescript": "4.0.8",
         "uglify-js": "3.7.5",
         "vinyl-fs": "3.0.3",
-        "vinyl-source-stream": "2.0.0"
+        "vinyl-source-stream": "2.0.0",
+        "ws": "7.4.6"
       },
       "engines": {
         "node": ">= 12"
@@ -14850,6 +14849,7 @@
       "version": "7.4.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
       "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "dev": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -14902,14 +14902,6 @@
       "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
       "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
       "dev": true
-    },
-    "node_modules/xmlhttprequest": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-      "integrity": "sha512-58Im/U0mlVBLM38NdZjHyhuMtCqa61469k2YP/AaPbvCoV9aQGUpbJBj1QRm2ytRiVQBD/fsw7L2bJGDVQswBA==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
     },
     "node_modules/xmlhttprequest-ssl": {
       "version": "1.5.5",

--- a/package.json
+++ b/package.json
@@ -125,8 +125,5 @@
     "loglevel": "1.6.7",
     "md5": "2.3.0",
     "rtcpeerconnection-shim": "1.2.8"
-  },
-  "browser": {
-    "ws": "./browser/ws.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -114,7 +114,8 @@
     "typescript": "4.0.8",
     "uglify-js": "3.7.5",
     "vinyl-fs": "3.0.3",
-    "vinyl-source-stream": "2.0.0"
+    "vinyl-source-stream": "2.0.0",
+    "ws": "7.4.6"
   },
   "dependencies": {
     "@twilio/audioplayer": "1.0.6",
@@ -123,12 +124,9 @@
     "events": "3.3.0",
     "loglevel": "1.6.7",
     "md5": "2.3.0",
-    "rtcpeerconnection-shim": "1.2.8",
-    "ws": "7.4.6",
-    "xmlhttprequest": "1.8.0"
+    "rtcpeerconnection-shim": "1.2.8"
   },
   "browser": {
-    "xmlhttprequest": "./browser/xmlhttprequest.js",
     "ws": "./browser/ws.js"
   }
 }

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,6 +1,10 @@
+import * as WebSocket from 'ws';
+
 const root = global as any;
 let handlers = {};
+
 root.resetEvents = () => { handlers = {}; };
+root.WebSocket = WebSocket;
 root.window = {
   addEventListener: (name: string, func: Function) => { (handlers as any)[name] = func; },
   dispatchEvent: (name: string) => {


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [VBLOCKS-1301](https://issues.corp.twilio.com/browse/VBLOCKS-1301)

### Description

* Remove `xmlhttprequest` package from dependency (use `fetch` instead)
* Move `ws` package to `devDependencies` (as it is required for unit tests)

## Burndown

### Confirmation from reviewer (@charliesantos or @mhuynh5757)

* [x] Switching to `fetch` did not disrupt the working of insights reporting

### Before review
* [x] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
