### PR TITLE
[VBLOCKS-4596] docs: remove packageDocumentation headers

### DIFF
--- a/lib/twilio.ts
+++ b/lib/twilio.ts
@@ -1,7 +1,3 @@
-/**
- * @packageDocumentation
- * @internalapi
- */
 import AudioProcessor from './twilio/audioprocessor';
 import Call from './twilio/call';
 import Device from './twilio/device';

--- a/lib/twilio/asyncQueue.ts
+++ b/lib/twilio/asyncQueue.ts
@@ -1,8 +1,3 @@
-/**
- * @packageDocumentation
- * @module Voice
- * @internalapi
- */
 import Deferred from './deferred';
 
 /**

--- a/lib/twilio/audiohelper.ts
+++ b/lib/twilio/audiohelper.ts
@@ -1,7 +1,3 @@
-/**
- * @packageDocumentation
- * @module Voice
- */
 import { EventEmitter } from 'events';
 import AudioProcessor from './audioprocessor';
 import { AudioProcessorEventObserver } from './audioprocessoreventobserver';

--- a/lib/twilio/audioplayer/audioplayer.ts
+++ b/lib/twilio/audioplayer/audioplayer.ts
@@ -1,8 +1,3 @@
-/**
- * @packageDocumentation
- * @module Voice
- * @internalapi
- */
 // @ts-nocheck
 import Deferred from './deferred';
 import EventTarget from './eventtarget';

--- a/lib/twilio/audioplayer/chromeaudiocontext.ts
+++ b/lib/twilio/audioplayer/chromeaudiocontext.ts
@@ -1,8 +1,3 @@
-/**
- * @packageDocumentation
- * @module Voice
- * @internalapi
- */
 /* tslint:disable:interface-name */
 export default interface ChromeAudioContext extends AudioContext {
   createMediaStreamDestination: () => any;

--- a/lib/twilio/audioplayer/deferred.ts
+++ b/lib/twilio/audioplayer/deferred.ts
@@ -1,8 +1,3 @@
-/**
- * @packageDocumentation
- * @module Voice
- * @internalapi
- */
 // @ts-nocheck
 export default class Deferred<T> {
   readonly promise: Promise<T>;

--- a/lib/twilio/audioplayer/eventtarget.ts
+++ b/lib/twilio/audioplayer/eventtarget.ts
@@ -1,8 +1,3 @@
-/**
- * @packageDocumentation
- * @module Voice
- * @internalapi
- */
 // @ts-nocheck
 import { EventEmitter } from 'events';
 

--- a/lib/twilio/audioprocessor.ts
+++ b/lib/twilio/audioprocessor.ts
@@ -1,9 +1,4 @@
 /**
- * @packageDocumentation
- * @module Voice
- */
-
-/**
  * An AudioProcessor can be added to the SDK, providing access to the audio input stream
  * and the ability to process or analyze the stream before sending it to Twilio.
  * To add the processor, you must implement the AudioProcessor interface and use

--- a/lib/twilio/audioprocessoreventobserver.ts
+++ b/lib/twilio/audioprocessoreventobserver.ts
@@ -1,9 +1,3 @@
-/**
- * @packageDocumentation
- * @module Voice
- * @internalapi
- */
-
 import { EventEmitter } from 'events';
 import Log from './log';
 

--- a/lib/twilio/backoff.ts
+++ b/lib/twilio/backoff.ts
@@ -1,7 +1,3 @@
-/**
- * @packageDocumentation
- * @internalapi
- */
 // @ts-nocheck
 // NOTE (csantos): This file was taken directly from twilio-video and has been renamed from JS to TS only.
 // It needs to be re-written as part of the overall updating of the files to TS.

--- a/lib/twilio/call.ts
+++ b/lib/twilio/call.ts
@@ -1,9 +1,3 @@
-/**
- * @packageDocumentation
- * @module Voice
- * @publicapi
- * @internal
- */
 import { EventEmitter } from 'events';
 import Backoff from './backoff';
 import Device from './device';

--- a/lib/twilio/deferred.ts
+++ b/lib/twilio/deferred.ts
@@ -1,10 +1,4 @@
 /**
- * @packageDocumentation
- * @module Voice
- * @internalapi
- */
-
-/**
  * Deferred Promise
  */
 export default class Deferred {

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -1,9 +1,3 @@
-/**
- * @packageDocumentation
- * @module Voice
- * @preferred
- * @publicapi
- */
 import { EventEmitter } from 'events';
 import { levels as LogLevels, LogLevelDesc } from 'loglevel';
 import AudioHelper from './audiohelper';

--- a/lib/twilio/dialtonePlayer.ts
+++ b/lib/twilio/dialtonePlayer.ts
@@ -1,9 +1,3 @@
-/**
- * @packageDocumentation
- * @module Tools
- * @internalapi
- */
-
 import { InvalidArgumentError } from './errors';
 
 /**

--- a/lib/twilio/errors/generated.ts
+++ b/lib/twilio/errors/generated.ts
@@ -1,11 +1,5 @@
 /* tslint:disable max-classes-per-file max-line-length */
 /**
- * @packageDocumentation
- * @module Voice
- * @internalapi
- */
-
-/**
  * This is a generated file. Any modifications here will be overwritten. See scripts/errors.js.
  */
 import TwilioError from './twilioError';

--- a/lib/twilio/errors/index.ts
+++ b/lib/twilio/errors/index.ts
@@ -1,7 +1,3 @@
-/**
- * @packageDocumentation
- * @internalapi
- */
 /* tslint:disable max-classes-per-file */
 
 /**

--- a/lib/twilio/errors/twilioError.ts
+++ b/lib/twilio/errors/twilioError.ts
@@ -1,11 +1,4 @@
 /**
- * @packageDocumentation
- * @module Voice
- * @publicapi
- * @internal
- */
-
-/**
  * Base class for all possible errors that the library can receive from the
  * Twilio backend.
  */

--- a/lib/twilio/eventpublisher.ts
+++ b/lib/twilio/eventpublisher.ts
@@ -1,8 +1,3 @@
-/**
- * @packageDocumentation
- * @module Voice
- * @internalapi
- */
 // @ts-nocheck
 import { EventEmitter } from 'events';
 import Log from './log';

--- a/lib/twilio/log.ts
+++ b/lib/twilio/log.ts
@@ -1,9 +1,3 @@
-/**
- * @packageDocumentation
- * @module Voice
- * @internalapi
- */
-
 import * as LogLevelModule from 'loglevel';
 import { PACKAGE_NAME } from './constants';
 

--- a/lib/twilio/outputdevicecollection.ts
+++ b/lib/twilio/outputdevicecollection.ts
@@ -1,7 +1,3 @@
-/**
- * @packageDocumentation
- * @module Voice
- */
 import { SOUNDS_BASE_URL } from './constants';
 import { InvalidArgumentError, InvalidStateError, NotSupportedError } from './errors';
 import Log from './log';

--- a/lib/twilio/preflight/preflight.ts
+++ b/lib/twilio/preflight/preflight.ts
@@ -1,9 +1,3 @@
-/**
- * @packageDocumentation
- * @module Voice
- * @preferred
- * @publicapi
- */
 import { EventEmitter } from 'events';
 import Call from '../call';
 import Device, { IExtendedDeviceOptions } from '../device';

--- a/lib/twilio/preflight/timing.ts
+++ b/lib/twilio/preflight/timing.ts
@@ -1,10 +1,4 @@
 /**
- * @packageDocumentation
- * @module Voice
- * @publicapi
- */
-
-/**
  * Timing measurements that provides operational milestones.
  */
 export interface TimeMeasurement {

--- a/lib/twilio/pstream.ts
+++ b/lib/twilio/pstream.ts
@@ -1,8 +1,3 @@
-/**
- * @packageDocumentation
- * @module Voice
- * @internalapi
- */
 // @ts-nocheck
 import { EventEmitter } from 'events';
 import * as C from './constants';

--- a/lib/twilio/regions.ts
+++ b/lib/twilio/regions.ts
@@ -1,8 +1,3 @@
-/**
- * @packageDocumentation
- * @module Voice
- * This module describes valid and deprecated regions.
- */
 import { InvalidArgumentError } from './errors';
 
 /**

--- a/lib/twilio/request.ts
+++ b/lib/twilio/request.ts
@@ -1,8 +1,3 @@
-/**
- * @packageDocumentation
- * @module Voice
- * @internalapi
- */
 // @ts-nocheck
 
 function request(method, params, callback) {

--- a/lib/twilio/rtc/getusermedia.ts
+++ b/lib/twilio/rtc/getusermedia.ts
@@ -1,8 +1,3 @@
-/**
- * @packageDocumentation
- * @module Voice
- * @internalapi
- */
 // @ts-nocheck
 import { NotSupportedError } from '../errors';
 import * as util from '../util';

--- a/lib/twilio/rtc/icecandidate.ts
+++ b/lib/twilio/rtc/icecandidate.ts
@@ -1,10 +1,4 @@
 /**
- * @packageDocumentation
- * @module Voice
- * @internalapi
- */
-
-/**
  * Payload object we send to insights
  * @private
  */

--- a/lib/twilio/rtc/index.ts
+++ b/lib/twilio/rtc/index.ts
@@ -1,8 +1,3 @@
-/**
- * @packageDocumentation
- * @module Voice
- * @internalapi
- */
 // @ts-nocheck
 import PeerConnection from './peerconnection';
 import RTCPC from './rtcpc';

--- a/lib/twilio/rtc/mockrtcstatsreport.ts
+++ b/lib/twilio/rtc/mockrtcstatsreport.ts
@@ -1,8 +1,3 @@
-/**
- * @packageDocumentation
- * @module Voice
- * @internalapi
- */
 // @ts-nocheck
 
 /**

--- a/lib/twilio/rtc/mos.ts
+++ b/lib/twilio/rtc/mos.ts
@@ -1,9 +1,3 @@
-/**
- * @packageDocumentation
- * @module Voice
- * @internalapi
- */
-
 const r0 = 94.768; // Constant used in computing "rFactor".
 
 /**

--- a/lib/twilio/rtc/peerconnection.ts
+++ b/lib/twilio/rtc/peerconnection.ts
@@ -1,8 +1,3 @@
-/**
- * @packageDocumentation
- * @module Voice
- * @internalapi
- */
 // @ts-nocheck
 import {
   InvalidArgumentError,

--- a/lib/twilio/rtc/rtcpc.ts
+++ b/lib/twilio/rtc/rtcpc.ts
@@ -1,8 +1,3 @@
-/**
- * @packageDocumentation
- * @module Voice
- * @internalapi
- */
 // @ts-nocheck
 // tslint:disable only-arrow-functions
 /* global webkitRTCPeerConnection, mozRTCPeerConnection, mozRTCSessionDescription, mozRTCIceCandidate */

--- a/lib/twilio/rtc/sample.ts
+++ b/lib/twilio/rtc/sample.ts
@@ -1,10 +1,4 @@
 /**
- * @packageDocumentation
- * @module Voice
- * @publicapi
- */
-
-/**
  * Sample RTC statistics. See [[Call.sampleEvent]]
  */
 export default interface RTCSample {

--- a/lib/twilio/rtc/sdp.ts
+++ b/lib/twilio/rtc/sdp.ts
@@ -1,8 +1,3 @@
-/**
- * @packageDocumentation
- * @module Voice
- * @internalapi
- */
 // @ts-nocheck
 import * as util from '../util';
 

--- a/lib/twilio/rtc/stats.ts
+++ b/lib/twilio/rtc/stats.ts
@@ -1,8 +1,3 @@
-/**
- * @packageDocumentation
- * @module Voice
- * @internalapi
- */
 // @ts-nocheck
 // tslint:disable no-empty
 import { InvalidArgumentError, NotSupportedError } from '../errors';

--- a/lib/twilio/rtc/warning.ts
+++ b/lib/twilio/rtc/warning.ts
@@ -1,8 +1,3 @@
-/**
- * @packageDocumentation
- * @module Voice
- * @publicapi
- */
 import RTCSample from './sample';
 
 /**

--- a/lib/twilio/shims/eventtarget.ts
+++ b/lib/twilio/shims/eventtarget.ts
@@ -1,8 +1,3 @@
-/**
- * @packageDocumentation
- * @module Voice
- * @internalapi
- */
 // @ts-nocheck
 
 import { EventEmitter } from 'events';

--- a/lib/twilio/shims/mediadeviceinfo.ts
+++ b/lib/twilio/shims/mediadeviceinfo.ts
@@ -1,8 +1,3 @@
-/**
- * @packageDocumentation
- * @module Voice
- * @internalapi
- */
 // @ts-nocheck
 class MediaDeviceInfoShim {
   constructor(options) {

--- a/lib/twilio/sound.ts
+++ b/lib/twilio/sound.ts
@@ -1,8 +1,3 @@
-/**
- * @packageDocumentation
- * @module Voice
- * @internalapi
- */
 // @ts-nocheck
 import { AsyncQueue } from './asyncQueue';
 import AudioPlayer from './audioplayer/audioplayer';

--- a/lib/twilio/statsMonitor.ts
+++ b/lib/twilio/statsMonitor.ts
@@ -1,9 +1,3 @@
-/**
- * @packageDocumentation
- * @module Voice
- * @internalapi
- */
-
 import { EventEmitter } from 'events';
 import { InvalidArgumentError } from './errors';
 import Mos from './rtc/mos';

--- a/lib/twilio/util.ts
+++ b/lib/twilio/util.ts
@@ -1,8 +1,3 @@
-/**
- * @packageDocumentation
- * @module Voice
- * @internalapi
- */
 // @ts-nocheck
 
 /**

--- a/lib/twilio/uuid.ts
+++ b/lib/twilio/uuid.ts
@@ -1,9 +1,3 @@
-/**
- * @packageDocumentation
- * @module Voice
- * @internalapi
- */
-
 import * as md5Lib from 'md5';
 import { NotSupportedError } from '../twilio/errors';
 

--- a/lib/twilio/wstransport.ts
+++ b/lib/twilio/wstransport.ts
@@ -1,9 +1,3 @@
-/**
- * @packageDocumentation
- * @module Tools
- * @internalapi
- */
-
 import { EventEmitter } from 'events';
 import Backoff from './backoff';
 import { SignalingErrors } from './errors';

--- a/scripts/errors.js
+++ b/scripts/errors.js
@@ -50,17 +50,7 @@ const USED_ERRORS = [
   'UserMediaErrors.AcquisitionFailedError',
 ];
 
-/**
- * VBLOCKS-4590: Consider removing the "@internalapi" tag from the generated
- * docs.
- */
 let output = `/* tslint:disable max-classes-per-file max-line-length */
-/**
- * @packageDocumentation
- * @module Voice
- * @internalapi
- */
-
 /**
  * This is a generated file. Any modifications here will be overwritten. See scripts/errors.js.
  */

--- a/templates/constants.ts
+++ b/templates/constants.ts
@@ -1,9 +1,3 @@
-/**
- * @packageDocumentation
- * @module Voice
- * @internalapi
- */
-
 const PACKAGE_NAME = '$packageName';
 const RELEASE_VERSION = '$version';
 const SOUNDS_BASE_URL = 'https://sdk.twilio.com/js/client/sounds/releases/1.0.0';


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [VBLOCKS-4596](https://twilio-engineering.atlassian.net/browse/VBLOCKS-4596)

### Description

This PR removes the unnecessary `packageDocumentation` headers at the top of each file since tsdocs no longer needs it.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [x] Updated affected documentation
* [x] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
