### PR TITLE
[VBLOCKS-3932] Add preflight stage capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 :warning: **Important**: If you are upgrading to version 2.3.0 or later and have firewall rules or network configuration that blocks any unknown traffic by default, you need to update your configuration to allow connections to the new DNS names and IP addresses. Please refer to this [changelog](#230-january-23-2023) for more details.
 
+2.12.4 (In Progress)
+====================
+
+Changes
+-------
+
+- Added an API for testing `PreflightTest` in realms other than prod. Users can now pass `chunderw` and `eventgw` values within the options object when constructing a `PreflightTest`. Note that these new options are meant for internal testing by Twilio employees only, and should not be used otherwise.
+
 2.12.3 (December 3, 2024)
 =========================
 

--- a/lib/twilio/preflight/preflight.ts
+++ b/lib/twilio/preflight/preflight.ts
@@ -736,7 +736,8 @@ export namespace PreflightTest {
     audioContext?: AudioContext;
 
     /**
-     * A string representing the URI of the signaling gateway to connect to.
+     * A string or array of strings representing the URI of the signaling
+     * gateway to connect to.
      * @private
      */
     chunderw?: string | string[];

--- a/lib/twilio/preflight/preflight.ts
+++ b/lib/twilio/preflight/preflight.ts
@@ -386,8 +386,10 @@ export class PreflightTest extends EventEmitter {
   private _initDevice(token: string, options: PreflightTest.ExtendedOptions): void {
     try {
       this._device = new (options.deviceFactory || Device)(token, {
+        chunderw: options.chunderw,
         codecPreferences: options.codecPreferences,
         edge: options.edge,
+        eventgw: options.eventgw,
         fileInputStream: options.fileInputStream,
         logLevel: options.logLevel,
         preflight: true,
@@ -734,9 +736,21 @@ export namespace PreflightTest {
     audioContext?: AudioContext;
 
     /**
+     * A string representing the URI of the signaling gateway to connect to.
+     * @private
+     */
+    chunderw?: string | string[];
+
+    /**
      * Device class to use.
      */
     deviceFactory?: typeof Device;
+
+    /**
+     * A string representing the URI of the insights gateway to connect to.
+     * @private
+     */
+    eventgw?: string;
 
     /**
      * File input stream to use instead of reading from mic

--- a/tests/unit/preflight.ts
+++ b/tests/unit/preflight.ts
@@ -138,8 +138,10 @@ describe('PreflightTest', () => {
     it('should pass defaults to device', () => {
       const preflight = new PreflightTest('foo', options);
       sinon.assert.calledOnceWithExactly(deviceContext.updateOptions, {
+        chunderw: undefined,
         codecPreferences: [Call.Codec.PCMU, Call.Codec.Opus],
         edge: 'roaming',
+        eventgw: undefined,
         fileInputStream: undefined,
         logLevel: 'error',
         preflight: true,
@@ -150,8 +152,10 @@ describe('PreflightTest', () => {
       options.codecPreferences = [Call.Codec.PCMU];
       const preflight = new PreflightTest('foo', options);
       sinon.assert.calledOnceWithExactly(deviceContext.updateOptions, {
+        chunderw: undefined,
         codecPreferences: options.codecPreferences,
         edge: 'roaming',
+        eventgw: undefined,
         fileInputStream: undefined,
         logLevel: 'error',
         preflight: true,
@@ -162,8 +166,10 @@ describe('PreflightTest', () => {
       options.logLevel = 'debug';
       const preflight = new PreflightTest('foo', options);
       sinon.assert.calledOnceWithExactly(deviceContext.updateOptions, {
+        chunderw: undefined,
         codecPreferences: [Call.Codec.PCMU, Call.Codec.Opus],
         edge: 'roaming',
+        eventgw: undefined,
         fileInputStream: undefined,
         logLevel: options.logLevel,
         preflight: true,
@@ -174,8 +180,10 @@ describe('PreflightTest', () => {
       options.edge = 'ashburn';
       const preflight = new PreflightTest('foo', options);
       sinon.assert.calledOnceWithExactly(deviceContext.updateOptions, {
+        chunderw: undefined,
         codecPreferences: [Call.Codec.PCMU, Call.Codec.Opus],
         edge: options.edge,
+        eventgw: undefined,
         fileInputStream: undefined,
         logLevel: 'error',
         preflight: true,
@@ -187,8 +195,38 @@ describe('PreflightTest', () => {
       options.rtcConfiguration = {foo: 'foo', iceServers: 'bar'};
       const preflight = new PreflightTest('foo', options);
       sinon.assert.calledWith(deviceContext.updateOptions, {
+        chunderw: undefined,
         codecPreferences: [Call.Codec.PCMU, Call.Codec.Opus],
         edge: 'roaming',
+        eventgw: undefined,
+        fileInputStream: undefined,
+        logLevel: 'error',
+        preflight: true,
+      });
+    });
+
+    it('should pass chunderw to device', () => {
+      options.chunderw = 'foobar';
+      new PreflightTest('token', options);
+      sinon.assert.calledWith(deviceContext.updateOptions, {
+        chunderw: 'foobar',
+        codecPreferences: [Call.Codec.PCMU, Call.Codec.Opus],
+        edge: 'roaming',
+        eventgw: undefined,
+        fileInputStream: undefined,
+        logLevel: 'error',
+        preflight: true,
+      });
+    });
+
+    it('should pass eventgw to device', () => {
+      options.eventgw = 'foobar';
+      new PreflightTest('token', options);
+      sinon.assert.calledWith(deviceContext.updateOptions, {
+        chunderw: undefined,
+        codecPreferences: [Call.Codec.PCMU, Call.Codec.Opus],
+        edge: 'roaming',
+        eventgw: 'foobar',
         fileInputStream: undefined,
         logLevel: 'error',
         preflight: true,
@@ -232,8 +270,10 @@ describe('PreflightTest', () => {
     it('should set fakeMicInput to false by default', () => {
       preflight = new PreflightTest('foo', options);
       sinon.assert.calledOnceWithExactly(deviceContext.updateOptions, {
+        chunderw: undefined,
         codecPreferences: [Call.Codec.PCMU, Call.Codec.Opus],
         edge: 'roaming',
+        eventgw: undefined,
         fileInputStream: undefined,
         logLevel: 'error',
         preflight: true,
@@ -245,8 +285,10 @@ describe('PreflightTest', () => {
       preflight = new PreflightTest('foo', {...options, fakeMicInput: true });
       await clock.tickAsync(1000);
       sinon.assert.calledOnceWithExactly(deviceContext.updateOptions, {
+        chunderw: undefined,
         codecPreferences: [Call.Codec.PCMU, Call.Codec.Opus],
         edge: 'roaming',
+        eventgw: undefined,
         fileInputStream: stream,
         logLevel: 'error',
         preflight: true,


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [VBLOCKS-3932](https://twilio-engineering.atlassian.net/browse/VBLOCKS-3932)

### Description

This PR adds the ability to pass a `chunderw` and `eventgw` to the internal `Twilio.Device` used in the `PreflightTest`. This API is not meant for public use, only for internal testing by Twilio employees.

This feature was tested locally using stage `chunderw` URI and a stage token.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [x] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
