### PR TITLE
Adds fix for stream not updating when selected input device is null

### DIFF
--- a/lib/twilio/audiohelper.ts
+++ b/lib/twilio/audiohelper.ts
@@ -832,7 +832,9 @@ class AudioHelper extends EventEmitter {
       //   then that device is unplugged or plugged back in. We can't check for the 'ended'
       //   event or readyState because it is asynchronous and may take upwards of 5 seconds,
       //   in my testing. (rrowland)
-      if (this.inputDevice !== null && this.inputDevice.deviceId === 'default') {
+
+      // If input device is null, we can assume it to behave it as if a default input device is selected 
+      if ((this.inputDevice === null && this.availableInputDevices.get("default")) || (this.inputDevice && this.inputDevice.deviceId === 'default')) {
         this._log.warn(`Calling getUserMedia after device change to ensure that the \
           tracks of the active device (default) have not gone stale.`);
         this._setInputDevice(this.inputDevice.deviceId, true);


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

### Description

This PR resolves issue https://github.com/twilio/twilio-voice.js/issues/256. 
Issue is that audioHelper used to handle updating stream when 'default' device was selected as input device.

However, it is possible that selected input device is empty or null (initially). We should consider this scenario as well as if a default device has been selected. In this case as well, when we get a 'devicechange' event, we should refresh input stream.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [x] Updated affected documentation
* [ ] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
