### PR TITLE
VBLOCKS-3726 Use chunderw if present on reconnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 :warning: **Important**: If you are upgrading to version 2.3.0 or later and have firewall rules or network configuration that blocks any unknown traffic by default, you need to update your configuration to allow connections to the new DNS names and IP addresses. Please refer to this [changelog](#230-january-23-2023) for more details.
 
+2.12.2 (In Progress)
+====================
+
+Bug Fixes
+---------
+
+- Fixed an issue where the `chunderw` parameter is not being used during signaling reconnection. Note that this parameter is intended solely for testing purposes.
+
 2.12.1 (August 30, 2024)
 ========================
 

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -789,16 +789,11 @@ class Device extends EventEmitter {
 
     const originalChunderURIs: Set<string> = new Set(this._chunderURIs);
 
-    const chunderw = typeof this._options.chunderw === 'string'
-      ? [this._options.chunderw]
-      : Array.isArray(this._options.chunderw) && this._options.chunderw;
-
     const newChunderURIs = this._chunderURIs = (
-      chunderw || getChunderURIs(this._options.edge)
+      this._getChunderws() || getChunderURIs(this._options.edge)
     ).map(createSignalingEndpointURL);
 
-    let hasChunderURIsChanged =
-      originalChunderURIs.size !== newChunderURIs.length;
+    let hasChunderURIsChanged = originalChunderURIs.size !== newChunderURIs.length;
 
     if (!hasChunderURIsChanged) {
       for (const uri of newChunderURIs) {
@@ -974,6 +969,14 @@ class Device extends EventEmitter {
   private _findCall(callSid: string): Call | null {
     return this._calls.find(call => call.parameters.CallSid === callSid
       || call.outboundConnectionId === callSid) || null;
+  }
+
+  /**
+   * Get chunderws array from the chunderw param
+   */
+  private _getChunderws(): string[] | null {
+    return typeof this._options.chunderw === 'string' ? [this._options.chunderw]
+      : Array.isArray(this._options.chunderw) ? this._options.chunderw : null;
   }
 
   /**
@@ -1229,7 +1232,7 @@ class Device extends EventEmitter {
       }
     }
 
-    const preferredURIs = getChunderURIs(this._edge as Edge);
+    const preferredURIs = this._getChunderws() || getChunderURIs(this._edge as Edge);
     if (preferredURIs.length > 0) {
       const [preferredURI] = preferredURIs;
       this._preferredURI = createSignalingEndpointURL(preferredURI);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@twilio/voice-sdk",
-  "version": "2.12.1-dev",
+  "version": "2.12.2-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@twilio/voice-sdk",
-      "version": "2.12.1-dev",
+      "version": "2.12.2-dev",
       "license": "Apache-2.0",
       "dependencies": {
         "@twilio/voice-errors": "1.7.0",

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -806,6 +806,20 @@ describe('Device', function() {
           assert.equal(device['_preferredURI'], ['wss://voice-js.dublin.twilio.com/signal']);
         });
 
+        context('when chunderw is set', () => {
+          it('should use chunderw as the preferred uri if it is a string', () => {
+            device['_options'].chunderw = 'foo';
+            pstream.emit('connected', { region: 'EU_IRELAND', edge: Edge.Dublin });
+            assert.equal(device['_preferredURI'], ['wss://foo/signal']);
+          });
+
+          it('should use the first chunderw as the preferred uri if it is an array', () => {
+            device['_options'].chunderw = ['foo', 'bar'];
+            pstream.emit('connected', { region: 'EU_IRELAND', edge: Edge.Dublin });
+            assert.equal(device['_preferredURI'], ['wss://foo/signal']);
+          });
+        });
+
         it('should set the identity', () => {
           pstream.emit('connected', { token: { identity: 'foobar' } });
           assert.equal(device['_identity'], 'foobar');


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

VBLOCKS-3726

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
