### PR TITLE
[VBLOCKS-6473] fix: typedoc

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -25,5 +25,6 @@ server.js
 templates
 tests
 tslint.json
+tsconfig.docs.json
 typedoc.json
 reports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Bug Fixes
 ---------
 
 - Fixed an issue where multiple PeerConnections are created when `device.connect()` is called multiple times.
+- Fixed an issue where the `docs:ts` build fails when the repository is inside a monorepo or workspace due to TypeDoc picking up conflicting `@types` from parent `node_modules`. Thanks @taf2 for your [contribution](https://github.com/twilio/twilio-voice.js/pull/416).
 
 2.18.1 (March 17, 2026)
 =======================

--- a/tsconfig.docs.json
+++ b/tsconfig.docs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "target": "es2015",
+    "typeRoots": ["./node_modules/@types"]
+  }
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,4 +1,5 @@
 {
+  "tsconfig": "./tsconfig.docs.json",
   "entryPoints": ["lib/twilio.ts"],
   "excludePrivate": true,
   "excludeProtected": true,


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

https://twilio-engineering.atlassian.net/browse/VBLOCKS-6473

### Description

  1. tsconfig.docs.json (new) — extends tsconfig.json with target: "es2015" and typeRoots scoped to local node_modules/@types
  2. typedoc.json — added "tsconfig": "./tsconfig.docs.json" so both docs:ts and docs:json use the isolated config
  3. .npmignore — added tsconfig.docs.json exclusion
  4. CHANGELOG.md — added entry under 2.18.2
## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Ready for review
