### PR TITLE
VBLOCKS-3064 Move Call Message related errors to the Call object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,19 +3,13 @@
 2.12.0 (In Progress)
 ====================
 
-Changes
--------
+### Call Message Events
 
-- The `CallMessage` API has changed. The type of `Call.Message.messageType` formerly had type `Call.MessageType`. The `Call.MessageType` enumeration has been removed and `Call.Message.messageType` is now of type `string`. The `CallMessage` interface is now as follows:
-```ts
-interface Call.Message {
-  content: any;
-  contentType?: string;
-  messageType: string;
-  voiceEventSid?: string;
-}
-```
-When sending a `Call.Message` using `call.sendMessage()`, if the message type is invalid or not understood by Twilio, an error response will be sent. See this [error page](https://www.twilio.com/docs/api/errors/31210) for further details.
+The Call Message Events (Beta), originally released in 2.2.0, has been promoted to GA. This release includes the following **breaking changes**.
+
+- [Call.Message.messageType](https://twilio.github.io/twilio-voice.js/interfaces/voice.call.message.html) has been converted from `Call.MessageType` enum to `string`.
+- Call Message related errors are now emitted via [call.on('error', handler(twilioError))](https://twilio.github.io/twilio-voice.js/classes/voice.call.html#errorevent) instead of [device.on('error', handler(twilioError))](https://twilio.github.io/twilio-voice.js/classes/voice.device.html#errorevent).
+- A new error, [31210](https://www.twilio.com/docs/api/errors/31210), has been added to the SDK. This new error is emitted via [call.on('error', handler(twilioError))](https://twilio.github.io/twilio-voice.js/classes/voice.call.html#errorevent) after calling the [sendMessage](https://twilio.github.io/twilio-voice.js/classes/voice.call.html#sendmessage) API with an invalid [Call.Message.messageType](https://twilio.github.io/twilio-voice.js/interfaces/voice.call.message.html).
 
 2.11.1 (May 30, 2024)
 ====================

--- a/lib/twilio/call.ts
+++ b/lib/twilio/call.ts
@@ -1480,6 +1480,24 @@ class Call extends EventEmitter {
         message: error.message,
         voice_event_sid: voiceeventsid,
       }, this);
+
+      let twilioError;
+      const errorConstructor = getPreciseSignalingErrorByCode(
+        !!this._options.enableImprovedSignalingErrorPrecision,
+        error.code,
+      );
+
+      if (typeof errorConstructor !== 'undefined') {
+        twilioError = new errorConstructor(error);
+      }
+
+      if (!twilioError) {
+        this._log.error('Unknown Call Message Error: ', error);
+        twilioError = new GeneralErrors.UnknownError(error.message, error);
+      }
+
+      this._log.debug('#error', error, twilioError);
+      this.emit('error', twilioError);
     }
    }
 

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -1229,11 +1229,19 @@ class Device extends EventEmitter {
    * Called when an 'error' event is received from the signaling stream.
    */
   private _onSignalingError = (payload: Record<string, any>) => {
-    if (typeof payload !== 'object') { return; }
+    if (typeof payload !== 'object') {
+      this._log.warn('Invalid signaling error payload', payload);
+      return;
+    }
 
-    const { error: originalError, callsid } = payload;
+    const { error: originalError, callsid, voiceeventsid } = payload;
 
-    if (typeof originalError !== 'object') { return; }
+    // voiceeventsid is for call message events which are handled in the call object
+    // missing originalError shouldn't be possible but check here to fail properly
+    if (typeof originalError !== 'object' || !!voiceeventsid) {
+      this._log.warn('Ignoring signaling error payload', { originalError, voiceeventsid });
+      return;
+    }
 
     const call: Call | undefined =
       (typeof callsid === 'string' && this._findCall(callsid)) || undefined;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@twilio/voice-sdk",
-  "version": "2.11.1-dev",
+  "version": "2.11.2-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@twilio/voice-sdk",
-      "version": "2.11.1-dev",
+      "version": "2.11.2-dev",
       "license": "Apache-2.0",
       "dependencies": {
         "@twilio/voice-errors": "1.5.0",

--- a/tests/integration/callMessage/userDefinedMessage.ts
+++ b/tests/integration/callMessage/userDefinedMessage.ts
@@ -155,15 +155,8 @@ describe('userDefinedMessage', function() {
     });
 
     it('should receive an error if the message type is invalid', async function() {
-      const { device, call } = alice;
-      /**
-       * NOTE(mhuynh): We will be changing the API such that the call emits
-       * the call message error, not the device. Change this when we make that
-       * API change.
-       *
-       * See VBLOCKS-3064
-       */
-      const errorPromise = expectEvent('error', device);
+      const { call } = alice;
+      const errorPromise = expectEvent('error', call);
       call.sendMessage({
         content: { foo: 'bar' },
         messageType: 'not-a-valid-message-type',

--- a/tests/unit/call.ts
+++ b/tests/unit/call.ts
@@ -4,7 +4,7 @@ import * as assert from 'assert';
 import { EventEmitter } from 'events';
 import { SinonFakeTimers, SinonSpy, SinonStubbedInstance } from 'sinon';
 import * as sinon from 'sinon';
-import { GeneralErrors, MediaErrors, InvalidStateError, InvalidArgumentError } from '../../lib/twilio/errors';
+import { GeneralErrors, MediaErrors, InvalidStateError, InvalidArgumentError, TwilioError } from '../../lib/twilio/errors';
 
 const Util = require('../../lib/twilio/util');
 
@@ -2031,15 +2031,19 @@ describe('Call', function() {
         assert.deepEqual(await payloadPromise, { ...mockMessagePayload, voiceEventSid: sid });
       });
 
-      it('should publish a user-defined-message sent event', () => {
+      it('should publish a user-defined-message sent event', async () => {
         const sid = conn.sendMessage(mockMessagePayload);
         const payloadPromise = new Promise((resolve) => {
           conn.on('messageSent', resolve);
         });
         pstream.emit('ack', { ...mockAckPayload, voiceeventsid: sid });
-        payloadPromise.then((payload) => {
-          sinon.assert.calledWith(publisher.info, 'user-defined-message', 'sent');
-          assert.deepEqual(payload, { ...mockMessagePayload, voiceEventSid: sid });
+        await payloadPromise;
+        assert.deepStrictEqual(publisher.info.args[1][0], 'call-message');
+        assert.deepStrictEqual(publisher.info.args[1][1], mockMessagePayload.messageType);
+        assert.deepStrictEqual(publisher.info.args[1][2], {
+          content_type: mockMessagePayload.contentType,
+          event_type: 'sent',
+          voice_event_sid: sid
         });
       });
 
@@ -2099,14 +2103,7 @@ describe('Call', function() {
         const payloadPromise = new Promise((resolve, reject) => {
           conn.on('messageSent', reject);
         });
-        pstream.emit('error', {
-          callsid: mockcallsid,
-          voiceeventsid: sid,
-          error: {
-            code: 123,
-            message: 'foo',
-          }
-        });
+        pstream.emit('error', { callsid: mockcallsid, voiceeventsid: sid, error: { code: 31210, message: 'foo' }});
         pstream.emit('ack', { ...mockAckPayload, voiceeventsid: sid });
         await Promise.race([
           wait(1),
@@ -2119,7 +2116,7 @@ describe('Call', function() {
         const payloadPromise = new Promise((resolve) => {
           conn.on('messageSent', resolve);
         });
-        pstream.emit('error', { callsid: 'foo', voiceeventsid: sid });
+        pstream.emit('error', { callsid: 'foo', voiceeventsid: sid, error: { code: 31210, message: 'foo' }});
         pstream.emit('ack', { ...mockAckPayload, voiceeventsid: sid });
         await payloadPromise;
       });
@@ -2129,7 +2126,7 @@ describe('Call', function() {
         const payloadPromise = new Promise((resolve) => {
           conn.on('messageSent', resolve);
         });
-        pstream.emit('error', { callsid: mockcallsid, voiceeventsid: 'foo' });
+        pstream.emit('error', { callsid: mockcallsid, voiceeventsid: 'foo', error: { code: 31210, message: 'foo' }});
         pstream.emit('ack', { ...mockAckPayload, voiceeventsid: sid });
         await payloadPromise;
       });
@@ -2139,9 +2136,41 @@ describe('Call', function() {
         const payloadPromise = new Promise((resolve) => {
           conn.on('messageSent', resolve);
         });
-        pstream.emit('error', { callsid: mockcallsid });
+        pstream.emit('error', { callsid: mockcallsid, error: { code: 31210, message: 'foo' }});
         pstream.emit('ack', { ...mockAckPayload, voiceeventsid: sid });
         await payloadPromise;
+      });
+
+      it('should publish a user-defined-message error event', () => {
+        const sid = conn.sendMessage(mockMessagePayload);
+        pstream.emit('error', { callsid: mockcallsid, voiceeventsid: sid, error: { code: 31210, message: 'foo' }});
+        assert.deepStrictEqual(publisher.error.args[0][0], 'call-message');
+        assert.deepStrictEqual(publisher.error.args[0][1], 'error');
+        assert.deepStrictEqual(publisher.error.args[0][2],   {
+          code: 31210,
+          message: 'foo',
+          voice_event_sid: sid
+        });
+      });
+
+      it('should emit the correct call message error', async () => {
+        const sid = conn.sendMessage(mockMessagePayload);
+        const payloadPromise: Promise<TwilioError> = new Promise((resolve) => {
+          conn.on('error', resolve);
+        });
+        pstream.emit('error', { callsid: mockcallsid, voiceeventsid: sid, error: { code: 31210, message: 'foo' }});
+        const error = await payloadPromise;
+        assert.strictEqual(error.code, 31210);
+      });
+
+      it('should emit an unknown error', async () => {
+        const sid = conn.sendMessage(mockMessagePayload);
+        const payloadPromise: Promise<TwilioError> = new Promise((resolve) => {
+          conn.on('error', resolve);
+        });
+        pstream.emit('error', { callsid: mockcallsid, voiceeventsid: sid, error: { code: 111, message: 'foo' }});
+        const error = await payloadPromise;
+        assert.strictEqual(error.code, 31000);
       });
     });
 
@@ -2191,40 +2220,13 @@ describe('Call', function() {
       });
 
       it('should publish a user-defined-message received event', () => {
-        const payloadPromise = new Promise((resolve) => {
-          conn.on('messageReceived', resolve);
-        });
         pstream.emit('message', mockPayload);
-        payloadPromise.then((payload) => {
-          sinon.assert.calledWith(publisher.info, 'user-defined-message', 'received');
-          assert.deepEqual(payload, {
-            content: mockPayload.content,
-            contentType: mockPayload.contenttype,
-            messageType: mockPayload.messagetype,
-            voiceEventSid: mockPayload.voiceeventsid,
-          });
-        });
-      });
-
-      it('should publish a user-defined-message error event', () => {
-        const payloadPromise = new Promise((resolve, reject) => {
-          conn.on('error', reject);
-        });
-        pstream.emit('error', {
-          callsid: mockcallsid,
-          voiceeventsid: 'mock-voiceeventsid-foobar',
-          error: {
-            code: 111,
-            message: 'foo-error',
-          }
-        });
-        payloadPromise.then((payload) => {
-          sinon.assert.calledWith(publisher.error, 'user-defined-message', 'error');
-          assert.deepEqual(payload, {
-            code: 111,
-            message: 'foo-error',
-            voiceEventSid: 'mock-voiceeventsid-foobar',
-          });
+        assert.deepStrictEqual(publisher.info.args[1][0], 'call-message');
+        assert.deepStrictEqual(publisher.info.args[1][1], mockPayload.messagetype);
+        assert.deepStrictEqual(publisher.info.args[1][2], {
+          content_type: mockPayload.contenttype,
+          event_type: 'received',
+          voice_event_sid: mockPayload.voiceeventsid
         });
       });
     });

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -925,6 +925,12 @@ describe('Device', function() {
           assert.equal(31005, errorObject.code);
         });
 
+        it('should not emit error if a voiceeventsid is passed', () => {
+          const spy = device.emit = sinon.spy();
+          pstream.emit('error', { error: { code: 31005, twilioError: new GeneralErrors.UnknownError() }, voiceeventsid: 'foo' });
+          sinon.assert.notCalled(spy);
+        });
+
         it('should emit the proper error message', () => {
           const spy = device.emit = sinon.spy();
           pstream.emit('error', { error: { code: 31005, message: 'foobar', twilioError: new GeneralErrors.UnknownError() } });


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

See VBLOCKS-3064

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [x] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
