### PR TITLE
[VBLOCKS-4478] fix: citrix mediastream error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,10 @@
 2.12.5 (WIP)
 ============
 
-Bug Fixes
----------
-- Fixed a Citrix issue where calling `device.audio.setInputDevice()`, results in a `MediaStreamError`.
-  - User must add `createMediaStream` to their `Device.Options`.
-  - [Device.Options.createMediaStream](https://twilio.github.io/twilio-voice.js/interfaces/voice.device.options.html#createMediaStream)
+New Features
+------------
+
+In version `2.5.0`, the SDK introduced a mechanism to override WebRTC APIs, enabling support for redirection technologies like [Citrix HDX](https://www.citrix.com/solutions/vdi-and-daas/hdx/what-is-hdx.html). In this release, the SDK extends this capability by allowing the override of the native [MediaStream](https://developer.mozilla.org/en-US/docs/Web/API/MediaStream) API, making it possible to create custom media streams tailored for such environments. Please check this [page](https://www.twilio.com/docs/voice/sdks/javascript/best-practices#webrtc-api-overrides) for an example.
 
 2.12.4 (March 12, 2025)
 =======================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 :warning: **Important**: If you are upgrading to version 2.3.0 or later and have firewall rules or network configuration that blocks any unknown traffic by default, you need to update your configuration to allow connections to the new DNS names and IP addresses. Please refer to this [changelog](#230-january-23-2023) for more details.
 
-2.12.5 (WIP)
+2.13.0 (In Progress)
 ============
 
 New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 :warning: **Important**: If you are upgrading to version 2.3.0 or later and have firewall rules or network configuration that blocks any unknown traffic by default, you need to update your configuration to allow connections to the new DNS names and IP addresses. Please refer to this [changelog](#230-january-23-2023) for more details.
 
+2.12.5 (WIP)
+============
+
+Bug Fixes
+---------
+- Fixed a Citrix issue where calling `device.audio.setInputDevice()`, results in a `MediaStreamError`.
+  - User must add `createMediaStream` to their `Device.Options`.
+  - [Device.Options.createMediaStream](https://twilio.github.io/twilio-voice.js/interfaces/voice.device.options.html#createMediaStream)
+
 2.12.4 (March 12, 2025)
 =======================
 

--- a/lib/twilio/call.ts
+++ b/lib/twilio/call.ts
@@ -279,6 +279,7 @@ class Call extends EventEmitter {
    */
   private _options: Call.Options = {
     MediaHandler: PeerConnection,
+    createMediaStream: null,
     enableImprovedSignalingErrorPrecision: false,
     offerSdp: null,
     shouldPlayDisconnect: () => true,
@@ -417,6 +418,7 @@ class Call extends EventEmitter {
       (config.audioHelper, config.pstream, {
         RTCPeerConnection: this._options.RTCPeerConnection,
         codecPreferences: this._options.codecPreferences,
+        createMediaStream: this._options.createMediaStream,
         dscp: this._options.dscp,
         forceAggressiveIceNomination: this._options.forceAggressiveIceNomination,
         isUnifiedPlan: this._isUnifiedPlanDefault,
@@ -1945,6 +1947,11 @@ namespace Call {
      * An ordered array of codec names, from most to least preferred.
      */
     codecPreferences?: Codec[];
+
+    /**
+     * Citrix method to create a RemoteStream object.
+     */
+    createMediaStream?: any;
 
     /**
      * A mapping of custom sound URLs by sound name.

--- a/lib/twilio/call.ts
+++ b/lib/twilio/call.ts
@@ -279,7 +279,7 @@ class Call extends EventEmitter {
    */
   private _options: Call.Options = {
     MediaHandler: PeerConnection,
-    createMediaStream: null,
+    MediaStream: null,
     enableImprovedSignalingErrorPrecision: false,
     offerSdp: null,
     shouldPlayDisconnect: () => true,
@@ -416,9 +416,9 @@ class Call extends EventEmitter {
 
     this._mediaHandler = new (this._options.MediaHandler)
       (config.audioHelper, config.pstream, {
+        MediaStream: this._options.MediaStream,
         RTCPeerConnection: this._options.RTCPeerConnection,
         codecPreferences: this._options.codecPreferences,
-        createMediaStream: this._options.createMediaStream,
         dscp: this._options.dscp,
         forceAggressiveIceNomination: this._options.forceAggressiveIceNomination,
         isUnifiedPlan: this._isUnifiedPlanDefault,
@@ -1949,11 +1949,6 @@ namespace Call {
     codecPreferences?: Codec[];
 
     /**
-     * Citrix method to create a RemoteStream object.
-     */
-    createMediaStream?: any;
-
-    /**
      * A mapping of custom sound URLs by sound name.
      */
     customSounds?: Partial<Record<Device.SoundName, string>>;
@@ -2005,6 +2000,11 @@ namespace Call {
      * Custom MediaHandler (PeerConnection) constructor.
      */
     MediaHandler?: IPeerConnection;
+
+    /**
+     * Overrides the native MediaStream class.
+     */
+    MediaStream?: any;
 
     /**
      * The offer SDP, if this is an incoming call.

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -110,11 +110,6 @@ export interface IExtendedDeviceOptions extends Device.Options {
   ignoreBrowserSupport?: boolean;
 
   /**
-   * MediaStream constructor.
-   */
-  MediaStream?: typeof MediaStream;
-
-  /**
    * Whether this is a preflight call or not
    */
   preflight?: boolean;
@@ -1055,7 +1050,7 @@ class Device extends EventEmitter {
     };
 
     options = Object.assign({
-      MediaStream: this._options.MediaStream || rtc.PeerConnection,
+      MediaStream: this._options.MediaStream,
       RTCPeerConnection: this._options.RTCPeerConnection,
       beforeAccept: (currentCall: Call) => {
         if (!this._activeCall || this._activeCall === currentCall) {

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -590,6 +590,7 @@ class Device extends EventEmitter {
     let isReconnect = false;
     let twimlParams: Record<string, string> = {};
     const callOptions: Call.Options = {
+      createMediaStream: this._options.createMediaStream,
       enableImprovedSignalingErrorPrecision:
       !!this._options.enableImprovedSignalingErrorPrecision,
       rtcConfiguration: options.rtcConfiguration,
@@ -1006,6 +1007,7 @@ class Device extends EventEmitter {
     ];
     const userOptionOverrides = [
       'RTCPeerConnection',
+      'createMediaStream',
       'enumerateDevices',
       'getUserMedia',
     ];
@@ -1093,6 +1095,7 @@ class Device extends EventEmitter {
 
     this._publisher.info('settings', 'init', {
       RTCPeerConnection: !!this._options.RTCPeerConnection,
+      createMediaStream: !!this._options.createMediaStream,
       enumerateDevices: !!this._options.enumerateDevices,
       getUserMedia: !!this._options.getUserMedia,
     }, call);
@@ -1326,6 +1329,7 @@ class Device extends EventEmitter {
       customParameters,
       {
         callParameters,
+        createMediaStream: this._options.createMediaStream,
         enableImprovedSignalingErrorPrecision:
           !!this._options.enableImprovedSignalingErrorPrecision,
         offerSdp: payload.sdp,
@@ -1898,6 +1902,11 @@ namespace Device {
      * An ordered array of codec names, from most to least preferred.
      */
     codecPreferences?: Call.Codec[];
+
+    /**
+     * Citrix method to create a RemoteStream object.
+     */
+    createMediaStream?: any;
 
     /**
      * Whether AudioContext sounds should be disabled. Useful for trouble shooting sound issues

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -585,7 +585,6 @@ class Device extends EventEmitter {
     let isReconnect = false;
     let twimlParams: Record<string, string> = {};
     const callOptions: Call.Options = {
-      MediaStream: this._options.MediaStream,
       enableImprovedSignalingErrorPrecision:
       !!this._options.enableImprovedSignalingErrorPrecision,
       rtcConfiguration: options.rtcConfiguration,
@@ -1323,7 +1322,6 @@ class Device extends EventEmitter {
     this._makeCallPromise = this._makeCall(
       customParameters,
       {
-        MediaStream: this._options.MediaStream,
         callParameters,
         enableImprovedSignalingErrorPrecision:
           !!this._options.enableImprovedSignalingErrorPrecision,

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -590,7 +590,7 @@ class Device extends EventEmitter {
     let isReconnect = false;
     let twimlParams: Record<string, string> = {};
     const callOptions: Call.Options = {
-      createMediaStream: this._options.createMediaStream,
+      MediaStream: this._options.MediaStream,
       enableImprovedSignalingErrorPrecision:
       !!this._options.enableImprovedSignalingErrorPrecision,
       rtcConfiguration: options.rtcConfiguration,
@@ -1007,9 +1007,9 @@ class Device extends EventEmitter {
     ];
     const userOptionOverrides = [
       'RTCPeerConnection',
-      'createMediaStream',
       'enumerateDevices',
       'getUserMedia',
+      'MediaStream',
     ];
     if (typeof options === 'object') {
       const toLog: any = { ...options };
@@ -1094,8 +1094,8 @@ class Device extends EventEmitter {
     const call = new (this._options.Call || Call)(config, options);
 
     this._publisher.info('settings', 'init', {
+      MediaStream: !!this._options.MediaStream,
       RTCPeerConnection: !!this._options.RTCPeerConnection,
-      createMediaStream: !!this._options.createMediaStream,
       enumerateDevices: !!this._options.enumerateDevices,
       getUserMedia: !!this._options.getUserMedia,
     }, call);
@@ -1328,8 +1328,8 @@ class Device extends EventEmitter {
     this._makeCallPromise = this._makeCall(
       customParameters,
       {
+        MediaStream: this._options.MediaStream,
         callParameters,
-        createMediaStream: this._options.createMediaStream,
         enableImprovedSignalingErrorPrecision:
           !!this._options.enableImprovedSignalingErrorPrecision,
         offerSdp: payload.sdp,
@@ -1904,11 +1904,6 @@ namespace Device {
     codecPreferences?: Call.Codec[];
 
     /**
-     * Citrix method to create a RemoteStream object.
-     */
-    createMediaStream?: any;
-
-    /**
      * Whether AudioContext sounds should be disabled. Useful for trouble shooting sound issues
      * that may be caused by AudioContext-specific sounds. If set to true, will fall back to
      * HTMLAudioElement sounds.
@@ -2053,6 +2048,11 @@ namespace Device {
      * contains webhooks that relies on [call status callbacks](https://www.twilio.com/docs/voice/twiml#callstatus-values).
      */
     maxCallSignalingTimeoutMs?: number;
+
+    /**
+     * Overrides the native MediaStream class.
+     */
+    MediaStream?: any;
 
     /**
      * Overrides the native RTCPeerConnection class.

--- a/lib/twilio/rtc/peerconnection.ts
+++ b/lib/twilio/rtc/peerconnection.ts
@@ -355,7 +355,7 @@ PeerConnection.prototype._setInputTracksForUnifiedPlan = function(shouldClone, n
   if (!localStream) {
     // We can't use MediaStream.clone() here because it stopped copying over tracks
     //   as of Chrome 61. https://bugs.chromium.org/p/chromium/issues/detail?id=770908
-    this.stream = shouldClone ? cloneStream(newStream, this.options.createMediaStream) : newStream;
+    this.stream = shouldClone ? cloneStream(newStream, this.options.MediaStream) : newStream;
   } else {
     // If the call was started with gUM, and we are now replacing that track with an
     // external stream's tracks, we should stop the old managed track.
@@ -369,7 +369,7 @@ PeerConnection.prototype._setInputTracksForUnifiedPlan = function(shouldClone, n
 
     return this._sender.replaceTrack(newStream.getAudioTracks()[0]).then(() => {
       this._updateInputStreamSource(newStream);
-      this.stream = shouldClone ? cloneStream(newStream, this.options.createMediaStream) : newStream;
+      this.stream = shouldClone ? cloneStream(newStream, this.options.MediaStream) : newStream;
       return getStreamPromise();
     });
   }
@@ -1122,10 +1122,10 @@ function addStream(pc, stream) {
   }
 }
 
-function cloneStream(oldStream, createMediaStream) {
+function cloneStream(oldStream, _MediaStream) {
   let newStream;
-  if (createMediaStream) {
-    newStream = createMediaStream();
+  if (_MediaStream) {
+    newStream = new _MediaStream();
   } else if (typeof MediaStream !== 'undefined') {
     newStream = new MediaStream();
   } else {

--- a/tests/peerconnection.js
+++ b/tests/peerconnection.js
@@ -281,7 +281,7 @@ describe('PeerConnection', () => {
         assert(mediaStream.calledOnce);
         assert(context._updateInputStreamSource.calledOnce);
       }).then(done).catch(done);
-    })
+    });
 
     it('Should call this.options.MediaStream if provided, and stream NOT provided', done => {
       const mediaStream = sinon.stub().returns({
@@ -298,10 +298,9 @@ describe('PeerConnection', () => {
       toTest(true, NEW_STREAM).then(() => {
         assert(mediaStream.calledOnce);
       }).then(done).catch(done);
-    })
+    });
   });
 
-  
   context('PeerConnection.prototype.close', () => {
     const METHOD = PeerConnection.prototype.close;
 

--- a/tests/peerconnection.js
+++ b/tests/peerconnection.js
@@ -255,8 +255,53 @@ describe('PeerConnection', () => {
         assert.strictEqual(result.id, NEW_STREAM.id);
       }).then(done).catch(done);
     });
+    
+    it('Should call this.options.MediaStream if provided, and stream provided', done => {
+      const mediaStream = sinon.stub().returns({
+        addTrack: sinon.stub()
+      });
+      context = {
+        stream: STREAM,
+        mute: sinon.stub(),
+        _sender: {},
+        options: {
+          MediaStream: mediaStream,
+        },
+      };
+      toTest = METHOD.bind(context);
+      
+      const replaceTrackCb = sinon.stub();
+      context._updateInputStreamSource = sinon.stub();
+      context._sender.replaceTrack = () => ({ then: (cb) => {
+        replaceTrackCb();
+        return cb();
+      }})
+      
+      toTest(true, NEW_STREAM).then(() => {
+        assert(mediaStream.calledOnce);
+        assert(context._updateInputStreamSource.calledOnce);
+      }).then(done).catch(done);
+    })
+
+    it('Should call this.options.MediaStream if provided, and stream NOT provided', done => {
+      const mediaStream = sinon.stub().returns({
+        addTrack: sinon.stub()
+      });
+      context = {
+        mute: sinon.stub(),
+        options: {
+          MediaStream: mediaStream,
+        },
+      };
+      toTest = METHOD.bind(context);
+      
+      toTest(true, NEW_STREAM).then(() => {
+        assert(mediaStream.calledOnce);
+      }).then(done).catch(done);
+    })
   });
 
+  
   context('PeerConnection.prototype.close', () => {
     const METHOD = PeerConnection.prototype.close;
 

--- a/tests/unit/call.ts
+++ b/tests/unit/call.ts
@@ -107,6 +107,15 @@ describe('Call', function() {
       assert.equal(conn.customParameters.get('baz'), 123);
     });
 
+    it('should set MediaStream to null by default', () => {
+      assert.equal(conn['_options'].MediaStream, null);
+    });
+
+    it('should set MediaStream to "foo" if passed in as "foo"', () => {
+      conn = new Call(config, Object.assign(options, { MediaStream: 'foo' }));
+      assert.equal(conn['_options'].MediaStream, 'foo');
+    });
+
     context('connectToken', () => {
       it('should return undefined if callsid is missing', () => {
         conn = new Call(config, Object.assign(options, { reconnectToken: 'testReconnectToken' }));

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -152,6 +152,15 @@ describe('Device', function() {
     it('should throw if the token is an invalid type', () => {
       assert.throws(() => new Device(null as any), /Parameter "token" must be of type "string"./);
     });
+
+    it('should set MediaStream to undefined by default', () => {
+      assert.equal(device['_options'].MediaStream, undefined);
+    });
+
+    it('should set MediaStream to "foo" if passed in as "foo"', () => {
+      device = new Device(token, { ...setupOptions, MediaStream: 'foo' });
+      assert.equal(device['_options'].MediaStream, 'foo');
+    })
   });
 
   describe('after Device is constructed', () => {

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -160,7 +160,7 @@ describe('Device', function() {
     it('should set MediaStream to "foo" if passed in as "foo"', () => {
       device = new Device(token, { ...setupOptions, MediaStream: 'foo' });
       assert.equal(device['_options'].MediaStream, 'foo');
-    })
+    });
   });
 
   describe('after Device is constructed', () => {


### PR DESCRIPTION
**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

https://twilio-engineering.atlassian.net/browse/VBLOCKS-4478

### Description

- Fix Citrix MediaStream Error
- Added: [Device.Options.createMediaStream](https://twilio.github.io/twilio-voice.js/interfaces/voice.device.options.html#createMediaStream)

### Manual Citrix Test Cases
- `setInputDevice()` -> outgoing call
- `setInputDevice()` -> incoming call

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
