### PR TITLE
[VBLOCKS-4686] Remove rtcpeerconnectionshim

### DIFF
--- a/lib/twilio/rtc/rtcpc.ts
+++ b/lib/twilio/rtc/rtcpc.ts
@@ -11,8 +11,6 @@ import Log from '../log';
 import * as util from '../util';
 import { setCodecPreferences, setMaxAverageBitrate } from './sdp';
 
-const RTCPeerConnectionShim = require('rtcpeerconnection-shim');
-
 function RTCPC(options) {
   if (typeof window === 'undefined') {
     this.log.info('No RTCPeerConnection implementation available. The window object was not found.');
@@ -22,7 +20,7 @@ function RTCPC(options) {
   if (options && options.RTCPeerConnection) {
     this.RTCPeerConnection = options.RTCPeerConnection;
   } else if (util.isLegacyEdge()) {
-    this.RTCPeerConnection = new RTCPeerConnectionShim(typeof window !== 'undefined' ? window : global);
+    this.log.error('This browser is not supported.');
   } else if (typeof window.RTCPeerConnection === 'function') {
     this.RTCPeerConnection = window.RTCPeerConnection;
   } else if (typeof window.webkitRTCPeerConnection === 'function') {

--- a/lib/twilio/rtc/rtcpc.ts
+++ b/lib/twilio/rtc/rtcpc.ts
@@ -21,8 +21,6 @@ function RTCPC(options: { RTCPeerConnection?: any }) {
 
   if (options && options.RTCPeerConnection) {
     this.RTCPeerConnection = options.RTCPeerConnection;
-  } else if (util.isLegacyEdge()) {
-    this.log.info('This browser is not supported.');
   } else if (typeof window.RTCPeerConnection === 'function') {
     this.RTCPeerConnection = window.RTCPeerConnection;
   } else if (typeof window.webkitRTCPeerConnection === 'function') {

--- a/lib/twilio/rtc/rtcpc.ts
+++ b/lib/twilio/rtc/rtcpc.ts
@@ -11,7 +11,9 @@ import Log from '../log';
 import * as util from '../util';
 import { setCodecPreferences, setMaxAverageBitrate } from './sdp';
 
-function RTCPC(options) {
+function RTCPC(options: { RTCPeerConnection?: any }) {
+  this.log = new Log('RTCPC');
+
   if (typeof window === 'undefined') {
     this.log.info('No RTCPeerConnection implementation available. The window object was not found.');
     return;
@@ -20,7 +22,7 @@ function RTCPC(options) {
   if (options && options.RTCPeerConnection) {
     this.RTCPeerConnection = options.RTCPeerConnection;
   } else if (util.isLegacyEdge()) {
-    this.log.error('This browser is not supported.');
+    this.log.info('This browser is not supported.');
   } else if (typeof window.RTCPeerConnection === 'function') {
     this.RTCPeerConnection = window.RTCPeerConnection;
   } else if (typeof window.webkitRTCPeerConnection === 'function') {
@@ -35,7 +37,6 @@ function RTCPC(options) {
 }
 
 RTCPC.prototype.create = function(rtcConfiguration) {
-  this.log = new Log('RTCPC');
   this.pc = new this.RTCPeerConnection(rtcConfiguration);
 };
 RTCPC.prototype.createModernConstraints = c => {

--- a/lib/twilio/util.ts
+++ b/lib/twilio/util.ts
@@ -63,8 +63,6 @@ function isFirefox(navigator?) {
 }
 
 /**
- * @privateRemarks
- *
  * Chromium-based Edge has a user-agent of "Edg/" where legacy Edge has a
  * user-agent of "Edge/".
  */

--- a/lib/twilio/util.ts
+++ b/lib/twilio/util.ts
@@ -62,6 +62,12 @@ function isFirefox(navigator?) {
     && /firefox|fxios/i.test(navigator.userAgent);
 }
 
+/**
+ * @privateRemarks
+ *
+ * Chromium-based Edge has a user-agent of "Edg/" where legacy Edge has a
+ * user-agent of "Edge/".
+ */
 function isLegacyEdge(navigator?) {
   navigator = navigator || (typeof window === 'undefined'
     ? global.navigator : window.navigator);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@twilio/voice-errors": "1.7.0",
-        "@types/md5": "2.3.2",
         "events": "3.3.0",
-        "loglevel": "1.6.7",
-        "md5": "2.3.0",
-        "rtcpeerconnection-shim": "1.2.8"
+        "loglevel": "1.6.7"
       },
       "devDependencies": {
         "@datadog/datadog-ci": "3.2.0",
@@ -6279,11 +6276,6 @@
         "@types/mdurl": "*"
       }
     },
-    "node_modules/@types/md5": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@types/md5/-/md5-2.3.2.tgz",
-      "integrity": "sha512-v+JFDu96+UYJ3/UWzB0mEglIS//MZXgRaJ4ubUPwOM0gvLc/kcQ3TWNYwENEK7/EcXGQVrW8h/XqednSjBd/Og=="
-    },
     "node_modules/@types/mdurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
@@ -7609,14 +7601,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -8267,14 +8251,6 @@
       },
       "bin": {
         "which": "bin/which"
-      }
-    },
-    "node_modules/crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/crypto-browserify": {
@@ -11388,7 +11364,8 @@
     "node_modules/is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
@@ -13027,16 +13004,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "dependencies": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
       }
     },
     "node_modules/md5.js": {
@@ -15747,18 +15714,6 @@
       "integrity": "sha512-R3wLbuAYejpxQjL/SjXo1Cjv4wcJECnMRT/FlcCfTwCBhaji9rWaRCoVEQ1SPiTJ4kKK+yh+bZLAV7SCafoDDw==",
       "dev": true
     },
-    "node_modules/rtcpeerconnection-shim": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rtcpeerconnection-shim/-/rtcpeerconnection-shim-1.2.8.tgz",
-      "integrity": "sha512-5Sx90FGru1sQw9aGOM+kHU4i6mbP8eJPgxliu2X3Syhg8qgDybx8dpDTxUwfJvPnubXFnZeRNl59DWr4AttJKQ==",
-      "dependencies": {
-        "sdp": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=6.0.0",
-        "npm": ">=3.10.0"
-      }
-    },
     "node_modules/run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -15844,11 +15799,6 @@
       "resolved": "https://registry.npmjs.org/scmp/-/scmp-2.1.0.tgz",
       "integrity": "sha512-o/mRQGk9Rcer/jEEw/yw4mwo3EU/NvYvp577/Btqrym9Qy5/MdWGBqipbALgd2lrdWTJ5/gqDusxfnQBxOxT2Q==",
       "dev": true
-    },
-    "node_modules/sdp": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/sdp/-/sdp-2.12.0.tgz",
-      "integrity": "sha512-jhXqQAQVM+8Xj5EjJGVweuEzgtGWb3tmEEpl3CLP3cStInSbVHSg0QWOGQzNq8pSID4JkpeV2mPqlMDLrm0/Vw=="
     },
     "node_modules/selenium-webdriver": {
       "version": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -128,10 +128,7 @@
   },
   "dependencies": {
     "@twilio/voice-errors": "1.7.0",
-    "@types/md5": "2.3.2",
     "events": "3.3.0",
-    "loglevel": "1.6.7",
-    "md5": "2.3.0",
-    "rtcpeerconnection-shim": "1.2.8"
+    "loglevel": "1.6.7"
   }
 }

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -113,3 +113,4 @@ require('./unit/regions');
 require('./unit/sid');
 require('./unit/cdn/viewerrequest/test');
 require('./unit/cdn/viewerresponse/test');
+require('./unit/rtcpc');

--- a/tests/unit/rtcpc.ts
+++ b/tests/unit/rtcpc.ts
@@ -1,0 +1,29 @@
+import * as sinon from 'sinon';
+import * as LogModule from '../../lib/twilio/log';
+import RTCPC from '../../lib/twilio/rtc/rtcpc';
+
+describe('rtcpc', function() {
+  this.afterEach(function() {
+    sinon.restore();
+  });
+
+  it('uses the default Log module when not passed an option', function() {
+    const logClassStub = sinon.createStubInstance(LogModule.default);
+    const logConstructorStub = sinon.stub(LogModule, 'default').returns(logClassStub);
+
+    RTCPC({});
+
+    sinon.assert.calledOnceWithExactly(logConstructorStub, 'RTCPC');
+  });
+
+  it('logs a message when legacy edge is detected', function() {
+    (window.navigator as any).userAgent = 'foobar foobar Edge/12.34 foobar';
+
+    const logClassStub = sinon.createStubInstance(LogModule.default);
+    sinon.stub(LogModule, 'default').returns(logClassStub);
+
+    RTCPC({});
+
+    sinon.assert.calledOnceWithExactly(logClassStub.info, 'This browser is not supported.');
+  });
+});

--- a/tests/unit/rtcpc.ts
+++ b/tests/unit/rtcpc.ts
@@ -7,7 +7,7 @@ describe('rtcpc', function() {
     sinon.restore();
   });
 
-  it('uses the default Log module when not passed an option', function() {
+  it('instantiates the default log module', function() {
     const logClassStub = sinon.createStubInstance(LogModule.default);
     const logConstructorStub = sinon.stub(LogModule, 'default').returns(logClassStub);
 

--- a/tests/unit/rtcpc.ts
+++ b/tests/unit/rtcpc.ts
@@ -1,3 +1,4 @@
+import * as assert from 'assert';
 import * as sinon from 'sinon';
 import * as LogModule from '../../lib/twilio/log';
 import RTCPC from '../../lib/twilio/rtc/rtcpc';
@@ -17,13 +18,10 @@ describe('rtcpc', function() {
   });
 
   it('logs a message when legacy edge is detected', function() {
-    (window.navigator as any).userAgent = 'foobar foobar Edge/12.34 foobar';
+    sinon.stub(window, 'RTCPeerConnection').get(() => undefined);
 
-    const logClassStub = sinon.createStubInstance(LogModule.default);
-    sinon.stub(LogModule, 'default').returns(logClassStub);
+    const result = RTCPC({});
 
-    RTCPC({});
-
-    sinon.assert.calledOnceWithExactly(logClassStub.info, 'This browser is not supported.');
+    assert(typeof result === 'undefined');
   });
 });


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [VBLOCKS-4686](https://twilio-engineering.atlassian.net/browse/VBLOCKS-4686)

### Description

This PR removes the `rtcpeerconnection-shim` library as it was only used for legacy edge, which our SDK has officially dropped support for.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
