### PR TITLE
[VBLOCKS-5243] fix: import and require paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
     "node": ">= 12"
   },
   "exports": {
-    ".": "./es5/twilio.js",
-    "./esm": "./esm/index.js"
+    ".": {
+      "import": "./esm/index.js",
+      "require": "./es5/index.js"
+    }
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

This PR fixes the import paths such that `require` uses our `es5` build and `import` uses the `esm` build and `esm` support is baked into the default import path.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review
