### PR TITLE
[VBLOCKS-2954] Update `@twilio/voice-errors` to `1.5.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 :warning: **Important**: If you are upgrading to version 2.3.0 or later and have firewall rules or network configuration that blocks any unknown traffic by default, you need to update your configuration to allow connections to the new DNS names and IP addresses. Please refer to this [changelog](#230-january-23-2023) for more details.
 
+2.12.0 (In Progress)
+====================
+
+Changes
+-------
+
+- The `CallMessage` API has changed. The type of `Call.Message.messageType` formerly had type `Call.MessageType`. The `Call.MessageType` enumeration has been removed and `Call.Message.messageType` is now of type `string`. The `CallMessage` interface is now as follows:
+```ts
+interface Call.Message {
+  content: any;
+  contentType?: string;
+  messageType: string;
+  voiceEventSid?: string;
+}
+```
+When sending a `Call.Message` using `call.sendMessage()`, if the message type is invalid or not understood by Twilio, an error response will be sent. See this [error page](https://www.twilio.com/docs/api/errors/31210) for further details.
+
 2.10.2 (February 14, 2024)
 ==========================
 

--- a/lib/twilio/errors/generated.ts
+++ b/lib/twilio/errors/generated.ts
@@ -921,6 +921,39 @@ export namespace AuthorizationErrors {
       this.originalError = originalError;
     }
   }
+
+  export class CallMessageEventTypeInvalidError extends TwilioError {
+    causes: string[] = [
+      'The Call Message Event Type is invalid and is not understood by Twilio Voice.',
+    ];
+    code: number = 31210;
+    description: string = 'Call Message Event Type is invalid.';
+    explanation: string = 'The Call Message Event Type is invalid and is not understood by Twilio Voice.';
+    name: string = 'CallMessageEventTypeInvalidError';
+    solutions: string[] = [
+      'Ensure the Call Message Event Type is Valid and understood by Twilio Voice and try again.',
+    ];
+
+    constructor();
+    constructor(message: string);
+    constructor(error: Error | object);
+    constructor(message: string, error: Error | object);
+    constructor(messageOrError?: string | Error | object, error?: Error | object) {
+      super(messageOrError, error);
+      Object.setPrototypeOf(this, AuthorizationErrors.CallMessageEventTypeInvalidError.prototype);
+
+      const message: string = typeof messageOrError === 'string'
+        ? messageOrError
+        : this.explanation;
+
+      const originalError: Error | object | undefined = typeof messageOrError === 'object'
+        ? messageOrError
+        : error;
+
+      this.message = `${this.name} (${this.code}): ${message}`;
+      this.originalError = originalError;
+    }
+  }
 }
 
 export namespace UserMediaErrors {
@@ -1200,6 +1233,7 @@ export const errorsByCode: ReadonlyMap<number, any> = new Map([
   [ 31206, AuthorizationErrors.RateExceededError ],
   [ 31207, AuthorizationErrors.JWTTokenExpirationTooLongError ],
   [ 31209, AuthorizationErrors.PayloadSizeExceededError ],
+  [ 31210, AuthorizationErrors.CallMessageEventTypeInvalidError ],
   [ 31401, UserMediaErrors.PermissionDeniedError ],
   [ 31402, UserMediaErrors.AcquisitionFailedError ],
   [ 53000, SignalingErrors.ConnectionError ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.10.3-dev",
       "license": "Apache-2.0",
       "dependencies": {
-        "@twilio/voice-errors": "1.4.0",
+        "@twilio/voice-errors": "1.5.0",
         "@types/md5": "2.3.2",
         "events": "3.3.0",
         "loglevel": "1.6.7",
@@ -2131,9 +2131,9 @@
       "dev": true
     },
     "node_modules/@twilio/voice-errors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@twilio/voice-errors/-/voice-errors-1.4.0.tgz",
-      "integrity": "sha512-7BCg9MPz+KQ0JJ6Rl5W3Zw3E+i3Tt77VZw3/2i3Z+IPZITmCOQLu1nKx/0Nlj505Xtfr7eY9Mcern5PfIoBW0w=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@twilio/voice-errors/-/voice-errors-1.5.0.tgz",
+      "integrity": "sha512-nmHG9bVikZXnWsJ6cN8Issbrm9ttUZwDJOsJ6ok3KNNVMVUp6KcWzFKvhSrskJpCtgqh0itiGOdpo0tALoYvLQ=="
     },
     "node_modules/@types/cookie": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "ws": "7.4.6"
   },
   "dependencies": {
-    "@twilio/voice-errors": "1.4.0",
+    "@twilio/voice-errors": "1.5.0",
     "@types/md5": "2.3.2",
     "events": "3.3.0",
     "loglevel": "1.6.7",

--- a/scripts/errors.js
+++ b/scripts/errors.js
@@ -19,6 +19,7 @@ const USED_ERRORS = [
   'AuthorizationErrors.NoValidAccountError',
   'AuthorizationErrors.PayloadSizeExceededError',
   'AuthorizationErrors.RateExceededError',
+  'AuthorizationErrors.CallMessageEventTypeInvalidError',
   'ClientErrors.BadRequest',
   'ClientErrors.BusyHere',
   'ClientErrors.NotFound',


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [VBLOCKS-2954](https://twilio-engineering.atlassian.net/browse/VBLOCKS-2954)

### Description

This PR updates the voice error dependency to the latest version and generates the new callmessageeventmessagetype error for use in the SDK.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [x] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
