### PR TITLE
[VBLOCKS-4564] Typescript 5.x: fix docstrings and exports

### DIFF
--- a/lib/twilio.ts
+++ b/lib/twilio.ts
@@ -5,8 +5,27 @@
 import AudioProcessor from './twilio/audioprocessor';
 import Call from './twilio/call';
 import Device from './twilio/device';
-import * as TwilioError from './twilio/errors';
 import { Logger } from './twilio/log';
+
 import { PreflightTest } from './twilio/preflight/preflight';
+import type { NetworkTiming, TimeMeasurement } from './twilio/preflight/timing';
+
+/**
+ * VBLOCKS-4589: Consider refactoring this export.
+ */
+import * as TwilioError from './twilio/errors';
+
+import type AudioHelper from './twilio/audiohelper';
+
+import type OutputDeviceCollection from './twilio/outputdevicecollection';
+
+import type { Edge } from './twilio/regions';
+
+import RTCSample from './twilio/rtc/sample';
+import { RTCSampleTotals } from './twilio/rtc/sample';
+
+import RTCWarning from './twilio/rtc/warning';
+import { ThresholdWarningData } from './twilio/rtc/warning';
 
 export { AudioProcessor, Call, Device, PreflightTest, Logger, TwilioError };
+export type { AudioHelper, Edge, OutputDeviceCollection, NetworkTiming, RTCSample, RTCSampleTotals, RTCWarning, TimeMeasurement, ThresholdWarningData };

--- a/lib/twilio/audiohelper.ts
+++ b/lib/twilio/audiohelper.ts
@@ -14,7 +14,6 @@ import { average, difference, isFirefox } from './util';
 
 /**
  * Aliases for audio kinds, used for labelling.
- * @private
  */
 const kindAliases: Record<string, string> = {
   audioinput: 'Audio Input',
@@ -23,7 +22,6 @@ const kindAliases: Record<string, string> = {
 
 /**
  * Provides input and output audio-based functionality in one convenient class.
- * @publicapi
  */
 class AudioHelper extends EventEmitter {
   /**
@@ -211,8 +209,7 @@ class AudioHelper extends EventEmitter {
   };
 
   /**
-   * @constructor
-   * @private
+   * @internal
    * @param onActiveOutputsChanged - A callback to be called when the user changes the active output devices.
    * @param onActiveInputChanged - A callback to be called when the user changes the active input device.
    * @param [options]
@@ -315,7 +312,7 @@ class AudioHelper extends EventEmitter {
 
   /**
    * Destroy this AudioHelper instance
-   * @private
+   * @internal
    */
   _destroy(): void {
     this._stopDefaultInputDeviceStream();
@@ -329,7 +326,7 @@ class AudioHelper extends EventEmitter {
 
   /**
    * Promise to wait for the input device, if setInputDevice is called outside of the SDK
-   * @private
+   * @internal
    */
   _getInputDevicePromise(): Promise<void> | null {
     return this._inputDevicePromise;
@@ -337,7 +334,7 @@ class AudioHelper extends EventEmitter {
 
   /**
    * Start polling volume if it's supported and there's an input stream to poll.
-   * @private
+   * @internal
    */
   _maybeStartPollingVolume(): void {
     if (!this.isVolumeSupported || !this.inputStream) { return; }
@@ -369,7 +366,7 @@ class AudioHelper extends EventEmitter {
 
   /**
    * Stop polling volume if it's currently polling and there are no listeners.
-   * @private
+   * @internal
    */
   _maybeStopPollingVolume(): void {
     if (!this.isVolumeSupported) { return; }
@@ -388,7 +385,7 @@ class AudioHelper extends EventEmitter {
 
   /**
    * Call getUserMedia with specified constraints
-   * @private
+   * @internal
    */
   _openDefaultDeviceWithConstraints(constraints: MediaStreamConstraints): Promise<MediaStream> {
     this._log.info('Opening default device with constraints', constraints);
@@ -408,7 +405,7 @@ class AudioHelper extends EventEmitter {
 
   /**
    * Stop the default audio stream
-   * @private
+   * @internal
    */
   _stopDefaultInputDeviceStream(): void {
     if (this._defaultInputDeviceStream) {
@@ -421,7 +418,7 @@ class AudioHelper extends EventEmitter {
 
   /**
    * Unbind the listeners from mediaDevices.
-   * @private
+   * @internal
    */
   _unbind(): void {
     if (this._mediaDevices?.removeEventListener) {
@@ -431,7 +428,7 @@ class AudioHelper extends EventEmitter {
 
   /**
    * Update the available input and output devices
-   * @private
+   * @internal
    */
   _updateAvailableDevices = (): Promise<void> => {
     if (!this._mediaDevices || !this._enumerateDevices) {
@@ -463,7 +460,7 @@ class AudioHelper extends EventEmitter {
 
   /**
    * Update AudioHelper options that can be changed by the user
-   * @private
+   * @internal
    */
   _updateUserOptions(options: AudioHelper.Options): void {
     if (typeof options.enumerateDevices === 'function') {
@@ -967,30 +964,39 @@ class AudioHelper extends EventEmitter {
   }
 }
 
+/**
+ * @mergeModuleWith AudioHelper
+ */
 namespace AudioHelper {
   /**
    * Emitted when the available set of Devices changes.
+   * @event
    * @param lostActiveDevices - An array containing any Devices that were previously active
    * that were lost as a result of this deviceChange event.
-   * @example `device.audio.on('deviceChange', lostActiveDevices => { })`
-   * @event
+   * @example
+   * ```ts
+   * device.audio.on('deviceChange', lostActiveDevices => { });
+   * ```
    */
-  declare function deviceChangeEvent(lostActiveDevices: MediaDeviceInfo[]): void;
+  export declare function deviceChangeEvent(lostActiveDevices: MediaDeviceInfo[]): void;
 
   /**
    * Emitted on `requestAnimationFrame` (up to 60fps, depending on browser) with
    *   the current input and output volumes, as a percentage of maximum
    *   volume, between -100dB and -30dB. Represented by a floating point
    *   number.
-   * @param inputVolume - A floating point number between 0.0 and 1.0 inclusive.
-   * @example `device.audio.on('inputVolume', volume => { })`
    * @event
+   * @param inputVolume - A floating point number between 0.0 and 1.0 inclusive.
+   * @example
+   * ```ts
+   * device.audio.on('inputVolume', volume => { });
+   * ```
    */
-  declare function inputVolumeEvent(inputVolume: number): void;
+  export declare function inputVolumeEvent(inputVolume: number): void;
 
   /**
    * An object like MediaDevices.
-   * @private
+   * @internal
    */
   export interface MediaDevicesLike {
     addEventListener?: (eventName: string, handler: (...args: any[]) => void) => void;
@@ -1001,7 +1007,7 @@ namespace AudioHelper {
 
   /**
    * Options that can be passed to the AudioHelper constructor
-   * @private
+   * @internal
    */
   export interface Options {
     /**

--- a/lib/twilio/audioprocessor.ts
+++ b/lib/twilio/audioprocessor.ts
@@ -67,7 +67,6 @@
  * // Or remove it later
  * // await device.audio.removeProcessor(processor);
  * ```
- * @publicapi
  */
 interface AudioProcessor {
   /**

--- a/lib/twilio/audioprocessoreventobserver.ts
+++ b/lib/twilio/audioprocessoreventobserver.ts
@@ -10,7 +10,7 @@ import Log from './log';
 /**
  * AudioProcessorEventObserver observes {@link AudioProcessor}
  * related operations and re-emits them as generic events.
- * @private
+ * @internal
  */
 export class AudioProcessorEventObserver extends EventEmitter {
 

--- a/lib/twilio/call.ts
+++ b/lib/twilio/call.ts
@@ -31,25 +31,10 @@ import { generateVoiceEventSid } from './uuid';
 import { RELEASE_VERSION } from './constants';
 
 // Placeholders until we convert the respective files to TypeScript.
-/**
- * @private
- */
 export type IAudioHelper = any;
-/**
- * @private
- */
 export type IPStream = any;
-/**
- * @private
- */
 export type IPeerConnection = any;
-/**
- * @private
- */
 export type IPublisher = any;
-/**
- * @private
- */
 export type ISound = any;
 
 const BACKOFF_CONFIG = {
@@ -104,12 +89,10 @@ const WARNING_PREFIXES: Record<string, string> = {
 
 /**
  * A {@link Call} represents a media and signaling connection to a TwiML application.
- * @publicapi
  */
 class Call extends EventEmitter {
   /**
    * String representation of the {@link Call} class.
-   * @private
    */
   static toString = () => '[Twilio.Call class]';
 
@@ -337,10 +320,9 @@ class Call extends EventEmitter {
   private _wasConnected: boolean = false;
 
   /**
-   * @constructor
-   * @private
+   * @internal
    * @param config - Mandatory configuration options
-   * @param [options] - Optional settings
+   * @param options - Optional settings
    */
   constructor(config: Call.Config, options?: Call.Options) {
     super();
@@ -609,8 +591,8 @@ class Call extends EventEmitter {
 
   /**
    * Set the audio input tracks from a given stream.
+   * @internal
    * @param stream
-   * @private
    */
   _setInputTracksFromStream(stream: MediaStream | null): Promise<void> {
     return this._mediaHandler.setInputTracksFromStream(stream);
@@ -618,8 +600,8 @@ class Call extends EventEmitter {
 
   /**
    * Set the audio output sink IDs.
+   * @internal
    * @param sinkIds
-   * @private
    */
   _setSinkIds(sinkIds: string[]): Promise<void> {
     return this._mediaHandler._setSinkIds(sinkIds);
@@ -984,7 +966,7 @@ class Call extends EventEmitter {
 
   /**
    * String representation of {@link Call} instance.
-   * @private
+   * @internal
    */
   toString = () => '[Twilio.Call instance]';
 
@@ -1612,127 +1594,166 @@ class Call extends EventEmitter {
   }
 }
 
+/**
+ * @mergeModuleWith Call
+ */
 namespace Call {
   /**
    * Emitted when the {@link Call} is accepted.
-   * @param call - The {@link Call}.
-   * @example `call.on('accept', call => { })`
    * @event
+   * @param call - The {@link Call}.
+   * @example
+   * ```ts
+   * call.on('accept', (call) => { });
+   * ```
    */
-  declare function acceptEvent(call: Call): void;
+  export declare function acceptEvent(call: Call): void;
 
   /**
    * Emitted after the HTMLAudioElement for the remote audio is created.
-   * @param remoteAudio - The HTMLAudioElement.
-   * @example `call.on('audio', handler(remoteAudio))`
    * @event
+   * @param remoteAudio - The HTMLAudioElement.
+   * @example
+   * ```ts
+   * call.on('audio', (remoteAudio) => { });
+   * ```
    */
-  declare function audioEvent(remoteAudio: HTMLAudioElement): void;
+  export declare function audioEvent(remoteAudio: HTMLAudioElement): void;
 
   /**
    * Emitted when the {@link Call} is canceled.
-   * @example `call.on('cancel', () => { })`
    * @event
+   * @example
+   * ```ts
+   * call.on('cancel', () => { });
+   * ```
    */
-  declare function cancelEvent(): void;
+  export declare function cancelEvent(): void;
 
   /**
    * Emitted when the {@link Call} is disconnected.
-   * @param call - The {@link Call}.
-   * @example `call.on('disconnect', call => { })`
    * @event
+   * @param call - The {@link Call}.
+   * @example
+   * ```ts
+   * call.on('disconnect', (call) => { });
+   * ```
    */
-  declare function disconnectEvent(call: Call): void;
+  export declare function disconnectEvent(call: Call): void;
 
   /**
    * Emitted when the {@link Call} receives an error.
-   * @param error
-   * @example `call.on('error', error => { })`
    * @event
+   * @param error
+   * @example
+   * ```ts
+   * call.on('error', (error) => { });
+   * ```
    */
-  declare function errorEvent(error: TwilioError): void;
+  export declare function errorEvent(error: TwilioError): void;
 
   /**
    * Emitted when a Call receives a message from the backend.
    * <br/><br/>This feature is currently in Beta.
+   * @event
    * @param message - A message object representing the payload
    * that was received from the Twilio backend.
-   * @event
    */
-  declare function messageReceivedEvent(message: Call.Message): void;
+  export declare function messageReceivedEvent(message: Call.Message): void;
 
   /**
    * Emitted after calling the {@link Call.sendMessage} API.
    * This event indicates that Twilio has received the message.
    * <br/><br/>This feature is currently in Beta.
-   * @param message - A message object that was sent to the Twilio backend.
    * @event
+   * @param message - A message object that was sent to the Twilio backend.
    */
-  declare function messageSentEvent(message: Call.Message): void;
+  export declare function messageSentEvent(message: Call.Message): void;
 
   /**
    * Emitted when the {@link Call} is muted or unmuted.
+   * @event
    * @param isMuted - Whether the {@link Call} is muted.
    * @param call - The {@link Call}.
-   * @example `call.on('mute', (isMuted, call) => { })`
-   * @event
+   * @example
+   * ```ts
+   * call.on('mute', (isMuted, call) => { });
+   * ```
    */
-  declare function muteEvent(isMuted: boolean, call: Call): void;
+  export declare function muteEvent(isMuted: boolean, call: Call): void;
 
   /**
    * Emitted when the {@link Call} has regained media connectivity.
-   * @example `call.on('reconnected', () => { })`
    * @event
+   * @example
+   * ```ts
+   * call.on('reconnected', () => { })
+   * ```
    */
-  declare function reconnectedEvent(): void;
+  export declare function reconnectedEvent(): void;
 
   /**
    * Emitted when the {@link Call} has lost media connectivity and is reconnecting.
-   * @param error - The {@link TwilioError} that caused the media connectivity loss
-   * @example `call.on('reconnecting', error => { })`
    * @event
+   * @param error - The {@link TwilioError} that caused the media connectivity loss
+   * @example
+   * ```ts
+   * call.on('reconnecting', (error) => { });
+   * ```
    */
-  declare function reconnectingEvent(error: TwilioError): void;
+  export declare function reconnectingEvent(error: TwilioError): void;
 
   /**
    * Emitted when the {@link Call} is rejected.
-   * @example `call.on('reject', () => { })`
    * @event
+   * @example
+   * ```ts
+   * call.on('reject', () => { })
+   * ```
    */
-  declare function rejectEvent(): void;
+  export declare function rejectEvent(): void;
 
   /**
    * Emitted when the {@link Call} has entered the `ringing` state.
    * When using the Dial verb with `answerOnBridge=true`, the ringing state will begin when
    * the callee has been notified of the call and will transition into open after the callee accepts the call,
    * or closed if the call is rejected or cancelled.
+   * @event
    * @param hasEarlyMedia - Denotes whether there is early media available from the callee.
    * If `true`, the Client SDK will automatically play the early media. Sometimes this is ringing,
    * other times it may be an important message about the call. If `false`, there is no remote media to play,
    * so the application may want to play its own outgoing ringtone sound.
-   * @example `call.on('ringing', hasEarlyMedia => { })`
-   * @event
+   * @example
+   * ```ts
+   * call.on('ringing', (hasEarlyMedia) => { });
+   * ```
    */
-  declare function ringingEvent(hasEarlyMedia: boolean): void;
+  export declare function ringingEvent(hasEarlyMedia: boolean): void;
 
   /**
    * Emitted when the {@link Call} gets a webrtc sample object.
    * This event is published every second.
-   * @param sample
-   * @example `call.on('sample', sample => { })`
    * @event
+   * @param sample
+   * @example
+   * ```ts
+   * call.on('sample', (sample) => { });
+   * ```
    */
-  declare function sampleEvent(sample: RTCSample): void;
+  export declare function sampleEvent(sample: RTCSample): void;
 
   /**
    * Emitted every 50ms with the current input and output volumes, as a percentage of maximum
    * volume, between -100dB and -30dB. Represented by a floating point number.
+   * @event
    * @param inputVolume - A floating point number between 0.0 and 1.0 inclusive.
    * @param outputVolume - A floating point number between 0.0 and 1.0 inclusive.
-   * @example `call.on('volume', (inputVolume, outputVolume) => { })`
-   * @event
+   * @example
+   * ```ts
+   * call.on('volume', (inputVolume, outputVolume) => { });
+   * ```
    */
-  declare function volumeEvent(inputVolume: number, outputVolume: number): void;
+  export declare function volumeEvent(inputVolume: number, outputVolume: number): void;
 
   /**
    * Emitted when the SDK detects a drop in call quality or other conditions that may indicate
@@ -1745,22 +1766,28 @@ namespace Call {
    * For a full list of conditions that will raise a warning event, check the
    * [Voice Insights SDK Events Reference](https://www.twilio.com/docs/voice/voice-insights/api/call/details-sdk-call-quality-events) page.
    *
+   * @event
    * @param name - The name of the warning
    * @param data - An object containing data on the warning
-   * @example `call.on('warning', (name, data) => { })`
-   * @event
+   * @example
+   * ```ts
+   * call.on('warning', (name, data) => { });
+   * ```
    */
-  declare function warningEvent(name: string, data: any): void;
+  export declare function warningEvent(name: string, data: any): void;
 
   /**
    * Emitted when a call quality metric has returned to normal.
    * You can listen for this event to update the user when a call quality issue has been resolved.
    *
-   * @param name - The name of the warning
-   * @example `call.on('warning-cleared', name => { })`
    * @event
+   * @param name - The name of the warning
+   * @example
+   * ```ts
+   * call.on('warning-cleared', (name) => { });
+   * ```
    */
-  declare function warningClearedEvent(name: string): void;
+  export declare function warningClearedEvent(name: string): void;
 
   /**
    * Possible states of the {@link Call}.
@@ -1863,7 +1890,7 @@ namespace Call {
 
   /**
    * Mandatory config options to be passed to the {@link Call} constructor.
-   * @private
+   * @internal
    */
   export interface Config {
     /**
@@ -1930,7 +1957,7 @@ namespace Call {
 
   /**
    * Options to be passed to the {@link Call} constructor.
-   * @private
+   * @internal
    */
   export interface Options {
     /**
@@ -2066,7 +2093,7 @@ namespace Call {
   /**
    * Call metrics published to Insight Metrics.
    * This include rtc samples and audio information.
-   * @private
+   * @internal
    */
   export interface CallMetrics extends RTCSample {
     /**

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -168,7 +168,6 @@ export interface ISoundDefinition {
 
 /**
  * Twilio Device. Allows registration for incoming calls, and placing outgoing calls.
- * @publicapi
  */
 class Device extends EventEmitter {
   /**
@@ -462,7 +461,6 @@ class Device extends EventEmitter {
   /**
    * Construct a {@link Device} instance. The {@link Device} can be registered
    * to make and listen for calls using {@link Device.register}.
-   * @constructor
    * @param options
    */
   constructor(token: string, options: Device.Options = { }) {
@@ -1699,21 +1697,30 @@ class Device extends EventEmitter {
   }
 }
 
+/**
+ * @mergeModuleWith Device
+ */
 namespace Device {
   /**
    * Emitted when the {@link Device} has been destroyed.
-   * @example `device.on('destroyed', () => { })`
    * @event
+   * @example
+   * ```ts
+   * device.on('destroyed', () => { });
+   * ```
    */
-  declare function destroyedEvent(): void;
+  export declare function destroyedEvent(): void;
 
   /**
    * Emitted when the {@link Device} receives an error.
-   * @param error
-   * @example `device.on('error', call => { })`
    * @event
+   * @param error
+   * @example
+   * ```ts
+   * device.on('error', call => { });
+   * ```
    */
-  declare function errorEvent(error: TwilioError, call?: Call): void;
+  export declare function errorEvent(error: TwilioError, call?: Call): void;
 
   /**
    * Emitted when an incoming {@link Call} is received. You can interact with the call object
@@ -1724,8 +1731,9 @@ namespace Device {
    * **Important:** When forwarding a call, the token for target device instance needs to have
    * the same identity as the token used in the device that originally received the call.
    *
+   * @event
+   * @param call - The incoming {@link Call}.
    * @example
-   *
    * ```js
    * const receiverDevice = new Device(token, options);
    * await receiverDevice.register();
@@ -1748,44 +1756,53 @@ namespace Device {
    *   call.on('disconnect', () => device.destroy());
    * }
    * ```
-   *
-   * @param call - The incoming {@link Call}.
-   * @event
    */
-  declare function incomingEvent(call: Call): void;
+  export declare function incomingEvent(call: Call): void;
 
   /**
    * Emitted when the {@link Device} is unregistered.
-   * @example `device.on('unregistered', () => { })`
    * @event
+   * @example
+   * ```ts
+   * device.on('unregistered', () => { });
+   * ```
    */
-  declare function unregisteredEvent(): void;
+  export declare function unregisteredEvent(): void;
 
   /**
    * Emitted when the {@link Device} is registering.
-   * @example `device.on('registering', () => { })`
    * @event
+   * @example
+   * ```ts
+   * device.on('registering', () => { });
+   * ```
    */
-  declare function registeringEvent(): void;
+  export declare function registeringEvent(): void;
 
   /**
    * Emitted when the {@link Device} is registered.
-   * @example `device.on('registered', () => { })`
    * @event
+   * @example
+   * ```ts
+   * device.on('registered', () => { });
+   * ```
    */
-  declare function registeredEvent(): void;
+  export declare function registeredEvent(): void;
 
   /**
    * Emitted when the {@link Device}'s token is about to expire. Use DeviceOptions.refreshTokenMs
    * to set a custom warning time. Default is 10000 (10 seconds) prior to the token expiring.
+   * @event
    * @param device
-   * @example `device.on('tokenWillExpire', device => {
+   * @example
+   * ```ts
+   * device.on('tokenWillExpire', device => {
    *   const token = getNewTokenViaAjax();
    *   device.updateToken(token);
-   * })`
-   * @event
+   * });
+   * ```
    */
-  declare function tokenWillExpireEvent(device: Device): void;
+  export declare function tokenWillExpireEvent(device: Device): void;
 
   /**
    * All valid {@link Device} event names.

--- a/lib/twilio/errors/generated.ts
+++ b/lib/twilio/errors/generated.ts
@@ -12,6 +12,9 @@ import TwilioError from './twilioError';
 export { TwilioError };
 
 export namespace AuthorizationErrors {
+  /**
+   * Error received from the Twilio backend.
+   */
   export class AccessTokenInvalid extends TwilioError {
     causes: string[] = [];
     code: number = 20101;
@@ -20,10 +23,25 @@ export namespace AuthorizationErrors {
     name: string = 'AccessTokenInvalid';
     solutions: string[] = [];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, AuthorizationErrors.AccessTokenInvalid.prototype);
@@ -41,6 +59,9 @@ export namespace AuthorizationErrors {
     }
   }
 
+  /**
+   * Error received from the Twilio backend.
+   */
   export class AccessTokenExpired extends TwilioError {
     causes: string[] = [];
     code: number = 20104;
@@ -49,10 +70,25 @@ export namespace AuthorizationErrors {
     name: string = 'AccessTokenExpired';
     solutions: string[] = [];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, AuthorizationErrors.AccessTokenExpired.prototype);
@@ -70,6 +106,9 @@ export namespace AuthorizationErrors {
     }
   }
 
+  /**
+   * Error received from the Twilio backend.
+   */
   export class AuthenticationFailed extends TwilioError {
     causes: string[] = [];
     code: number = 20151;
@@ -78,10 +117,25 @@ export namespace AuthorizationErrors {
     name: string = 'AuthenticationFailed';
     solutions: string[] = [];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, AuthorizationErrors.AuthenticationFailed.prototype);
@@ -101,6 +155,9 @@ export namespace AuthorizationErrors {
 }
 
 export namespace SignatureValidationErrors {
+  /**
+   * Error received from the Twilio backend.
+   */
   export class AccessTokenSignatureValidationFailed extends TwilioError {
     causes: string[] = [
       'The access token has an invalid Account SID, API Key, or API Key Secret.',
@@ -113,10 +170,25 @@ export namespace SignatureValidationErrors {
       'Ensure the Account SID, API Key, and API Key Secret are valid when generating your access token.',
     ];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, SignatureValidationErrors.AccessTokenSignatureValidationFailed.prototype);
@@ -136,6 +208,9 @@ export namespace SignatureValidationErrors {
 }
 
 export namespace ClientErrors {
+  /**
+   * Error received from the Twilio backend.
+   */
   export class BadRequest extends TwilioError {
     causes: string[] = [];
     code: number = 31400;
@@ -144,10 +219,25 @@ export namespace ClientErrors {
     name: string = 'BadRequest';
     solutions: string[] = [];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, ClientErrors.BadRequest.prototype);
@@ -165,6 +255,9 @@ export namespace ClientErrors {
     }
   }
 
+  /**
+   * Error received from the Twilio backend.
+   */
   export class NotFound extends TwilioError {
     causes: string[] = [
       'The outbound call was made to an invalid phone number.',
@@ -179,10 +272,25 @@ export namespace ClientErrors {
       'Ensure the TwiML application is configured correctly with a Voice URL link.',
     ];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, ClientErrors.NotFound.prototype);
@@ -200,6 +308,9 @@ export namespace ClientErrors {
     }
   }
 
+  /**
+   * Error received from the Twilio backend.
+   */
   export class TemporarilyUnavailable extends TwilioError {
     causes: string[] = [];
     code: number = 31480;
@@ -208,10 +319,25 @@ export namespace ClientErrors {
     name: string = 'TemporarilyUnavailable';
     solutions: string[] = [];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, ClientErrors.TemporarilyUnavailable.prototype);
@@ -229,6 +355,9 @@ export namespace ClientErrors {
     }
   }
 
+  /**
+   * Error received from the Twilio backend.
+   */
   export class BusyHere extends TwilioError {
     causes: string[] = [];
     code: number = 31486;
@@ -237,10 +366,25 @@ export namespace ClientErrors {
     name: string = 'BusyHere';
     solutions: string[] = [];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, ClientErrors.BusyHere.prototype);
@@ -260,6 +404,9 @@ export namespace ClientErrors {
 }
 
 export namespace SIPServerErrors {
+  /**
+   * Error received from the Twilio backend.
+   */
   export class Decline extends TwilioError {
     causes: string[] = [];
     code: number = 31603;
@@ -268,10 +415,25 @@ export namespace SIPServerErrors {
     name: string = 'Decline';
     solutions: string[] = [];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, SIPServerErrors.Decline.prototype);
@@ -291,6 +453,9 @@ export namespace SIPServerErrors {
 }
 
 export namespace GeneralErrors {
+  /**
+   * Error received from the Twilio backend.
+   */
   export class UnknownError extends TwilioError {
     causes: string[] = [];
     code: number = 31000;
@@ -299,10 +464,25 @@ export namespace GeneralErrors {
     name: string = 'UnknownError';
     solutions: string[] = [];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, GeneralErrors.UnknownError.prototype);
@@ -320,6 +500,9 @@ export namespace GeneralErrors {
     }
   }
 
+  /**
+   * Error received from the Twilio backend.
+   */
   export class ApplicationNotFoundError extends TwilioError {
     causes: string[] = [];
     code: number = 31001;
@@ -328,10 +511,25 @@ export namespace GeneralErrors {
     name: string = 'ApplicationNotFoundError';
     solutions: string[] = [];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, GeneralErrors.ApplicationNotFoundError.prototype);
@@ -349,6 +547,9 @@ export namespace GeneralErrors {
     }
   }
 
+  /**
+   * Error received from the Twilio backend.
+   */
   export class ConnectionDeclinedError extends TwilioError {
     causes: string[] = [];
     code: number = 31002;
@@ -357,10 +558,25 @@ export namespace GeneralErrors {
     name: string = 'ConnectionDeclinedError';
     solutions: string[] = [];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, GeneralErrors.ConnectionDeclinedError.prototype);
@@ -378,6 +594,9 @@ export namespace GeneralErrors {
     }
   }
 
+  /**
+   * Error received from the Twilio backend.
+   */
   export class ConnectionTimeoutError extends TwilioError {
     causes: string[] = [];
     code: number = 31003;
@@ -386,10 +605,25 @@ export namespace GeneralErrors {
     name: string = 'ConnectionTimeoutError';
     solutions: string[] = [];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, GeneralErrors.ConnectionTimeoutError.prototype);
@@ -407,6 +641,9 @@ export namespace GeneralErrors {
     }
   }
 
+  /**
+   * Error received from the Twilio backend.
+   */
   export class ConnectionError extends TwilioError {
     causes: string[] = [];
     code: number = 31005;
@@ -415,10 +652,25 @@ export namespace GeneralErrors {
     name: string = 'ConnectionError';
     solutions: string[] = [];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, GeneralErrors.ConnectionError.prototype);
@@ -436,6 +688,9 @@ export namespace GeneralErrors {
     }
   }
 
+  /**
+   * Error received from the Twilio backend.
+   */
   export class CallCancelledError extends TwilioError {
     causes: string[] = [
       'The incoming call was cancelled because it was not answered in time or it was accepted/rejected by another application instance registered with the same identity.',
@@ -446,10 +701,25 @@ export namespace GeneralErrors {
     name: string = 'CallCancelledError';
     solutions: string[] = [];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, GeneralErrors.CallCancelledError.prototype);
@@ -467,6 +737,9 @@ export namespace GeneralErrors {
     }
   }
 
+  /**
+   * Error received from the Twilio backend.
+   */
   export class TransportError extends TwilioError {
     causes: string[] = [];
     code: number = 31009;
@@ -475,10 +748,25 @@ export namespace GeneralErrors {
     name: string = 'TransportError';
     solutions: string[] = [];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, GeneralErrors.TransportError.prototype);
@@ -498,6 +786,9 @@ export namespace GeneralErrors {
 }
 
 export namespace MalformedRequestErrors {
+  /**
+   * Error received from the Twilio backend.
+   */
   export class MalformedRequestError extends TwilioError {
     causes: string[] = [
       'Invalid content or MessageType passed to sendMessage method.',
@@ -510,10 +801,25 @@ export namespace MalformedRequestErrors {
       'Ensure content and MessageType passed to sendMessage method are valid.',
     ];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, MalformedRequestErrors.MalformedRequestError.prototype);
@@ -531,6 +837,9 @@ export namespace MalformedRequestErrors {
     }
   }
 
+  /**
+   * Error received from the Twilio backend.
+   */
   export class MissingParameterArrayError extends TwilioError {
     causes: string[] = [];
     code: number = 31101;
@@ -539,10 +848,25 @@ export namespace MalformedRequestErrors {
     name: string = 'MissingParameterArrayError';
     solutions: string[] = [];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, MalformedRequestErrors.MissingParameterArrayError.prototype);
@@ -560,6 +884,9 @@ export namespace MalformedRequestErrors {
     }
   }
 
+  /**
+   * Error received from the Twilio backend.
+   */
   export class AuthorizationTokenMissingError extends TwilioError {
     causes: string[] = [];
     code: number = 31102;
@@ -568,10 +895,25 @@ export namespace MalformedRequestErrors {
     name: string = 'AuthorizationTokenMissingError';
     solutions: string[] = [];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, MalformedRequestErrors.AuthorizationTokenMissingError.prototype);
@@ -589,6 +931,9 @@ export namespace MalformedRequestErrors {
     }
   }
 
+  /**
+   * Error received from the Twilio backend.
+   */
   export class MaxParameterLengthExceededError extends TwilioError {
     causes: string[] = [];
     code: number = 31103;
@@ -597,10 +942,25 @@ export namespace MalformedRequestErrors {
     name: string = 'MaxParameterLengthExceededError';
     solutions: string[] = [];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, MalformedRequestErrors.MaxParameterLengthExceededError.prototype);
@@ -618,6 +978,9 @@ export namespace MalformedRequestErrors {
     }
   }
 
+  /**
+   * Error received from the Twilio backend.
+   */
   export class InvalidBridgeTokenError extends TwilioError {
     causes: string[] = [];
     code: number = 31104;
@@ -626,10 +989,25 @@ export namespace MalformedRequestErrors {
     name: string = 'InvalidBridgeTokenError';
     solutions: string[] = [];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, MalformedRequestErrors.InvalidBridgeTokenError.prototype);
@@ -647,6 +1025,9 @@ export namespace MalformedRequestErrors {
     }
   }
 
+  /**
+   * Error received from the Twilio backend.
+   */
   export class InvalidClientNameError extends TwilioError {
     causes: string[] = [
       'Client name contains invalid characters.',
@@ -659,10 +1040,25 @@ export namespace MalformedRequestErrors {
       'Make sure that client name does not contain any of the invalid characters.',
     ];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, MalformedRequestErrors.InvalidClientNameError.prototype);
@@ -680,6 +1076,9 @@ export namespace MalformedRequestErrors {
     }
   }
 
+  /**
+   * Error received from the Twilio backend.
+   */
   export class ReconnectParameterInvalidError extends TwilioError {
     causes: string[] = [];
     code: number = 31107;
@@ -688,10 +1087,25 @@ export namespace MalformedRequestErrors {
     name: string = 'ReconnectParameterInvalidError';
     solutions: string[] = [];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, MalformedRequestErrors.ReconnectParameterInvalidError.prototype);
@@ -711,6 +1125,9 @@ export namespace MalformedRequestErrors {
 }
 
 export namespace AuthorizationErrors {
+  /**
+   * Error received from the Twilio backend.
+   */
   export class AuthorizationError extends TwilioError {
     causes: string[] = [];
     code: number = 31201;
@@ -719,10 +1136,25 @@ export namespace AuthorizationErrors {
     name: string = 'AuthorizationError';
     solutions: string[] = [];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, AuthorizationErrors.AuthorizationError.prototype);
@@ -740,6 +1172,9 @@ export namespace AuthorizationErrors {
     }
   }
 
+  /**
+   * Error received from the Twilio backend.
+   */
   export class NoValidAccountError extends TwilioError {
     causes: string[] = [];
     code: number = 31203;
@@ -748,10 +1183,25 @@ export namespace AuthorizationErrors {
     name: string = 'NoValidAccountError';
     solutions: string[] = [];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, AuthorizationErrors.NoValidAccountError.prototype);
@@ -769,6 +1219,9 @@ export namespace AuthorizationErrors {
     }
   }
 
+  /**
+   * Error received from the Twilio backend.
+   */
   export class InvalidJWTTokenError extends TwilioError {
     causes: string[] = [];
     code: number = 31204;
@@ -777,10 +1230,25 @@ export namespace AuthorizationErrors {
     name: string = 'InvalidJWTTokenError';
     solutions: string[] = [];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, AuthorizationErrors.InvalidJWTTokenError.prototype);
@@ -798,6 +1266,9 @@ export namespace AuthorizationErrors {
     }
   }
 
+  /**
+   * Error received from the Twilio backend.
+   */
   export class JWTTokenExpiredError extends TwilioError {
     causes: string[] = [];
     code: number = 31205;
@@ -806,10 +1277,25 @@ export namespace AuthorizationErrors {
     name: string = 'JWTTokenExpiredError';
     solutions: string[] = [];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, AuthorizationErrors.JWTTokenExpiredError.prototype);
@@ -827,6 +1313,9 @@ export namespace AuthorizationErrors {
     }
   }
 
+  /**
+   * Error received from the Twilio backend.
+   */
   export class RateExceededError extends TwilioError {
     causes: string[] = [
       'Rate limit exceeded.',
@@ -839,10 +1328,25 @@ export namespace AuthorizationErrors {
       'Ensure message send rate does not exceed authorized limits.',
     ];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, AuthorizationErrors.RateExceededError.prototype);
@@ -860,6 +1364,9 @@ export namespace AuthorizationErrors {
     }
   }
 
+  /**
+   * Error received from the Twilio backend.
+   */
   export class JWTTokenExpirationTooLongError extends TwilioError {
     causes: string[] = [];
     code: number = 31207;
@@ -868,10 +1375,25 @@ export namespace AuthorizationErrors {
     name: string = 'JWTTokenExpirationTooLongError';
     solutions: string[] = [];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, AuthorizationErrors.JWTTokenExpirationTooLongError.prototype);
@@ -889,6 +1411,9 @@ export namespace AuthorizationErrors {
     }
   }
 
+  /**
+   * Error received from the Twilio backend.
+   */
   export class ReconnectAttemptError extends TwilioError {
     causes: string[] = [];
     code: number = 31209;
@@ -897,10 +1422,25 @@ export namespace AuthorizationErrors {
     name: string = 'ReconnectAttemptError';
     solutions: string[] = [];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, AuthorizationErrors.ReconnectAttemptError.prototype);
@@ -918,6 +1458,9 @@ export namespace AuthorizationErrors {
     }
   }
 
+  /**
+   * Error received from the Twilio backend.
+   */
   export class CallMessageEventTypeInvalidError extends TwilioError {
     causes: string[] = [
       'The Call Message Event Type is invalid and is not understood by Twilio Voice.',
@@ -930,10 +1473,25 @@ export namespace AuthorizationErrors {
       'Ensure the Call Message Event Type is Valid and understood by Twilio Voice and try again.',
     ];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, AuthorizationErrors.CallMessageEventTypeInvalidError.prototype);
@@ -951,6 +1509,9 @@ export namespace AuthorizationErrors {
     }
   }
 
+  /**
+   * Error received from the Twilio backend.
+   */
   export class PayloadSizeExceededError extends TwilioError {
     causes: string[] = [
       'The payload size of Call Message Event exceeds the authorized limit.',
@@ -963,10 +1524,25 @@ export namespace AuthorizationErrors {
       'Reduce payload size of Call Message Event to be within the authorized limit and try again.',
     ];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, AuthorizationErrors.PayloadSizeExceededError.prototype);
@@ -986,6 +1562,9 @@ export namespace AuthorizationErrors {
 }
 
 export namespace UserMediaErrors {
+  /**
+   * Error received from the Twilio backend.
+   */
   export class PermissionDeniedError extends TwilioError {
     causes: string[] = [
       'The user denied the getUserMedia request.',
@@ -1000,10 +1579,25 @@ export namespace UserMediaErrors {
       'The user should to verify that the browser has permission to access the microphone at this address.',
     ];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, UserMediaErrors.PermissionDeniedError.prototype);
@@ -1021,6 +1615,9 @@ export namespace UserMediaErrors {
     }
   }
 
+  /**
+   * Error received from the Twilio backend.
+   */
   export class AcquisitionFailedError extends TwilioError {
     causes: string[] = [
       'NotFoundError - The deviceID specified was not found.',
@@ -1035,10 +1632,25 @@ export namespace UserMediaErrors {
       'Try acquiring media with fewer constraints.',
     ];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, UserMediaErrors.AcquisitionFailedError.prototype);
@@ -1058,6 +1670,9 @@ export namespace UserMediaErrors {
 }
 
 export namespace SignalingErrors {
+  /**
+   * Error received from the Twilio backend.
+   */
   export class ConnectionError extends TwilioError {
     causes: string[] = [];
     code: number = 53000;
@@ -1066,10 +1681,25 @@ export namespace SignalingErrors {
     name: string = 'ConnectionError';
     solutions: string[] = [];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, SignalingErrors.ConnectionError.prototype);
@@ -1087,6 +1717,9 @@ export namespace SignalingErrors {
     }
   }
 
+  /**
+   * Error received from the Twilio backend.
+   */
   export class ConnectionDisconnected extends TwilioError {
     causes: string[] = [
       'The device running your application lost its Internet connection.',
@@ -1099,10 +1732,25 @@ export namespace SignalingErrors {
       'Ensure the device running your application has access to a stable Internet connection.',
     ];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, SignalingErrors.ConnectionDisconnected.prototype);
@@ -1122,6 +1770,9 @@ export namespace SignalingErrors {
 }
 
 export namespace MediaErrors {
+  /**
+   * Error received from the Twilio backend.
+   */
   export class ClientLocalDescFailed extends TwilioError {
     causes: string[] = [
       'The Client may not be using a supported WebRTC implementation.',
@@ -1135,10 +1786,25 @@ export namespace MediaErrors {
       'If you are experiencing this error using the JavaScript SDK, ensure you are running it with a supported WebRTC implementation.',
     ];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, MediaErrors.ClientLocalDescFailed.prototype);
@@ -1156,6 +1822,9 @@ export namespace MediaErrors {
     }
   }
 
+  /**
+   * Error received from the Twilio backend.
+   */
   export class ClientRemoteDescFailed extends TwilioError {
     causes: string[] = [
       'The Client may not be using a supported WebRTC implementation.',
@@ -1170,10 +1839,25 @@ export namespace MediaErrors {
       'If you are experiencing this error using the JavaScript SDK, ensure you are running it with a supported WebRTC implementation.',
     ];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, MediaErrors.ClientRemoteDescFailed.prototype);
@@ -1191,6 +1875,9 @@ export namespace MediaErrors {
     }
   }
 
+  /**
+   * Error received from the Twilio backend.
+   */
   export class ConnectionError extends TwilioError {
     causes: string[] = [
       'The Client was unable to establish a media connection.',
@@ -1206,10 +1893,25 @@ export namespace MediaErrors {
       'If you\'ve provided custom ICE Servers then ensure that the URLs and credentials are valid.',
     ];
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, MediaErrors.ConnectionError.prototype);

--- a/lib/twilio/errors/index.ts
+++ b/lib/twilio/errors/index.ts
@@ -3,6 +3,11 @@
  * @internalapi
  */
 /* tslint:disable max-classes-per-file */
+
+/**
+ * VBLOCKS-4589: Consider refactoring this file.
+ */
+
 import {
   AuthorizationErrors,
   ClientErrors,
@@ -63,6 +68,18 @@ const PRECISE_SIGNALING_ERROR_CODES: Set<number> = new Set([
    */
   31603,
 ]);
+
+/**
+ * Get a error constructor using the [[PRECISE_SIGNALING_ERROR_CODES]] set.
+ * @internal
+ * @param enableImprovedSignalingErrorPrecision - A boolean representing the
+ * optional flag whether or not to use more precise error codes.
+ * @param errorCode - The error code.
+ * @returns This function returns `undefined` if the passed error code does not
+ * correlate to an error or should not be constructed with a more precise error
+ * constructor. A sub-class of {@link TwilioError} if the code does correlate to
+ * an error.
+ */
 export function getPreciseSignalingErrorByCode(
   enableImprovedSignalingErrorPrecision: boolean,
   errorCode: number,
@@ -85,28 +102,51 @@ export function getPreciseSignalingErrorByCode(
   return getErrorByCode(errorCode);
 }
 
-// Application errors that can be avoided by good app logic
+/**
+ * The error that is thrown when an invalid argument is passed to a library API.
+ */
 export class InvalidArgumentError extends Error {
+  /**
+   * @internal
+   */
   constructor(message?: string) {
     super(message);
     this.name = 'InvalidArgumentError';
   }
 }
+
+/**
+ * The error that is thrown when the library has entered an invalid state.
+ */
 export class InvalidStateError extends Error {
+  /**
+   * @internal
+   */
   constructor(message?: string) {
     super(message);
     this.name = 'InvalidStateError';
   }
 }
+
+/**
+ * The error that is thrown when an attempt is made to use an API that is not
+ * supported on the current platform.
+ */
 export class NotSupportedError extends Error {
+  /**
+   * @internal
+   */
   constructor(message?: string) {
     super(message);
     this.name = 'NotSupportedError';
   }
 }
 
-// This should only be used to look up error codes returned by a server
-// using the same repo of error codes.
+/**
+ * This should only be used to look up error codes returned by a server
+ * using the same repo of error codes.
+ * @internal
+ */
 export function getErrorByCode(code: number): (typeof TwilioError) {
   const error: (typeof TwilioError) | undefined = errorsByCode.get(code);
   if (!error) {
@@ -115,13 +155,18 @@ export function getErrorByCode(code: number): (typeof TwilioError) {
   return error;
 }
 
-// This should only be used to look up error codes returned by a server
-// using the same repo of error codes.
+/**
+ * This should only be used to look up error codes returned by a server
+ * using the same repo of error codes.
+ * @internal
+ */
 export function hasErrorByCode(code: number): boolean {
   return errorsByCode.has(code);
 }
 
 /**
+ * @privateRemarks
+ *
  * All errors we want to throw or emit locally in the SDK need to be passed
  * through here.
  *

--- a/lib/twilio/errors/twilioError.ts
+++ b/lib/twilio/errors/twilioError.ts
@@ -4,6 +4,11 @@
  * @publicapi
  * @internal
  */
+
+/**
+ * Base class for all possible errors that the library can receive from the
+ * Twilio backend.
+ */
 export default class TwilioError extends Error {
   /**
    * A list of possible causes for the Error.
@@ -45,6 +50,9 @@ export default class TwilioError extends Error {
    */
   solutions: string[];
 
+  /**
+   * @internal
+   */
   constructor(messageOrError?: string | Error | object, error?: Error | object) {
     super();
     Object.setPrototypeOf(this, TwilioError.prototype);

--- a/lib/twilio/outputdevicecollection.ts
+++ b/lib/twilio/outputdevicecollection.ts
@@ -9,7 +9,6 @@ const DEFAULT_TEST_SOUND_URL = `${SOUNDS_BASE_URL}/outgoing.mp3`;
 
 /**
  * A smart collection containing a Set of active output devices.
- * @publicapi
  */
 export default class OutputDeviceCollection {
   /**
@@ -23,7 +22,7 @@ export default class OutputDeviceCollection {
   private _log: Log = new Log('OutputDeviceCollection');
 
   /**
-   * @private
+   * @internal
    */
   constructor(private _name: string,
               private _availableDevices: Map<string, MediaDeviceInfo>,

--- a/lib/twilio/preflight/preflight.ts
+++ b/lib/twilio/preflight/preflight.ts
@@ -26,7 +26,6 @@ import { COWBELL_AUDIO_URL, ECHO_TEST_DURATION } from '../constants';
 /**
  * Placeholder until we convert peerconnection.js to TypeScript.
  * Represents the audio output object coming from Client SDK's PeerConnection object.
- * @internalapi
  */
 export interface AudioOutput {
   /**
@@ -35,6 +34,9 @@ export interface AudioOutput {
   audio: HTMLAudioElement;
 }
 
+/**
+ * @mergeModuleWith PreflightTest
+ */
 export declare interface PreflightTest {
   /**
    * Raised when [[PreflightTest.status]] has transitioned to [[PreflightTest.Status.Completed]].
@@ -184,7 +186,6 @@ export class PreflightTest extends EventEmitter {
 
   /**
    * Construct a {@link PreflightTest} instance.
-   * @constructor
    * @param token - A Twilio JWT token string.
    * @param options
    */
@@ -632,6 +633,9 @@ export class PreflightTest extends EventEmitter {
   }
 }
 
+/**
+ * @mergeModuleWith PreflightTest
+ */
 export namespace PreflightTest {
   /**
    * The quality of the call determined by different mos ranges.
@@ -727,7 +731,7 @@ export namespace PreflightTest {
 
   /**
    * Options that may be passed to {@link PreflightTest} constructor for internal testing.
-   * @internalapi
+   * @internal
    */
   export interface ExtendedOptions extends Options {
     /**
@@ -738,7 +742,6 @@ export namespace PreflightTest {
     /**
      * A string or array of strings representing the URI of the signaling
      * gateway to connect to.
-     * @private
      */
     chunderw?: string | string[];
 
@@ -749,7 +752,6 @@ export namespace PreflightTest {
 
     /**
      * A string representing the URI of the insights gateway to connect to.
-     * @private
      */
     eventgw?: string;
 

--- a/lib/twilio/regions.ts
+++ b/lib/twilio/regions.ts
@@ -7,7 +7,6 @@ import { InvalidArgumentError } from './errors';
 
 /**
  * Valid edges.
- * @private
  */
 export enum Edge {
   /**

--- a/scripts/errors.js
+++ b/scripts/errors.js
@@ -50,6 +50,10 @@ const USED_ERRORS = [
   'UserMediaErrors.AcquisitionFailedError',
 ];
 
+/**
+ * VBLOCKS-4590: Consider removing the "@internalapi" tag from the generated
+ * docs.
+ */
 let output = `/* tslint:disable max-classes-per-file max-line-length */
 /**
  * @packageDocumentation
@@ -70,6 +74,9 @@ const generateStringArray = arr => arr ? `[
     ]` : '[]';
 
 const generateDefinition = (code, subclassName, errorName, error) => `\
+  /**
+   * Error received from the Twilio backend.
+   */
   export class ${errorName} extends TwilioError {
     causes: string[] = ${generateStringArray(error.causes)};
     code: number = ${code};
@@ -78,10 +85,25 @@ const generateDefinition = (code, subclassName, errorName, error) => `\
     name: string = '${escapeQuotes(errorName)}';
     solutions: string[] = ${generateStringArray(error.solutions)};
 
+    /**
+     * @internal
+     */
     constructor();
+    /**
+     * @internal
+     */
     constructor(message: string);
+    /**
+     * @internal
+     */
     constructor(error: Error | object);
+    /**
+     * @internal
+     */
     constructor(message: string, error: Error | object);
+    /**
+     * @internal
+     */
     constructor(messageOrError?: string | Error | object, error?: Error | object) {
       super(messageOrError, error);
       Object.setPrototypeOf(this, ${subclassName}Errors.${errorName}.prototype);


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [VBLOCKS-4564](https://twilio-engineering.atlassian.net/browse/VBLOCKS-4564)

### Description

This PR adjusts the docstrings to comply with the new Typedoc specifications. Also, export previously non-exported members whose types are necessary for users.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
