### PR TITLE
Fix `package-lock.json` for Rollup RC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,14 +13,14 @@
         "@types/events": "^3.0.3",
         "events": "3.3.0",
         "loglevel": "1.6.7",
-        "tslib": "^2.8.1"
+        "tslib": "2.8.1"
       },
       "devDependencies": {
         "@datadog/datadog-ci": "3.2.0",
         "@ngrok/ngrok": "1.2.0",
-        "@rollup/plugin-commonjs": "^28.0.6",
-        "@rollup/plugin-node-resolve": "^16.0.1",
-        "@rollup/plugin-typescript": "^12.1.4",
+        "@rollup/plugin-commonjs": "28.0.6",
+        "@rollup/plugin-node-resolve": "16.0.1",
+        "@rollup/plugin-typescript": "12.1.4",
         "@types/mime": "3.0.0",
         "@types/mocha": "5.2.7",
         "@types/node": "22.15.3",
@@ -49,7 +49,7 @@
         "pre-commit": "1.2.2",
         "puppeteer": "24.16.2",
         "renamer": "4.0.0",
-        "rollup": "^4.46.3",
+        "rollup": "4.46.3",
         "sinon": "9.0.3",
         "ts-node": "10.9.2",
         "tslint": "6.1.3",


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

This PR fixes missing changes from the packagelock file that is preventing the RC from being cut properly.

### Description

Add `package-lock.json` changes.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review
