### PR TITLE
[VBLOCKS-2739] fix: remove preflight info from invite pstream message

### DIFF
--- a/lib/twilio/pstream.ts
+++ b/lib/twilio/pstream.ts
@@ -222,10 +222,9 @@ PStream.prototype.register = function(mediaCapabilities) {
   this._publish('register', regPayload, true);
 };
 
-PStream.prototype.invite = function(sdp, callsid, preflight, params) {
+PStream.prototype.invite = function(sdp, callsid, params) {
   const payload = {
     callsid,
-    preflight: !!preflight,
     sdp,
     twilio: params ? { params } : {},
   };

--- a/lib/twilio/rtc/peerconnection.ts
+++ b/lib/twilio/rtc/peerconnection.ts
@@ -916,7 +916,7 @@ PeerConnection.prototype.makeOutgoingCall = function(token, params, callsid, rtc
 
   function onOfferSuccess() {
     if (self.status !== 'closed') {
-      self.pstream.invite(self.version.getSDP(), self.callSid, self.options.preflight, params);
+      self.pstream.invite(self.version.getSDP(), self.callSid, params);
       self._setupRTCDtlsTransportListener();
     }
   }

--- a/tests/peerconnection.js
+++ b/tests/peerconnection.js
@@ -867,7 +867,7 @@ describe('PeerConnection', () => {
       assert(version.createOffer.calledWithExactly(undefined, undefined, {audio: true}, sinon.match.func, sinon.match.func));
       assert.equal(callback.called, false);
       assert(context.pstream.invite.calledOnce);
-      assert(context.pstream.invite.calledWithExactly(eSDP, eCallSid, true, eParams));
+      assert(context.pstream.invite.calledWithExactly(eSDP, eCallSid, eParams));
       assert(version.getSDP.calledOnce);
       assert(version.getSDP.calledWithExactly());
       assert(context.pstream.on.calledWithExactly('answer', sinon.match.func));
@@ -884,7 +884,7 @@ describe('PeerConnection', () => {
       assert(version.createOffer.calledWithExactly(undefined, undefined, {audio: true}, sinon.match.func, sinon.match.func));
       assert.equal(callback.called, false);
       assert(context.pstream.invite.calledOnce);
-      assert(context.pstream.invite.calledWithExactly(eSDP, eCallSid, true, eParams));
+      assert(context.pstream.invite.calledWithExactly(eSDP, eCallSid, eParams));
       assert(version.getSDP.calledOnce);
       assert(version.getSDP.calledWithExactly());
       assert(context.pstream.on.calledWithExactly('answer', sinon.match.func));

--- a/tests/pstream.js
+++ b/tests/pstream.js
@@ -391,20 +391,15 @@ describe('PStream', () => {
     ]],
     ['invite', [
       {
-        args: ['bar', 'foo', true, ''],
-        payload: { callsid: 'foo', sdp: 'bar', preflight: true, twilio: {} },
+        args: ['bar', 'foo', ''],
+        payload: { callsid: 'foo', sdp: 'bar', twilio: {} },
         scenario: 'called with empty params'
       },
       {
-        args: ['bar', 'foo', true, 'baz=zee&foo=2'],
-        payload: { callsid: 'foo', sdp: 'bar', preflight: true,  twilio: { params: 'baz=zee&foo=2' } },
+        args: ['bar', 'foo', 'baz=zee&foo=2'],
+        payload: { callsid: 'foo', sdp: 'bar', twilio: { params: 'baz=zee&foo=2' } },
         scenario: 'called with non-empty params'
       },
-      {
-        args: ['bar', 'foo', false, ''],
-        payload: { callsid: 'foo', sdp: 'bar', preflight: false,  twilio: {} },
-        scenario: 'called with preflight = false'
-      }
     ]],
     ['answer', [
       {


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [VBLOCKS-2739](https://issues.corp.twilio.com/browse/VBLOCKS-2739)

### Description

This PR removes the "preflight" parameter and payload member from the pstream invite method.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [x] Updated affected documentation
* [x] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
