### PR TITLE
[VBLOCKS-4941] document unset input device

### DIFF
--- a/lib/twilio/audiohelper.ts
+++ b/lib/twilio/audiohelper.ts
@@ -578,7 +578,6 @@ class AudioHelper extends EventEmitter {
   /**
    * Replace the current input device with a new device by ID.
    *
-   * @remarks
    * Calling `setInputDevice` sets the stream for current and future calls and
    * will not release it automatically.
    *


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [VBLOCKS-4941](https://twilio-engineering.atlassian.net/browse/VBLOCKS-4941)

### Description

This PR documents usage of `unsetInputDevice` after using `setInputDevice` for some UX cases.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [x] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Squashed erroneous commits if necessary
* [ ] Re-tested if necessary
