### PR TITLE
Fix CSP in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Use the following policy directives to enable [CSP](https://developer.mozilla.or
 
 ```
 script-src https://media.twiliocdn.com https://sdk.twilio.com
-media-src mediastream https://media.twiliocdn.com https://sdk.twilio.com
+media-src mediastream: https://media.twiliocdn.com https://sdk.twilio.com
 connect-src https://eventgw.twilio.com wss://voice-js.roaming.twilio.com https://media.twiliocdn.com https://sdk.twilio.com
 ```
 


### PR DESCRIPTION
Per https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources -- the correct format for protocol source values has a trailing colon.


**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.


