### PR TITLE
[VBLOCKS-4114] Remove relay server from healthcheck

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,12 +100,19 @@ commands:
           path: coverage
           destination: coverage
   integration-tests:
+    parameters:
+      start_relay_server:
+        type: boolean
+        default: false
     steps:
       - build
-      - run:
-          name: "Start test relay server"
-          background: true
-          command: bash scripts/run-relay-server.sh
+      - when:
+          condition: <<parameters.start_relay_server>>
+          steps:
+            - run:
+                name: "Start test relay server"
+                background: true
+                command: bash scripts/run-relay-server.sh
       - run:
           name: Running integration tests
           command: bash scripts/run-integration-tests.sh
@@ -161,6 +168,9 @@ jobs:
       integration_test_files:
         type: string
         default: ""
+      start_relay_server:
+        type: boolean
+        default: false
     executor:
       name: docker-with-browser
       browser: <<parameters.browser>>
@@ -170,7 +180,9 @@ jobs:
       BVER: <<parameters.bver>>
       BUILD_LABEL: <<parameters.build_label>>
       INTEGRATION_TEST_FILES: <<parameters.integration_test_files>>
-    steps: [integration-tests]
+    steps:
+      - integration-tests:
+          start_relay_server: <<parameters.start_relay_server>>
   run-release:
     parameters:
       dryRun:
@@ -233,6 +245,7 @@ workflows:
           context:
             - dockerhub-pulls
             - vblocks-js
+          start_relay_server: false
           matrix:
             parameters:
               browser: ["chrome"]
@@ -258,6 +271,7 @@ workflows:
           context:
             - dockerhub-pulls
             - vblocks-js
+          start_relay_server: true
           matrix:
             parameters:
               browser: ["chrome", "firefox"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,6 +293,7 @@ workflows:
           context:
             - dockerhub-pulls
             - vblocks-js
+          start_relay_server: true
           matrix:
             parameters:
               browser: ["chrome", "firefox"]
@@ -325,10 +326,11 @@ workflows:
           name: Build Checks
           datadog-test-service: "release-workflow"
       - run-integration-tests:
+          name: Integration tests <<matrix.browser>> <<matrix.bver>>
           context:
             - dockerhub-pulls
             - vblocks-js
-          name: Integration tests <<matrix.browser>> <<matrix.bver>>
+          start_relay_server: true
           matrix:
             parameters:
               browser: ["chrome", "firefox"]


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [VBLOCKS-4114](https://twilio-engineering.atlassian.net/browse/VBLOCKS-4114)

### Description

This PR removes the relay server from the healthcheck workflow.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [x] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
