### PR TITLE
[VBLOCKS-3375] fix: check for navigator permissions

### DIFF
--- a/lib/twilio/audiohelper.ts
+++ b/lib/twilio/audiohelper.ts
@@ -286,19 +286,24 @@ class AudioHelper extends EventEmitter {
       this._initializeEnumeration();
     }
 
-    // NOTE (kchoy): Currently microphone permissions are not supported in firefox.
+    // NOTE (kchoy): Currently microphone permissions are not supported in firefox, and Safari V15.
     // https://github.com/mozilla/standards-positions/issues/19#issuecomment-370158947
-    navigator.permissions.query({ name: 'microphone' }).then((microphonePermissionStatus) => {
-      if (microphonePermissionStatus.state !== 'granted') {
-        const handleStateChange = () => {
-          this._updateAvailableDevices();
-          this._stopMicrophonePermissionListener();
-        };
-        microphonePermissionStatus.addEventListener('change', handleStateChange);
-        this._microphonePermissionStatus = microphonePermissionStatus;
-        this._onMicrophonePermissionStatusChanged = handleStateChange;
-      }
-    }).catch((reason) => this._log.warn(`Warning: unable to listen for microphone permission changes. ${reason}`));
+    // https://caniuse.com/permissions-api
+    if (navigator && navigator.permissions && typeof navigator.permissions.query === 'function') {
+      navigator.permissions.query({ name: 'microphone' }).then((microphonePermissionStatus) => {
+        if (microphonePermissionStatus.state !== 'granted') {
+          const handleStateChange = () => {
+            this._updateAvailableDevices();
+            this._stopMicrophonePermissionListener();
+          };
+          microphonePermissionStatus.addEventListener('change', handleStateChange);
+          this._microphonePermissionStatus = microphonePermissionStatus;
+          this._onMicrophonePermissionStatusChanged = handleStateChange;
+        }
+      }).catch((reason) => this._log.warn(`Warning: unable to listen for microphone permission changes. ${reason}`));
+    } else {
+      this._log.warn('Warning: current browser does not support permissions API');
+    }
   }
 
   /**

--- a/lib/twilio/audiohelper.ts
+++ b/lib/twilio/audiohelper.ts
@@ -286,7 +286,7 @@ class AudioHelper extends EventEmitter {
       this._initializeEnumeration();
     }
 
-    // NOTE (kchoy): Currently microphone permissions are not supported in firefox, and Safari V15.
+    // NOTE (kchoy): Currently microphone permissions are not supported in firefox, and Safari V15 and older.
     // https://github.com/mozilla/standards-positions/issues/19#issuecomment-370158947
     // https://caniuse.com/permissions-api
     if (navigator && navigator.permissions && typeof navigator.permissions.query === 'function') {
@@ -302,7 +302,7 @@ class AudioHelper extends EventEmitter {
         }
       }).catch((reason) => this._log.warn(`Warning: unable to listen for microphone permission changes. ${reason}`));
     } else {
-      this._log.warn('Warning: current browser does not support permissions API');
+      this._log.warn('Warning: current browser does not support permissions API.');
     }
   }
 

--- a/tests/audiohelper.js
+++ b/tests/audiohelper.js
@@ -178,6 +178,14 @@ describe('AudioHelper', () => {
         mockEventTarget.dispatchEvent({ type: 'change' });
         sinon.assert.calledOnce(enumerateDevices);
       });
+
+      it('should not update list of devices if navigator permissions is undefined', async () => {
+        navigator.permissions = undefined
+        audio = new AudioHelper(onActiveOutputsChanged, onActiveInputChanged, { enumerateDevices });
+        await wait();
+        mockEventTarget.dispatchEvent({ type: 'change' });
+        sinon.assert.calledOnce(enumerateDevices);
+      })
     });
 
     describe('._destroy', () => {


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [VBLOCKS-3375](https://twilio-engineering.atlassian.net/browse/VBLOCKS-3375)

### Description

Permissions API not supported for Safari v15

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [x] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [x] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
