### PR TITLE
Handle when `rtcIceCandidateStatsReport` is undefined

### DIFF
--- a/lib/twilio/preflight/preflight.ts
+++ b/lib/twilio/preflight/preflight.ts
@@ -292,7 +292,7 @@ export class PreflightTest extends EventEmitter {
     const report: PreflightTest.Report = {
       callSid: this._callSid,
       edge: this._edge,
-      iceCandidateStats: this._rtcIceCandidateStatsReport.iceCandidateStats,
+      iceCandidateStats: this._rtcIceCandidateStatsReport?.iceCandidateStats ?? [],
       networkTiming: this._networkTiming,
       samples: this._samples,
       selectedEdge: this._options.edge,
@@ -302,7 +302,7 @@ export class PreflightTest extends EventEmitter {
       warnings: this._warnings,
     };
 
-    const selectedIceCandidatePairStats = this._rtcIceCandidateStatsReport.selectedIceCandidatePairStats;
+    const selectedIceCandidatePairStats = this._rtcIceCandidateStatsReport?.selectedIceCandidatePairStats;
 
     if (selectedIceCandidatePairStats) {
       report.selectedIceCandidatePairStats = selectedIceCandidatePairStats;


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-0000](https://issues.corp.twilio.com/browse/CLIENT-0000)

### Description

In the case where rtcIceCandidateStatsReport is never set, we cannot read from one of its properties. This change ensures that a default value is set when rtcIceCandidateStatsReport is undefined.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
