### PR TITLE
[VBLOCKS-3973] chrome extension destroy issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 2.12.4 (In Progress)
 ====================
 
+Bug Fixes
+---------
+
+- Fixed an [issue](https://github.com/twilio/twilio-voice.js/issues/309) where `device.destroy()` does not work for Chrome Extension V3.
+
 Changes
 -------
 

--- a/lib/twilio/audiohelper.ts
+++ b/lib/twilio/audiohelper.ts
@@ -424,11 +424,7 @@ class AudioHelper extends EventEmitter {
    * @private
    */
   _unbind(): void {
-    if (!this._mediaDevices || !this._enumerateDevices) {
-      throw new NotSupportedError('Enumeration is not supported');
-    }
-
-    if (this._mediaDevices.removeEventListener) {
+    if (this._mediaDevices?.removeEventListener) {
       this._mediaDevices.removeEventListener('devicechange', this._updateAvailableDevices);
     }
   }

--- a/tests/audiohelper.js
+++ b/tests/audiohelper.js
@@ -212,6 +212,22 @@ describe('AudioHelper', () => {
         sinon.assert.calledOnce(audio._maybeStopPollingVolume);
         sinon.assert.calledOnce(mediaDevices.removeEventListener);
       });
+
+      it('should allow enumerateDevices and mediaDevices to be undefined', () => {
+        navigator.enumerateDevices = undefined;
+        navigator.mediaDevices = undefined;
+        audio = new AudioHelper(onActiveOutputsChanged, onActiveInputChanged);
+        audio._stopDefaultInputDeviceStream = sinon.stub();
+        audio._stopSelectedInputDeviceStream = sinon.stub();
+        audio._destroyProcessedStream = sinon.stub();
+        audio._maybeStopPollingVolume = sinon.stub();
+        audio._destroy();
+        assert.strictEqual(audio.eventNames().length, 0);
+        sinon.assert.calledOnce(audio._stopDefaultInputDeviceStream);
+        sinon.assert.calledOnce(audio._stopSelectedInputDeviceStream);
+        sinon.assert.calledOnce(audio._destroyProcessedStream);
+        sinon.assert.calledOnce(audio._maybeStopPollingVolume);
+      });
     });
 
     describe('._updateUserOptions', () => {

--- a/tests/extension/app/popup/popup.html
+++ b/tests/extension/app/popup/popup.html
@@ -13,6 +13,7 @@
     <button id="accept">Accept</button>
     <button id="reject">Reject</button>
     <p id="test-incoming"></p>
+    <button id="destroy">Destroy</button>
   </div>
   <pre id="log"></pre>
   <script src="popup.js"></script>

--- a/tests/extension/app/popup/popup.js
+++ b/tests/extension/app/popup/popup.js
@@ -15,6 +15,7 @@ function start() {
   hangupBtn = document.querySelector('#hangup');
   acceptBtn = document.querySelector('#accept');
   rejectBtn = document.querySelector('#reject');
+  destroyBtn = document.querySelector('#destroy');
   incomingCallTestEl = document.querySelector('#test-incoming')
 
   setupButtonHandlers();
@@ -44,7 +45,7 @@ function setStatus(status) {
   if (status === 'pending') {
     showButtons('init');
   } else if (status === 'idle') {
-    showButtons('call');
+    showButtons('call', 'destroy');
   } else if (status === 'incoming') {
   /**
     * NOTE(kchoy): To verify an incoming call has occured, for 
@@ -54,6 +55,8 @@ function setStatus(status) {
     showButtons('accept', 'reject');
   } else if (status === 'inprogress') {
     showButtons('hangup');
+  } else if (status === 'destroyed') {
+    showButtons('init'); 
   }
   recepientEl.style.display = status === 'idle' ? 'block' : 'none';
   statusEl.innerHTML = `Status: ${status}`;
@@ -65,6 +68,7 @@ function setupButtonHandlers() {
   hangupBtn.onclick = () => chrome.runtime.sendMessage({ type: 'hangup' });
   acceptBtn.onclick = () => chrome.runtime.sendMessage({ type: 'accept' });
   rejectBtn.onclick = () => chrome.runtime.sendMessage({ type: 'reject' });
+  destroyBtn.onclick = () => chrome.runtime.sendMessage({ type: 'destroy'});
 }
 
 function showButtons(...buttonsToShow) {

--- a/tests/extension/app/worker.js
+++ b/tests/extension/app/worker.js
@@ -1,5 +1,6 @@
 import './twilio.js';
 
+let device;
 let incomingCall = null;
 
 const offscreenPath = 'offscreen/offscreen.html';
@@ -34,6 +35,9 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     chrome.runtime.sendMessage({ type: 'connect-incoming' });
   } else if (request.type === 'getstate' && sender.url.includes('popup')) {
     sendResponse(sessionState);
+  } else if (request.type === 'destroy' && sender.url.includes('popup')) {
+    device.destroy();
+    setState({ status: 'destroyed'});
   } else if (request.type === 'accept' && sender.url.includes('offscreen')) {
     setState({ status: 'inprogress' });
     incomingCall = null;
@@ -53,7 +57,7 @@ async function init() {
     'http://127.0.0.1:3030/token?identity=' + device1ClientIdentity
   );
   const data = await response.json();
-  const device = new Twilio.Device(data.token, { logLevel: 1 });
+  device = new Twilio.Device(data.token, { logLevel: 1 });
   await device.register();
   /**
    * NOTE(kchoy): This is the first device created in this extension. device1ClientIdentity

--- a/tests/extension/tests/index.js
+++ b/tests/extension/tests/index.js
@@ -92,4 +92,19 @@ describe('Chrome extension tests', function () {
     const expectedIncomingText = 'Incoming call has occured';
     assert.equal(testIncomingText, expectedIncomingText);
   });
+
+  it('should allow device to be destroyed', async () => {
+    const initButton = await page.waitForSelector('#init', { visible: true });
+    await initButton.click();
+    const destroyButton = await page.$('#destroy');
+    await destroyButton.click();
+    await page.waitForSelector('#init', { visible: true });
+    const status = await page.waitForSelector('#status');
+    const statusText = await page.evaluate(
+      (element) => element.innerText.trim(),
+      status
+    );
+    const expectedStatusText = 'Status: destroyed';
+    assert.equal(statusText, expectedStatusText);
+  });
 });


### PR DESCRIPTION
**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

https://twilio-engineering.atlassian.net/browse/VBLOCKS-3973

### Description

- Issue: https://github.com/twilio/twilio-voice.js/issues/309
- Allow `device.destroy` in chrome extension
- remove enumeration check for `unbind`
- add unit test
- add puppeteer e2e test

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
