### PR TITLE
VBLOCKS-2032 | AudioProcessor insights and reusing AudioHelper

### DIFF
--- a/lib/twilio/audioprocessoreventobserver.ts
+++ b/lib/twilio/audioprocessoreventobserver.ts
@@ -1,0 +1,36 @@
+/**
+ * @packageDocumentation
+ * @module Voice
+ * @internalapi
+ */
+
+import { EventEmitter } from 'events';
+import Log from './log';
+
+/**
+ * AudioProcessorEventObserver observes {@link AudioProcessor}
+ * related operations and re-emits them as generic events.
+ * @private
+ */
+export class AudioProcessorEventObserver extends EventEmitter {
+
+  private _log: Log = Log.getInstance();
+  
+  constructor() {
+    super();
+    this._log.debug('Creating AudioProcessorEventObserver instance');
+    this.on('add', () => this._reEmitEvent('add'));
+    this.on('remove', () => this._reEmitEvent('remove'));
+    this.on('create', () => this._reEmitEvent('create-processed-stream'));
+    this.on('destroy', () => this._reEmitEvent('destroy-processed-stream'));
+  }
+
+  destroy(): void {
+    this.removeAllListeners();
+  }
+
+  private _reEmitEvent(name: string): void {
+    this._log.debug(`AudioProcessor:${name}`);
+    this.emit('event', { name, group: 'audio-processor' });
+  }
+}

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -7,6 +7,7 @@
 import { EventEmitter } from 'events';
 import { levels as LogLevels, LogLevelDesc } from 'loglevel';
 import AudioHelper from './audiohelper';
+import { AudioProcessorEventObserver } from './audioprocessoreventobserver';
 import Call from './call';
 import * as C from './constants';
 import DialtonePlayer from './dialtonePlayer';
@@ -299,6 +300,11 @@ class Device extends EventEmitter {
   private _audio: AudioHelper | null = null;
 
   /**
+   * The AudioProcessorEventObserver instance to use
+   */
+  private _audioProcessorEventObserver: AudioProcessorEventObserver | null = null;
+
+  /**
    * {@link Device._confirmClose} bound to the specific {@link Device} instance.
    */
   private _boundConfirmClose: typeof Device.prototype._confirmClose;
@@ -589,13 +595,10 @@ class Device extends EventEmitter {
     this.disconnectAll();
     this._stopRegistrationTimer();
 
-    if (this._audio) {
-      this._audio._unbind();
-    }
-
     this._destroyStream();
     this._destroyPublisher();
     this._destroyAudioHelper();
+    this._audioProcessorEventObserver?.destroy();
 
     if (this._networkInformation && typeof this._networkInformation.removeEventListener === 'function') {
       this._networkInformation.removeEventListener('change', this._publishNetworkChange);
@@ -887,8 +890,7 @@ class Device extends EventEmitter {
    */
   private _destroyAudioHelper() {
     if (!this._audio) { return; }
-
-    this._audio.removeAllListeners();
+    this._audio._destroy();
     this._audio = null;
   }
 
@@ -1325,21 +1327,29 @@ class Device extends EventEmitter {
    * Set up an audio helper for usage by this {@link Device}.
    */
   private _setupAudioHelper(): void {
+    if (!this._audioProcessorEventObserver) {
+      this._audioProcessorEventObserver = new AudioProcessorEventObserver();
+      this._audioProcessorEventObserver.on('event', ({ name, group }) => {
+        this._publisher.info(group, name, {}, this._activeCall);
+      });
+    }
+
     const audioOptions: AudioHelper.Options = {
       audioContext: Device.audioContext,
+      audioProcessorEventObserver: this._audioProcessorEventObserver,
       enumerateDevices: this._options.enumerateDevices,
+      getUserMedia: this._options.getUserMedia || getUserMedia,
     };
 
     if (this._audio) {
-      this._log.info('Found existing audio helper; destroying...');
-      audioOptions.enabledSounds = this._audio._getEnabledSounds();
-      this._destroyAudioHelper();
+      this._log.info('Found existing audio helper; updating options...');
+      this._audio._updateUserOptions(audioOptions);
+      return;
     }
 
     this._audio = new (this._options.AudioHelper || AudioHelper)(
       this._updateSinkIds,
       this._updateInputStream,
-      this._options.getUserMedia || getUserMedia,
       audioOptions,
     );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@twilio/voice-sdk",
-  "version": "2.8.0-dev",
+  "version": "2.8.1-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@twilio/voice-sdk",
-      "version": "2.8.0-dev",
+      "version": "2.8.1-dev",
       "license": "Apache-2.0",
       "dependencies": {
         "@twilio/voice-errors": "1.4.0",


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

- AudioProcessor Insights. See https://issues.corp.twilio.com/browse/VBLOCKS-2032.
- Using observer pattern with separate observable to separate public events (device.audio) vs internal (audio processor).
- Reusing audio helper instance, fixing a bug where calling device.updateOptions causes audio helper memory leak.
- Tests are no included. They are part of a separate ticket.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
