### PR TITLE
[VBLOCKS-4107] Fix null publisher on destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Changes
 
 - Added an API for testing `PreflightTest` in realms other than prod. Users can now pass `chunderw` and `eventgw` values within the options object when constructing a `PreflightTest`. Note that these new options are meant for internal testing by Twilio employees only, and should not be used otherwise.
 
+Bug Fixes
+---------
+
+- Addressed an issue where the `publisher` would be `null` upon destruction of an `AudioProcessorObserver`.
+
 2.12.3 (December 3, 2024)
 =========================
 

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -646,9 +646,9 @@ class Device extends EventEmitter {
     this._stopRegistrationTimer();
 
     this._destroyStream();
-    this._destroyPublisher();
     this._destroyAudioHelper();
     this._audioProcessorEventObserver?.destroy();
+    this._destroyPublisher();
 
     if (this._networkInformation && typeof this._networkInformation.removeEventListener === 'function') {
       this._networkInformation.removeEventListener('change', this._publishNetworkChange);

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -475,6 +475,15 @@ describe('Device', function() {
           sinon.assert.calledOnce(stub);
         });
 
+        it('should destroy the publisher after the audioProcessorEventObserver', () => {
+          const observerStub =
+            (device['_audioProcessorEventObserver']!.destroy = sinon.stub());
+          const publisherStub =
+            (device['_destroyPublisher'] = sinon.stub());
+          device.destroy();
+          assert(observerStub.calledBefore(publisherStub));
+        });
+
         it('should stop sending registrations', () => {
           pstream.register.resetHistory();
 


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [VBLOCKS-4107](https://twilio-engineering.atlassian.net/browse/VBLOCKS-4107)

### Description

This PR addresses an issue where the publisher is null upon device destruction.

Detailed explanation:
- When `device.destroy` is invoked, the signaling stream is destroyed first.
- This causes all the mediahandlers to close, issuing `PeerConnection._stopStream`
- In `_stopStream`, the default audio input stream is closed.
- However, in cases where audio processors are used, specifically if they are added after a call is started, the code path for a _selected_ audio input stream is used.
- `_stopStream` does _not_ handle selected audio input stream destruction.
- Further, `_stopSelectedAudioInputStream` does not destroy the processed stream where `_stopDefaultAudioInputStream` _does_.
- This means that when the default audio input stream is in use, users will not see the null publisher error since the observer is destroyed via side effects.
- When a selected audio input stream is used, users may see the error since the destruction is left up to the `device.destroy` method, which destroys the publisher before destroying the `audioProcessorObserver`.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [x] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [x] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
