### PR TITLE
Include @types/events in the install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Installation
 We recommend using `npm` to add the Voice SDK as a dependency.
 
 ```
-npm install @twilio/voice-sdk --save
+npm install @twilio/voice-sdk @types/events --save
 ```
 
 Using this method, you can `import` the Voice SDK using ES Module or TypeScript syntax:


### PR DESCRIPTION
I took me sometime to realize that I couldn't listen on the device/call events because my React app didn't recognize the EventEmitter as a type because it's a js node library.

<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-0000](https://issues.corp.twilio.com/browse/CLIENT-0000)

### Description

A description of what this PR does.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
