### PR TITLE
VBLOCKS-2518 device.register() promise rejection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 :warning: **Important**: If you are upgrading to version 2.3.0 or later and have firewall rules or network configuration that blocks any unknown traffic by default, you need to update your configuration to allow connections to the new DNS names and IP addresses. Please refer to this [changelog](#230-january-23-2023) for more details.
 
+2.10.1 (In Progress)
+====================
+
+Bug Fixes
+---------
+
+- Fixed an [issue](https://github.com/twilio/twilio-voice.js/issues/231) where `device.register()` does not return a promise rejection when the WebSocket fails to connect. Thank you @kamalbennani for your [contribution](https://github.com/twilio/twilio-voice.js/pull/232).
+
 2.10.0 (January 5, 2024)
 ========================
 

--- a/lib/twilio/util.ts
+++ b/lib/twilio/util.ts
@@ -144,6 +144,25 @@ function flatMap(list, mapFn) {
   }, []);
 }
 
+/**
+ * Converts an EventEmitter's events into a promise and automatically
+ * cleans up handlers once the promise is resolved or rejected.
+ */
+function promisifyEvents(emitter, resolveEventName, rejectEventName) {
+  return new Promise((resolve, reject) => {
+    function resolveHandler() {
+      emitter.removeListener(rejectEventName, rejectHandler);
+      resolve();
+    }
+    function rejectHandler() {
+      emitter.removeListener(resolveEventName, resolveHandler);
+      reject();
+    }
+    emitter.once(resolveEventName, resolveHandler);
+    emitter.once(rejectEventName, rejectHandler);
+  });
+}
+
 const Exception = TwilioException;
 
 export {
@@ -158,4 +177,5 @@ export {
   isUnifiedPlanDefault,
   queryToJson,
   flatMap,
+  promisifyEvents,
 };

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -382,6 +382,43 @@ describe('Device', function() {
           await clock.tickAsync(30000 + 1);
           sinon.assert.calledTwice(pstream.register);
         });
+
+        it('should throw an error if the websocket is closed', async () => {
+          device['_streamConnectedPromise'] = null;
+
+          const _setupStream = device['_setupStream'].bind(device)
+          device['_setupStream'] = sinon.spy(async () => {
+            const setupPromise = _setupStream();
+            pstream.emit('close');
+            await setupPromise;
+          });
+
+          await assert.rejects(() => registerDevice());
+        });
+
+        it('should throw an error if the device failed to register because of the WebSocket being closed', async () => {
+          device['_streamConnectedPromise'] = null;
+
+          const _setupStream = device['_setupStream'].bind(device)
+          device['_setupStream'] = sinon.spy(async () => {
+            const setupPromise = _setupStream();
+            pstream.emit('close');
+            await setupPromise;
+          });
+
+          await assert.rejects(() => registerDevice());
+        })
+      });
+
+      describe('._setupStream()', () => {
+        it('should throw an error if the websocket is closed', async () => {
+          setupStream = async () => {
+            const setupPromise = device['_setupStream']();
+            pstream.emit('close');
+            await setupPromise;
+          };
+          await assert.rejects(() => setupStream());
+        })
       });
 
       describe('._sendPresence(presence)', () => {


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

See VBLOCKS-2518

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
