### PR TITLE
[VBLOCKS-3256] Feat: listen for navigator permissions changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 :warning: **Important**: If you are upgrading to version 2.3.0 or later and have firewall rules or network configuration that blocks any unknown traffic by default, you need to update your configuration to allow connections to the new DNS names and IP addresses. Please refer to this [changelog](#230-january-23-2023) for more details.
 
+2.11.3 (August 2, 2024)
+======================
+
+Improvements
+------------
+
+- The SDK now updates its internal device list when the microphone permission changes
+
 2.11.2 (June 26, 2024)
 ======================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Bug Fixes
 Improvements
 ------------
 
-- The SDK now updates its internal device list when the microphone permission changes
+- The SDK now updates its internal device list when the microphone permission changes.
 
 2.11.2 (June 26, 2024)
 ======================

--- a/lib/twilio/audiohelper.ts
+++ b/lib/twilio/audiohelper.ts
@@ -275,6 +275,16 @@ class AudioHelper extends EventEmitter {
     if (isEnumerationSupported) {
       this._initializeEnumeration();
     }
+
+    navigator.permissions.query({ name: 'microphone' as PermissionName }).then((microphonePermissionStatus) => {
+      if (microphonePermissionStatus.state !== 'granted') {
+        const handleStateChange = () => {
+          this._updateAvailableDevices();
+          microphonePermissionStatus.removeEventListener('change', this._updateAvailableDevices);
+        };
+        microphonePermissionStatus.addEventListener('change', handleStateChange);
+      }
+    }).catch((reason) => this._log.warn(`Warning: unable to listen for microphone permission changes. ${reason}`));
   }
 
   /**

--- a/lib/twilio/audiohelper.ts
+++ b/lib/twilio/audiohelper.ts
@@ -166,7 +166,7 @@ class AudioHelper extends EventEmitter {
   /**
    * The microphone permission status
    */
-  private _microphonePermissionStatus: PermissionStatus;
+  private _microphonePermissionStatus: PermissionStatus | null;
 
   /**
    * Called with the new input stream when the active input is changed.
@@ -412,7 +412,9 @@ class AudioHelper extends EventEmitter {
    * @private
    */
   _stopMicrophonePermissionListener(): void {
-    this._microphonePermissionStatus.removeEventListener('change', this._onMicrophonePermissionStatusChanged);
+    if (this._microphonePermissionStatus?.removeEventListener) {
+      this._microphonePermissionStatus.removeEventListener('change', this._onMicrophonePermissionStatusChanged);
+    }
   }
 
   /**

--- a/lib/twilio/audiohelper.ts
+++ b/lib/twilio/audiohelper.ts
@@ -292,7 +292,6 @@ class AudioHelper extends EventEmitter {
       if (microphonePermissionStatus.state !== 'granted') {
         const handleStateChange = () => {
           this._updateAvailableDevices();
-          microphonePermissionStatus.removeEventListener('change', this._updateAvailableDevices);
         };
         microphonePermissionStatus.addEventListener('change', handleStateChange);
         this._microphonePermissionStatus = microphonePermissionStatus;
@@ -404,16 +403,6 @@ class AudioHelper extends EventEmitter {
       this._defaultInputDeviceStream.getTracks().forEach(track => track.stop());
       this._defaultInputDeviceStream = null;
       this._destroyProcessedStream();
-    }
-  }
-
-  /**
-   * Remove event listener for microphone permissions
-   * @private
-   */
-  _stopMicrophonePermissionListener(): void {
-    if (this._microphonePermissionStatus?.removeEventListener) {
-      this._microphonePermissionStatus.removeEventListener('change', this._onMicrophonePermissionStatusChanged);
     }
   }
 
@@ -832,6 +821,15 @@ class AudioHelper extends EventEmitter {
     return this._inputDevicePromise = setInputDevice().finally(() => {
       this._inputDevicePromise = null;
     });
+  }
+
+  /**
+   * Remove event listener for microphone permissions
+   */
+  private _stopMicrophonePermissionListener(): void {
+    if (this._microphonePermissionStatus?.removeEventListener) {
+      this._microphonePermissionStatus.removeEventListener('change', this._onMicrophonePermissionStatusChanged);
+    }
   }
 
   /**

--- a/lib/twilio/audiohelper.ts
+++ b/lib/twilio/audiohelper.ts
@@ -292,6 +292,7 @@ class AudioHelper extends EventEmitter {
       if (microphonePermissionStatus.state !== 'granted') {
         const handleStateChange = () => {
           this._updateAvailableDevices();
+          this._stopMicrophonePermissionListener();
         };
         microphonePermissionStatus.addEventListener('change', handleStateChange);
         this._microphonePermissionStatus = microphonePermissionStatus;

--- a/tests/audiohelper.js
+++ b/tests/audiohelper.js
@@ -180,6 +180,7 @@ describe('AudioHelper', () => {
         audio._stopSelectedInputDeviceStream = sinon.stub();
         audio._destroyProcessedStream = sinon.stub();
         audio._maybeStopPollingVolume = sinon.stub();
+        audio._stopMicrophonePermissionListener = sinon.stub();
         audio._destroy();
         assert.strictEqual(audio.eventNames().length, 0);
         sinon.assert.calledOnce(audio._stopDefaultInputDeviceStream);
@@ -187,7 +188,7 @@ describe('AudioHelper', () => {
         sinon.assert.calledOnce(audio._destroyProcessedStream);
         sinon.assert.calledOnce(audio._maybeStopPollingVolume);
         sinon.assert.calledOnce(mediaDevices.removeEventListener);
-
+        sinon.assert.calledOnce(audio._stopMicrophonePermissionListener);
       });
     });
 

--- a/tests/audiohelper.js
+++ b/tests/audiohelper.js
@@ -16,7 +16,7 @@ describe('AudioHelper', () => {
 
     let audio;
     let oldHTMLAudioElement;
-    let oldNavigator;
+    let oldMediaDevices;
 
     beforeEach(() => {
       audio = new AudioHelper(noop, noop, {
@@ -33,16 +33,15 @@ describe('AudioHelper', () => {
       oldHTMLAudioElement = typeof HTMLAudioElement !== 'undefined'
         ? HTMLAudioElement
         : undefined;
-      oldNavigator = typeof navigator !== 'undefined'
-        ? navigator
-        : undefined;
       HTMLAudioElement = undefined;
-      navigator = { };
+
+      oldMediaDevices = navigator.mediaDevices;
+      navigator.mediaDevices = undefined;
     });
 
     after(() => {
       HTMLAudioElement = oldHTMLAudioElement;
-      navigator = oldNavigator;
+      navigator.mediaDevices = oldMediaDevices;
     });
 
     describe('constructor', () => {
@@ -187,7 +186,6 @@ describe('AudioHelper', () => {
         audio._stopSelectedInputDeviceStream = sinon.stub();
         audio._destroyProcessedStream = sinon.stub();
         audio._maybeStopPollingVolume = sinon.stub();
-        audio._stopMicrophonePermissionListener = sinon.stub();
         audio._destroy();
         assert.strictEqual(audio.eventNames().length, 0);
         sinon.assert.calledOnce(audio._stopDefaultInputDeviceStream);

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,5 +1,7 @@
 import * as WebSocket from 'ws';
 
+const EventTarget = require('./eventtarget');
+
 const root = global as any;
 let handlers = {};
 
@@ -75,7 +77,7 @@ root.navigator = {
   userAgent: 'userAgent',
   permissions: {
     query: function() {
-      return Promise.resolve('prompt');
+      return Promise.resolve(new EventTarget());
     }
   }
 };

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -73,6 +73,11 @@ root.navigator = {
   },
   platform: 'platform',
   userAgent: 'userAgent',
+  permissions: {
+    query: function() {
+      return Promise.resolve('prompt');
+    }
+  }
 };
 
 root.RTCPeerConnection = root.window.RTCPeerConnection = function() { };


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [VBLOCKS-3256](https://twilio-engineering.atlassian.net/browse/VBLOCKS-3256)

### Description

Reference issue: https://github.com/twilio/twilio-voice.js/issues/228
- allow user to instantiate the Twilio Device after the permissions are set
- listen to microphone permission changes

## Burndown

Tested:
* [x] Chrome
* [x] Safari
* [x] Edge
* [ ] Firefox - Firefox shows error, but is able to make outgoing call. Microphone permissions not supported in firefox https://github.com/mozilla/standards-positions/issues/19#issuecomment-370158947 

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
