### PR TITLE
VBLOCKS-1690 Call reconnect() only when pstream is not null.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 :warning: **Important**: If you are upgrading to version 2.3.0 or later and have firewall rules or network configuration that blocks any unknown traffic by default, you need to update your configuration to allow connections to the new DNS names and IP addresses. Please refer to this [changelog](#230-january-23-2023) for more details.
 
+2.7.3 (in progress)
+===================
+
+Bug Fixes
+---------
+
+- Fixed an [issue](https://github.com/twilio/twilio-voice.js/issues/163) where, sometimes a TypeError is raised while handling an incoming call under the following circumstances:
+  - Network interruptions
+  - updating the token before accepting the call
+
 2.7.2 (September 21, 2023)
 =========================
 

--- a/lib/twilio/call.ts
+++ b/lib/twilio/call.ts
@@ -1173,7 +1173,7 @@ class Call extends EventEmitter {
    */
   private _onConnected = (): void => {
     this._log.info('Received connected from pstream');
-    if (this._signalingReconnectToken) {
+    if (this._signalingReconnectToken && this._mediaHandler.version) {
       this._pstream.reconnect(
         this._mediaHandler.version.getSDP(),
         this.parameters.CallSid,


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [VBLOCKS-1690](https://issues.corp.twilio.com/browse/VBLOCKS-1690)
- Fix for https://github.com/twilio/twilio-voice.js/issues/163

### Description

A description of what this PR does.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
