### PR TITLE
fix: add package-lock.json to development

### DIFF
--- a/.release.json
+++ b/.release.json
@@ -45,6 +45,7 @@
         "npm run clean",
         "npm run docs:clean",
         "git add package.json",
+        "git add package-lock.json",
         "git commit -nm \"${DEVELOPMENT_VERSION}\"",
         "git push origin ${BRANCH}"
       ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@twilio/voice-sdk",
-  "version": "2.12.4-rc1",
+  "version": "2.12.4-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@twilio/voice-sdk",
-      "version": "2.12.4-rc1",
+      "version": "2.12.4-dev",
       "license": "Apache-2.0",
       "dependencies": {
         "@twilio/voice-errors": "1.7.0",


### PR DESCRIPTION
**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

### Description

Fix release `development`, by adding `package-lock.json` to release plan

Only `package.json` was added back to `2.12.4-dev`, but `package-lock.json` still `2.12.4-rc1`

https://github.com/twilio/twilio-voice.js/commit/5d05caa5c57ca734056ec15fb0b2b9be8568567b#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R3


## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
