### PR TITLE
fix(audio): Persist enabled sounds state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Bug Fixes
   });
   ```
 
+- Fixed an [issue](https://github.com/twilio/twilio-voice.js/issues/178) where calling `device.updateOptions` would reset the `device.audio._enabledSounds` state.
+
 2.6.0 (June 20, 2023)
 =====================
 

--- a/lib/twilio/audiohelper.ts
+++ b/lib/twilio/audiohelper.ts
@@ -98,8 +98,6 @@ class AudioHelper extends EventEmitter {
     [Device.SoundName.Outgoing]: true,
   };
 
-  get enabledSounds(): Record<Device.ToggleableSound, boolean> { return this._enabledSounds; }
-
   /**
    * The enumerateDevices method to use
    */
@@ -238,6 +236,14 @@ class AudioHelper extends EventEmitter {
     if (isEnumerationSupported) {
       this._initializeEnumeration();
     }
+  }
+
+  /**
+   * Current state of the enabled sounds
+   * @private
+   */
+  _getEnabledSounds(): Record<Device.ToggleableSound, boolean> {
+    return this._enabledSounds;
   }
 
   /**

--- a/lib/twilio/audiohelper.ts
+++ b/lib/twilio/audiohelper.ts
@@ -98,6 +98,8 @@ class AudioHelper extends EventEmitter {
     [Device.SoundName.Outgoing]: true,
   };
 
+  get enabledSounds(): Record<Device.ToggleableSound, boolean> { return this._enabledSounds; }
+
   /**
    * The enumerateDevices method to use
    */
@@ -184,6 +186,10 @@ class AudioHelper extends EventEmitter {
 
     const isAudioContextSupported: boolean = !!(options.AudioContext || options.audioContext);
     const isEnumerationSupported: boolean = !!this._enumerateDevices;
+
+    if (options.enabledSounds) {
+      this._enabledSounds = options.enabledSounds;
+    }
 
     const isSetSinkSupported: boolean = typeof options.setSinkId === 'function';
     this.isOutputSelectionSupported = isEnumerationSupported && isSetSinkSupported;
@@ -708,6 +714,11 @@ namespace AudioHelper {
      * An existing AudioContext instance to use.
      */
     audioContext?: AudioContext;
+
+    /**
+     * Whether each sound is enabled.
+     */
+    enabledSounds?: Record<Device.ToggleableSound, boolean>;
 
     /**
      * Overrides the native MediaDevices.enumerateDevices API.

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -1310,8 +1310,14 @@ class Device extends EventEmitter {
    * Set up an audio helper for usage by this {@link Device}.
    */
   private _setupAudioHelper(): void {
+    const audioOptions: AudioHelper.Options = {
+      audioContext: Device.audioContext,
+      enumerateDevices: this._options.enumerateDevices,
+    };
+
     if (this._audio) {
       this._log.info('Found existing audio helper; destroying...');
+      audioOptions.enabledSounds = this._audio.enabledSounds;
       this._destroyAudioHelper();
     }
 
@@ -1319,10 +1325,7 @@ class Device extends EventEmitter {
       this._updateSinkIds,
       this._updateInputStream,
       this._options.getUserMedia || getUserMedia,
-      {
-        audioContext: Device.audioContext,
-        enumerateDevices: this._options.enumerateDevices,
-      },
+      audioOptions,
     );
 
     this._audio.on('deviceChange', (lostActiveDevices: MediaDeviceInfo[]) => {

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -1317,7 +1317,7 @@ class Device extends EventEmitter {
 
     if (this._audio) {
       this._log.info('Found existing audio helper; destroying...');
-      audioOptions.enabledSounds = this._audio.enabledSounds;
+      audioOptions.enabledSounds = this._audio._getEnabledSounds();
       this._destroyAudioHelper();
     }
 

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -49,6 +49,7 @@ describe('Device', function() {
     updateSinkIds = _updateSinkIds;
     const audioHelper = createEmitterStub(require('../../lib/twilio/audiohelper').default);
     audioHelper._enabledSounds = enabledSounds;
+    audioHelper._getEnabledSounds = () => enabledSounds;
     audioHelper.disconnect = () => enabledSounds[Device.SoundName.Disconnect];
     audioHelper.incoming = () => enabledSounds[Device.SoundName.Incoming];
     audioHelper.outgoing = () => enabledSounds[Device.SoundName.Outgoing];

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -13,6 +13,7 @@ import * as assert from 'assert';
 import { EventEmitter } from 'events';
 import { SinonFakeTimers, SinonSpy, SinonStubbedInstance } from 'sinon';
 import * as sinon from 'sinon';
+import AudioHelper from '../../lib/twilio/audiohelper';
 
 const root = global as any;
 
@@ -38,8 +39,8 @@ describe('Device', function() {
 
   const sounds: Partial<Record<Device.SoundName, any>> = { };
 
-  const AudioHelper = (_updateSinkIds: Function, _updateInputStream: Function) => {
-    enabledSounds = {
+  const AudioHelper = (_updateSinkIds: Function, _updateInputStream: Function, getUserMedia: Function, options?: AudioHelper.Options) => {
+    enabledSounds = options?.enabledSounds || {
       [Device.SoundName.Disconnect]: true,
       [Device.SoundName.Incoming]: true,
       [Device.SoundName.Outgoing]: true,
@@ -47,6 +48,7 @@ describe('Device', function() {
     updateInputStream = _updateInputStream;
     updateSinkIds = _updateSinkIds;
     const audioHelper = createEmitterStub(require('../../lib/twilio/audiohelper').default);
+    audioHelper._enabledSounds = enabledSounds;
     audioHelper.disconnect = () => enabledSounds[Device.SoundName.Disconnect];
     audioHelper.incoming = () => enabledSounds[Device.SoundName.Incoming];
     audioHelper.outgoing = () => enabledSounds[Device.SoundName.Outgoing];
@@ -245,6 +247,20 @@ describe('Device', function() {
           await device.connect();
           activeCall._direction = 'OUTGOING';
           activeCall.emit('accept');
+          sinon.assert.notCalled(spy.play);
+        });
+
+        it('should not play outgoing sound after accepted if disabled after calling updateOptions', async () => {
+          enabledSounds[Device.SoundName.Outgoing] = false;
+          // Force a new audio-helper instance to be recreated
+          // After updating the enabled sounds state
+          device.updateOptions();
+          const spy: any = { play: sinon.spy() };
+          device['_soundcache'].set(Device.SoundName.Outgoing, spy);
+          await device.connect();
+          activeCall._direction = 'OUTGOING';
+          activeCall.emit('accept');
+          // should fail
           sinon.assert.notCalled(spy.play);
         });
       });

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -39,6 +39,11 @@ describe('Device', function() {
   const sounds: Partial<Record<Device.SoundName, any>> = { };
 
   const AudioHelper = (_updateSinkIds: Function, _updateInputStream: Function) => {
+    enabledSounds = {
+      [Device.SoundName.Disconnect]: true,
+      [Device.SoundName.Incoming]: true,
+      [Device.SoundName.Outgoing]: true,
+    };
     updateInputStream = _updateInputStream;
     updateSinkIds = _updateSinkIds;
     const audioHelper = createEmitterStub(require('../../lib/twilio/audiohelper').default);
@@ -68,11 +73,6 @@ describe('Device', function() {
   });
 
   beforeEach(() => {
-    enabledSounds = {
-      [Device.SoundName.Disconnect]: true,
-      [Device.SoundName.Incoming]: true,
-      [Device.SoundName.Outgoing]: true,
-    };
     pstream = null;
     publisher = null;
     clock = sinon.useFakeTimers(Date.now());


### PR DESCRIPTION
**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-0000](https://issues.corp.twilio.com/browse/CLIENT-0000)

### Description

This PR ensures that the enabled state persist during the lifetime of a Device instance.

Fixes #178 

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
