### PR TITLE
[VBLOCKS-5062] feat: missing reconnecting insights event for signaling

### DIFF
--- a/lib/twilio/call.ts
+++ b/lib/twilio/call.ts
@@ -1500,6 +1500,7 @@ class Call extends EventEmitter {
     if (this._signalingReconnectToken) {
       this._status = Call.State.Reconnecting;
       this._signalingStatus = Call.State.Reconnecting;
+      this._publisher.info('connection', 'reconnecting', null, this);
       this._log.debug('#reconnecting');
       this.emit('reconnecting', new SignalingErrors.ConnectionDisconnected());
     } else {

--- a/tests/unit/call.ts
+++ b/tests/unit/call.ts
@@ -1654,6 +1654,18 @@ describe('Call', function() {
 
         assert(callback.calledOnce);
       });
+
+      it('should publish a reconnecting event if reconnectToken is set', () => {
+        publisher.info.reset();
+        conn = new Call(config, Object.assign({
+          callParameters: { CallSid: 'CA123' },
+          reconnectToken: 'testReconnectToken',
+        }, options));
+
+        pstream.emit('transportClose');
+
+        sinon.assert.calledWith(publisher.info, 'connection', 'reconnecting');
+      });
     });
 
     describe('pstream.cancel event', () => {


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

https://twilio-engineering.atlassian.net/browse/VBLOCKS-5062

- Adds missing reconnecting insights event for signaling.

### Description

A description of what this PR does.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review
