### PR TITLE
[VBLOCKS-6374] feat: call signaling methods and events

### DIFF
--- a/lib/twilio/signaling/sipsignalingadapter.ts
+++ b/lib/twilio/signaling/sipsignalingadapter.ts
@@ -2,10 +2,12 @@ import { EventEmitter } from 'events';
 import {
   Invitation,
   Inviter,
+  InviterOptions,
   Registerer,
   RegistererState,
   Session,
   SessionState,
+  URI,
   UserAgent,
 } from 'sip.js';
 import Log from '../log';
@@ -31,7 +33,7 @@ export interface SipSignalingAdapterOptions {
   /**
    * Factory override for testing.
    */
-  createInviter?: (userAgent: UserAgent, targetURI: any, options?: any) => Inviter;
+  createInviter?: (userAgent: UserAgent, targetURI: URI, options?: InviterOptions) => Inviter;
 }
 
 /**
@@ -64,11 +66,11 @@ function createNoOpSDH(): any {
 export class SipSignalingAdapter extends EventEmitter implements SignalingAdapter {
   private _log: Log = new Log('SipSignalingAdapter');
   private _options: SipSignalingAdapterOptions;
-  private _outboundCallSids: Set<string> = new Set();
+  private _inboundSessions: Map<string, Invitation> = new Map();
+  private _outboundSessions: Map<string, Inviter> = new Map();
   private _pendingInvitations: Map<string, Invitation> = new Map();
   private _registerer: any | null = null;
   private _region: string | undefined;
-  private _sessions: Map<string, Session> = new Map();
   private _status: SignalingAdapterStatus = 'disconnected';
   private _token: string = '';
   private _uri: string;
@@ -207,16 +209,18 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
   destroy(): void {
     this._log.info('Destroying SipSignalingAdapter');
 
-    this._sessions.forEach((session) => {
+    const byeEstablished = (session: Session) => {
       if (session.state === SessionState.Established) {
         session.bye().catch((error: Error) => {
           this._log.warn('Error sending BYE during destroy', error);
         });
       }
-    });
-    this._sessions.clear();
+    };
+    this._inboundSessions.forEach(byeEstablished);
+    this._outboundSessions.forEach(byeEstablished);
+    this._inboundSessions.clear();
+    this._outboundSessions.clear();
     this._pendingInvitations.clear();
-    this._outboundCallSids.clear();
 
     if (this._registerer) {
       this._registerer.dispose().catch((error: Error) => {
@@ -259,7 +263,7 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
       return;
     }
     this._pendingInvitations.delete(callSid);
-    this._sessions.set(callSid, invitation);
+    this._inboundSessions.set(callSid, invitation);
     invitation.accept().catch((error: Error) => {
       this._log.error('Failed to accept invitation', error);
       this.emit('error', { error: { code: 31000, message: error.message }, callsid: callSid });
@@ -267,42 +271,19 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
   }
 
   hangup(callSid: string, _message?: string | null): void {
-    const invitation = this._pendingInvitations.get(callSid);
-    if (invitation) {
-      this._pendingInvitations.delete(callSid);
-      invitation.reject().catch((error: Error) => {
-        this._log.error('Failed to reject invitation during hangup', error);
-        this.emit('error', { error: { code: 31000, message: error.message }, callsid: callSid });
-      });
-      return;
+    if (this._pendingInvitations.has(callSid)) {
+      return this._hangupPendingInvitation(callSid);
     }
 
-    const session = this._sessions.get(callSid);
-    if (!session) {
-      this._log.warn('hangup: no session for callSid', callSid);
-      return;
+    if (this._outboundSessions.has(callSid)) {
+      return this._hangupOutboundSession(callSid);
     }
-    this._sessions.delete(callSid);
 
-    if (session.state === SessionState.Established) {
-      session.bye().catch((error: Error) => {
-        this._log.error('Failed to send BYE', error);
-        this.emit('error', { error: { code: 31000, message: error.message }, callsid: callSid });
-      });
-    } else if (session.state === SessionState.Initial || session.state === SessionState.Establishing) {
-      if (this._outboundCallSids.has(callSid)) {
-        (session as Inviter).cancel().catch((error: Error) => {
-          this._log.error('Failed to cancel outgoing call', error);
-          this.emit('error', { error: { code: 31000, message: error.message }, callsid: callSid });
-        });
-      } else {
-        (session as Invitation).reject().catch((error: Error) => {
-          this._log.error('Failed to reject invitation during hangup', error);
-          this.emit('error', { error: { code: 31000, message: error.message }, callsid: callSid });
-        });
-      }
+    if (this._inboundSessions.has(callSid)) {
+      return this._hangupInboundSession(callSid);
     }
-    this._outboundCallSids.delete(callSid);
+
+    this._log.warn('hangup: no session for callSid', callSid);
   }
 
   reject(callSid: string): void {
@@ -319,7 +300,7 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
   }
 
   reinvite(sdp: string, callSid: string): void {
-    const session = this._sessions.get(callSid);
+    const session = this._getSession(callSid);
     if (!session || session.state !== SessionState.Established) {
       this._log.warn('reinvite: no established session for callSid', callSid);
       return;
@@ -343,12 +324,12 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
   }
 
   dtmf(callSid: string, digits: string): void {
-    const session = this._sessions.get(callSid);
+    const session = this._getSession(callSid);
     if (!session || session.state !== SessionState.Established) {
       this._log.warn('dtmf: no established session for callSid', callSid);
       return;
     }
-    const sendDigit = async () => {
+    const sendDigits = async () => {
       for (const digit of digits) {
         try {
           await session.info({
@@ -365,7 +346,7 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
         }
       }
     };
-    sendDigit();
+    sendDigits();
   }
 
   sendMessage(
@@ -375,7 +356,7 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
     _messageType: string,
     voiceEventSid: string,
   ): void {
-    const session = this._sessions.get(callSid);
+    const session = this._getSession(callSid);
     if (!session || session.state !== SessionState.Established) {
       this._log.warn('sendMessage: no established session for callSid', callSid);
       return;
@@ -404,27 +385,81 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
   // Private helpers
   // ---------------------------------------------------------------------------
 
+  private _hangupPendingInvitation(callSid: string): void {
+    const invitation = this._pendingInvitations.get(callSid)!;
+    this._pendingInvitations.delete(callSid);
+    invitation.reject().catch((error: Error) => {
+      this._log.error('Failed to reject invitation during hangup', error);
+      this.emit('error', { error: { code: 31000, message: error.message }, callsid: callSid });
+    });
+  }
+
+  private _hangupOutboundSession(callSid: string): void {
+    const session = this._outboundSessions.get(callSid)!;
+    this._outboundSessions.delete(callSid);
+
+    if (session.state === SessionState.Established) {
+      session.bye().catch((error: Error) => {
+        this._log.error('Failed to send BYE', error);
+        this.emit('error', { error: { code: 31000, message: error.message }, callsid: callSid });
+      });
+    } else if (session.state === SessionState.Initial || session.state === SessionState.Establishing) {
+      session.cancel().catch((error: Error) => {
+        this._log.error('Failed to cancel outgoing call', error);
+        this.emit('error', { error: { code: 31000, message: error.message }, callsid: callSid });
+      });
+    }
+  }
+
+  private _hangupInboundSession(callSid: string): void {
+    const session = this._inboundSessions.get(callSid)!;
+    this._inboundSessions.delete(callSid);
+
+    if (session.state === SessionState.Established) {
+      session.bye().catch((error: Error) => {
+        this._log.error('Failed to send BYE', error);
+        this.emit('error', { error: { code: 31000, message: error.message }, callsid: callSid });
+      });
+    } else if (session.state === SessionState.Initial || session.state === SessionState.Establishing) {
+      session.reject().catch((error: Error) => {
+        this._log.error('Failed to reject invitation during hangup', error);
+        this.emit('error', { error: { code: 31000, message: error.message }, callsid: callSid });
+      });
+    }
+  }
+
+  private _getSession(callSid: string): Session | undefined {
+    return this._outboundSessions.get(callSid) || this._inboundSessions.get(callSid);
+  }
+
   private _handleIncomingInvite(invitation: Invitation): void {
-    const callSid = invitation.id;
+    const callSid = invitation.request.getHeader('X-Twilio-CallSid');
+    if (!callSid) {
+      this._log.error('Incoming INVITE missing X-Twilio-CallSid header');
+      invitation.reject().catch((error: Error) => {
+        this._log.error('Failed to reject invitation missing CallSid', error);
+      });
+      return;
+    }
     this._pendingInvitations.set(callSid, invitation);
 
-    invitation.delegate = {
-      ...invitation.delegate,
-      onCancel: () => {
-        this._pendingInvitations.delete(callSid);
-        this._sessions.delete(callSid);
-        this.emit('cancel', { callsid: callSid });
-      },
-      onBye: () => {
-        this._sessions.delete(callSid);
-        this.emit('hangup', { callsid: callSid });
-      },
+    if (!invitation.delegate) {
+      invitation.delegate = {};
+    }
+    invitation.delegate.onCancel = () => {
+      this._pendingInvitations.delete(callSid);
+      this._inboundSessions.delete(callSid);
+      this.emit('cancel', { callsid: callSid });
+    };
+    invitation.delegate.onBye = () => {
+      this._inboundSessions.delete(callSid);
+      this.emit('hangup', { callsid: callSid });
     };
 
     invitation.stateChange.addListener((state: SessionState) => {
       if (state === SessionState.Terminated) {
         this._pendingInvitations.delete(callSid);
-        this._sessions.delete(callSid);
+        this._inboundSessions.delete(callSid);
       }
     });
 
@@ -452,24 +487,21 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
     }
 
     const createInv = this._options.createInviter
-      || ((ua: UserAgent, uri: any, opts?: any) => new Inviter(ua, uri, opts));
+      || ((ua: UserAgent, uri: URI, opts?: InviterOptions) => new Inviter(ua, uri, opts));
     const inviter = createInv(this._userAgent, targetUri);
 
-    this._sessions.set(callSid, inviter);
-    this._outboundCallSids.add(callSid);
+    this._outboundSessions.set(callSid, inviter);
 
     inviter.delegate = {
       onBye: () => {
-        this._sessions.delete(callSid);
-        this._outboundCallSids.delete(callSid);
+        this._outboundSessions.delete(callSid);
         this.emit('hangup', { callsid: callSid });
       },
     };
 
     inviter.stateChange.addListener((state: SessionState) => {
       if (state === SessionState.Terminated) {
-        this._sessions.delete(callSid);
-        this._outboundCallSids.delete(callSid);
+        this._outboundSessions.delete(callSid);
       }
     });
 
@@ -488,15 +520,13 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
         onReject: (response: any) => {
           const code = response?.message?.statusCode || 31000;
           const message = response?.message?.reasonPhrase || 'Call rejected';
-          this._sessions.delete(callSid);
-          this._outboundCallSids.delete(callSid);
+          this._outboundSessions.delete(callSid);
           this.emit('hangup', { callsid: callSid, error: { code, message } });
         },
       },
     }).catch((error: Error) => {
       this._log.error('Failed to send INVITE', error);
-      this._sessions.delete(callSid);
-      this._outboundCallSids.delete(callSid);
+      this._outboundSessions.delete(callSid);
       this.emit('error', { error: { code: 31000, message: error.message }, callsid: callSid });
     });
   }
@@ -518,9 +548,9 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
   private _onTransportDisconnect(error?: Error): void {
     this._log.info('WebSocket disconnected', error?.message);
 
-    this._sessions.clear();
+    this._inboundSessions.clear();
+    this._outboundSessions.clear();
     this._pendingInvitations.clear();
-    this._outboundCallSids.clear();
 
     if (this._registerer) {
       this._registerer.dispose().catch((err: Error) => {

--- a/lib/twilio/signaling/sipsignalingadapter.ts
+++ b/lib/twilio/signaling/sipsignalingadapter.ts
@@ -271,16 +271,19 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
   }
 
   hangup(callSid: string, _message?: string | null): void {
-    if (this._pendingInvitations.has(callSid)) {
-      return this._hangupPendingInvitation(callSid);
+    const pendingInvitation = this._pendingInvitations.get(callSid);
+    if (pendingInvitation) {
+      return this._hangupPendingInvitation(pendingInvitation, callSid);
     }
 
-    if (this._outboundSessions.has(callSid)) {
-      return this._hangupOutboundSession(callSid);
+    const outboundSession = this._outboundSessions.get(callSid);
+    if (outboundSession) {
+      return this._hangupOutboundSession(outboundSession, callSid);
     }
 
-    if (this._inboundSessions.has(callSid)) {
-      return this._hangupInboundSession(callSid);
+    const inboundSession = this._inboundSessions.get(callSid);
+    if (inboundSession) {
+      return this._hangupInboundSession(inboundSession, callSid);
     }
 
     this._log.warn('hangup: no session for callSid', callSid);
@@ -385,8 +388,7 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
   // Private helpers
   // ---------------------------------------------------------------------------
 
-  private _hangupPendingInvitation(callSid: string): void {
-    const invitation = this._pendingInvitations.get(callSid)!;
+  private _hangupPendingInvitation(invitation: Invitation, callSid: string): void {
     this._pendingInvitations.delete(callSid);
     invitation.reject().catch((error: Error) => {
       this._log.error('Failed to reject invitation during hangup', error);
@@ -394,37 +396,59 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
     });
   }
 
-  private _hangupOutboundSession(callSid: string): void {
-    const session = this._outboundSessions.get(callSid)!;
+  private _hangupOutboundSession(session: Inviter, callSid: string): void {
     this._outboundSessions.delete(callSid);
 
-    if (session.state === SessionState.Established) {
-      session.bye().catch((error: Error) => {
-        this._log.error('Failed to send BYE', error);
-        this.emit('error', { error: { code: 31000, message: error.message }, callsid: callSid });
-      });
-    } else if (session.state === SessionState.Initial || session.state === SessionState.Establishing) {
-      session.cancel().catch((error: Error) => {
-        this._log.error('Failed to cancel outgoing call', error);
-        this.emit('error', { error: { code: 31000, message: error.message }, callsid: callSid });
-      });
+    switch (session.state) {
+      case SessionState.Established:
+        session.bye().catch((error: Error) => {
+          this._log.error('Failed to send BYE', error);
+          this.emit('error', { error: { code: 31000, message: error.message }, callsid: callSid });
+        });
+        return;
+      case SessionState.Initial:
+      case SessionState.Establishing:
+        session.cancel().catch((error: Error) => {
+          this._log.error('Failed to cancel outgoing call', error);
+          this.emit('error', { error: { code: 31000, message: error.message }, callsid: callSid });
+        });
+        return;
+      case SessionState.Terminating:
+      case SessionState.Terminated:
+        this._log.debug('_hangupOutboundSession: session already ending', session.state);
+        return;
+      default: {
+        const _exhaustive: never = session.state;
+        this._log.warn('_hangupOutboundSession: unexpected session state', _exhaustive);
+      }
     }
   }
 
-  private _hangupInboundSession(callSid: string): void {
-    const session = this._inboundSessions.get(callSid)!;
+  private _hangupInboundSession(session: Invitation, callSid: string): void {
     this._inboundSessions.delete(callSid);
 
-    if (session.state === SessionState.Established) {
-      session.bye().catch((error: Error) => {
-        this._log.error('Failed to send BYE', error);
-        this.emit('error', { error: { code: 31000, message: error.message }, callsid: callSid });
-      });
-    } else if (session.state === SessionState.Initial || session.state === SessionState.Establishing) {
-      session.reject().catch((error: Error) => {
-        this._log.error('Failed to reject invitation during hangup', error);
-        this.emit('error', { error: { code: 31000, message: error.message }, callsid: callSid });
-      });
+    switch (session.state) {
+      case SessionState.Established:
+        session.bye().catch((error: Error) => {
+          this._log.error('Failed to send BYE', error);
+          this.emit('error', { error: { code: 31000, message: error.message }, callsid: callSid });
+        });
+        return;
+      case SessionState.Initial:
+      case SessionState.Establishing:
+        session.reject().catch((error: Error) => {
+          this._log.error('Failed to reject invitation during hangup', error);
+          this.emit('error', { error: { code: 31000, message: error.message }, callsid: callSid });
+        });
+        return;
+      case SessionState.Terminating:
+      case SessionState.Terminated:
+        this._log.debug('_hangupInboundSession: session already ending', session.state);
+        return;
+      default: {
+        const _exhaustive: never = session.state;
+        this._log.warn('_hangupInboundSession: unexpected session state', _exhaustive);
+      }
     }
   }
 

--- a/lib/twilio/signaling/sipsignalingadapter.ts
+++ b/lib/twilio/signaling/sipsignalingadapter.ts
@@ -353,7 +353,7 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
     callSid: string,
     content: string,
     contentType: string | undefined,
-    _messageType: string,
+    _messageType: string, // PStream-specific; no SIP MESSAGE equivalent
     voiceEventSid: string,
   ): void {
     const session = this._getSession(callSid);

--- a/lib/twilio/signaling/sipsignalingadapter.ts
+++ b/lib/twilio/signaling/sipsignalingadapter.ts
@@ -1,10 +1,13 @@
 import { EventEmitter } from 'events';
 import {
+  Invitation,
+  Inviter,
   Registerer,
   RegistererState,
+  Session,
+  SessionState,
   UserAgent,
 } from 'sip.js';
-import { NotSupportedError } from '../errors';
 import Log from '../log';
 import { SignalingAdapter, SignalingAdapterStatus } from './signalingadapter';
 
@@ -25,12 +28,18 @@ export interface SipSignalingAdapterOptions {
    * Factory override for testing.
    */
   createRegisterer?: (userAgent: UserAgent) => Registerer;
+  /**
+   * Factory override for testing.
+   */
+  createInviter?: (userAgent: UserAgent, targetURI: any, options?: any) => Inviter;
 }
 
 /**
- * A no-op SessionDescriptionHandler for SIP.js. Call signaling is not yet
- * implemented in this ticket (VBLOCKS-6374), so this stub satisfies the
- * SIP.js SDH interface without doing any real media work.
+ * A no-op SessionDescriptionHandler for SIP.js. SDP relay through
+ * SIP.js is deferred to VBLOCKS-6372 (SipSessionDescriptionHandler).
+ * This stub satisfies the SIP.js SDH interface without doing any
+ * real media work — actual SDP exchange is handled out-of-band by
+ * PeerConnection via Call.ts.
  */
 function createNoOpSDH(): any {
   return {
@@ -49,14 +58,17 @@ function createNoOpSDH(): any {
 
 /**
  * SignalingAdapter implementation backed by SIP.js. Handles WebSocket
- * connection and SIP registration lifecycle. Call-level signaling methods
- * are not yet implemented (VBLOCKS-6374).
+ * connection, SIP registration lifecycle, and call-level signaling
+ * (INVITE, BYE, re-INVITE, INFO, MESSAGE).
  */
 export class SipSignalingAdapter extends EventEmitter implements SignalingAdapter {
   private _log: Log = new Log('SipSignalingAdapter');
   private _options: SipSignalingAdapterOptions;
+  private _outboundCallSids: Set<string> = new Set();
+  private _pendingInvitations: Map<string, Invitation> = new Map();
   private _registerer: any | null = null;
   private _region: string | undefined;
+  private _sessions: Map<string, Session> = new Map();
   private _status: SignalingAdapterStatus = 'disconnected';
   private _token: string = '';
   private _uri: string;
@@ -87,9 +99,7 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
       delegate: {
         onConnect: () => this._onTransportConnect(),
         onDisconnect: (error?: Error) => this._onTransportDisconnect(error),
-        onInvite: () => {
-          this._log.warn('Received incoming INVITE but call signaling is not yet implemented (VBLOCKS-6374)');
-        },
+        onInvite: (invitation: Invitation) => this._handleIncomingInvite(invitation),
       },
     });
 
@@ -197,6 +207,17 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
   destroy(): void {
     this._log.info('Destroying SipSignalingAdapter');
 
+    this._sessions.forEach((session) => {
+      if (session.state === SessionState.Established) {
+        session.bye().catch((error: Error) => {
+          this._log.warn('Error sending BYE during destroy', error);
+        });
+      }
+    });
+    this._sessions.clear();
+    this._pendingInvitations.clear();
+    this._outboundCallSids.clear();
+
     if (this._registerer) {
       this._registerer.dispose().catch((error: Error) => {
         this._log.warn('Error disposing registerer during destroy', error);
@@ -224,50 +245,257 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
   }
 
   // ---------------------------------------------------------------------------
-  // Call signaling — not yet implemented (VBLOCKS-6374)
+  // Call signaling
   // ---------------------------------------------------------------------------
 
-  invite(_sdp: string, _callSid: string, _params: string): void {
-    throw new NotSupportedError('SIP call signaling is not yet implemented (VBLOCKS-6374)');
+  invite(sdp: string, callSid: string, params: string): void {
+    this._sendInvite(sdp, callSid, params);
   }
 
-  answer(_sdp: string, _callSid: string): void {
-    throw new NotSupportedError('SIP call signaling is not yet implemented (VBLOCKS-6374)');
+  answer(sdp: string, callSid: string): void {
+    const invitation = this._pendingInvitations.get(callSid);
+    if (!invitation) {
+      this._log.warn('answer: no pending invitation for callSid', callSid);
+      return;
+    }
+    this._pendingInvitations.delete(callSid);
+    this._sessions.set(callSid, invitation);
+    invitation.accept().catch((error: Error) => {
+      this._log.error('Failed to accept invitation', error);
+      this.emit('error', { error: { code: 31000, message: error.message }, callsid: callSid });
+    });
   }
 
-  hangup(_callSid: string, _message?: string | null): void {
-    throw new NotSupportedError('SIP call signaling is not yet implemented (VBLOCKS-6374)');
+  hangup(callSid: string, _message?: string | null): void {
+    const invitation = this._pendingInvitations.get(callSid);
+    if (invitation) {
+      this._pendingInvitations.delete(callSid);
+      invitation.reject().catch((error: Error) => {
+        this._log.warn('Failed to reject invitation during hangup', error);
+      });
+      return;
+    }
+
+    const session = this._sessions.get(callSid);
+    if (!session) {
+      this._log.warn('hangup: no session for callSid', callSid);
+      return;
+    }
+    this._sessions.delete(callSid);
+
+    if (session.state === SessionState.Established) {
+      session.bye().catch((error: Error) => {
+        this._log.warn('Failed to send BYE', error);
+      });
+    } else if (session.state === SessionState.Initial || session.state === SessionState.Establishing) {
+      if (this._outboundCallSids.has(callSid)) {
+        (session as Inviter).cancel().catch((error: Error) => {
+          this._log.warn('Failed to cancel outgoing call', error);
+        });
+      } else {
+        (session as unknown as Invitation).reject().catch((error: Error) => {
+          this._log.warn('Failed to reject invitation during hangup', error);
+        });
+      }
+    }
+    this._outboundCallSids.delete(callSid);
   }
 
-  reject(_callSid: string): void {
-    throw new NotSupportedError('SIP call signaling is not yet implemented (VBLOCKS-6374)');
+  reject(callSid: string): void {
+    const invitation = this._pendingInvitations.get(callSid);
+    if (!invitation) {
+      this._log.warn('reject: no pending invitation for callSid', callSid);
+      return;
+    }
+    this._pendingInvitations.delete(callSid);
+    invitation.reject().catch((error: Error) => {
+      this._log.error('Failed to reject invitation', error);
+      this.emit('error', { error: { code: 31000, message: error.message }, callsid: callSid });
+    });
   }
 
-  reinvite(_sdp: string, _callSid: string): void {
-    throw new NotSupportedError('SIP call signaling is not yet implemented (VBLOCKS-6374)');
+  reinvite(sdp: string, callSid: string): void {
+    const session = this._sessions.get(callSid);
+    if (!session || session.state !== SessionState.Established) {
+      this._log.warn('reinvite: no established session for callSid', callSid);
+      return;
+    }
+    session.invite({
+      requestDelegate: {
+        onAccept: () => {
+          this.emit('answer', { callsid: callSid, sdp: '' });
+        },
+        onReject: (response: any) => {
+          this._log.warn('re-INVITE rejected', response?.message?.statusCode);
+        },
+      },
+    }).catch((error: Error) => {
+      this._log.warn('Failed to send re-INVITE', error);
+    });
   }
 
-  reconnect(_sdp: string, _callSid: string, _reconnectToken: string): void {
-    throw new NotSupportedError('SIP call signaling is not yet implemented (VBLOCKS-6374)');
+  reconnect(sdp: string, callSid: string, reconnectToken: string): void {
+    this._sendInvite(sdp, callSid, undefined, reconnectToken);
   }
 
-  dtmf(_callSid: string, _digits: string): void {
-    throw new NotSupportedError('SIP call signaling is not yet implemented (VBLOCKS-6374)');
+  dtmf(callSid: string, digits: string): void {
+    const session = this._sessions.get(callSid);
+    if (!session || session.state !== SessionState.Established) {
+      this._log.warn('dtmf: no established session for callSid', callSid);
+      return;
+    }
+    const sendDigit = async () => {
+      for (const digit of digits) {
+        try {
+          await session.info({
+            requestOptions: {
+              body: {
+                contentDisposition: 'render',
+                contentType: 'application/dtmf-relay',
+                content: `Signal=${digit}\r\nDuration=100\r\n`,
+              },
+            },
+          });
+        } catch (error: any) {
+          this._log.warn('Failed to send DTMF digit', digit, error?.message);
+        }
+      }
+    };
+    sendDigit();
   }
 
   sendMessage(
-    _callSid: string,
-    _content: string,
-    _contentType: string | undefined,
+    callSid: string,
+    content: string,
+    contentType: string | undefined,
     _messageType: string,
-    _voiceEventSid: string,
+    voiceEventSid: string,
   ): void {
-    throw new NotSupportedError('SIP call signaling is not yet implemented (VBLOCKS-6374)');
+    const session = this._sessions.get(callSid);
+    if (!session) {
+      this._log.warn('sendMessage: no session for callSid', callSid);
+      return;
+    }
+    session.message({
+      requestOptions: {
+        body: {
+          contentDisposition: 'render',
+          contentType: contentType || 'application/json',
+          content,
+        },
+      },
+    }).then(() => {
+      this.emit('ack', { acktype: 'message', callsid: callSid, voiceeventsid: voiceEventSid });
+    }).catch((error: Error) => {
+      this._log.error('Failed to send message', error);
+      this.emit('error', {
+        error: { code: 31000, message: error.message },
+        callsid: callSid,
+        voiceeventsid: voiceEventSid,
+      });
+    });
   }
 
   // ---------------------------------------------------------------------------
   // Private helpers
   // ---------------------------------------------------------------------------
+
+  private _handleIncomingInvite(invitation: Invitation): void {
+    const callSid = invitation.id;
+    this._pendingInvitations.set(callSid, invitation);
+
+    invitation.delegate = {
+      ...invitation.delegate,
+      onCancel: () => {
+        this._pendingInvitations.delete(callSid);
+        this._sessions.delete(callSid);
+        this.emit('cancel', { callsid: callSid });
+      },
+      onBye: () => {
+        this._sessions.delete(callSid);
+        this.emit('hangup', { callsid: callSid });
+      },
+    };
+
+    invitation.stateChange.addListener((state: SessionState) => {
+      if (state === SessionState.Terminated) {
+        this._pendingInvitations.delete(callSid);
+        this._sessions.delete(callSid);
+      }
+    });
+
+    this.emit('invite', {
+      callsid: callSid,
+      sdp: invitation.body || '',
+      parameters: {
+        CallSid: callSid,
+        From: invitation.remoteIdentity.uri.toString(),
+      },
+    });
+  }
+
+  private _sendInvite(sdp: string, callSid: string, params?: string, reconnectToken?: string): void {
+    if (!this._userAgent) {
+      this._log.warn('Cannot invite: UserAgent not initialized');
+      return;
+    }
+
+    const targetUri = UserAgent.makeURI(`sip:${this._options.sipDomain}`);
+    if (!targetUri) {
+      this._log.error('Failed to create target URI for invite');
+      this.emit('error', { error: { code: 31000, message: 'Invalid SIP target URI' }, callsid: callSid });
+      return;
+    }
+
+    const createInv = this._options.createInviter
+      || ((ua: UserAgent, uri: any, opts?: any) => new Inviter(ua, uri, opts));
+    const inviter = createInv(this._userAgent, targetUri);
+
+    this._sessions.set(callSid, inviter);
+    this._outboundCallSids.add(callSid);
+
+    inviter.delegate = {
+      onBye: () => {
+        this._sessions.delete(callSid);
+        this._outboundCallSids.delete(callSid);
+        this.emit('hangup', { callsid: callSid });
+      },
+    };
+
+    inviter.stateChange.addListener((state: SessionState) => {
+      if (state === SessionState.Terminated) {
+        this._sessions.delete(callSid);
+        this._outboundCallSids.delete(callSid);
+      }
+    });
+
+    inviter.invite({
+      requestDelegate: {
+        onProgress: () => {
+          this.emit('ringing', { callsid: callSid });
+        },
+        onAccept: () => {
+          const payload: Record<string, any> = { callsid: callSid, sdp: '' };
+          if (reconnectToken) {
+            payload.reconnect = reconnectToken;
+          }
+          this.emit('answer', payload);
+        },
+        onReject: (response: any) => {
+          const code = response?.message?.statusCode || 31000;
+          const message = response?.message?.reasonPhrase || 'Call rejected';
+          this._sessions.delete(callSid);
+          this._outboundCallSids.delete(callSid);
+          this.emit('hangup', { callsid: callSid, error: { code, message } });
+        },
+      },
+    }).catch((error: Error) => {
+      this._log.error('Failed to send INVITE', error);
+      this._sessions.delete(callSid);
+      this._outboundCallSids.delete(callSid);
+      this.emit('error', { error: { code: 31000, message: error.message }, callsid: callSid });
+    });
+  }
 
   private _onTransportConnect(): void {
     this._log.info('WebSocket connected');
@@ -285,6 +513,10 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
 
   private _onTransportDisconnect(error?: Error): void {
     this._log.info('WebSocket disconnected', error?.message);
+
+    this._sessions.clear();
+    this._pendingInvitations.clear();
+    this._outboundCallSids.clear();
 
     if (this._registerer) {
       this._registerer.dispose().catch((err: Error) => {

--- a/lib/twilio/signaling/sipsignalingadapter.ts
+++ b/lib/twilio/signaling/sipsignalingadapter.ts
@@ -271,7 +271,8 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
     if (invitation) {
       this._pendingInvitations.delete(callSid);
       invitation.reject().catch((error: Error) => {
-        this._log.warn('Failed to reject invitation during hangup', error);
+        this._log.error('Failed to reject invitation during hangup', error);
+        this.emit('error', { error: { code: 31000, message: error.message }, callsid: callSid });
       });
       return;
     }
@@ -285,16 +286,19 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
 
     if (session.state === SessionState.Established) {
       session.bye().catch((error: Error) => {
-        this._log.warn('Failed to send BYE', error);
+        this._log.error('Failed to send BYE', error);
+        this.emit('error', { error: { code: 31000, message: error.message }, callsid: callSid });
       });
     } else if (session.state === SessionState.Initial || session.state === SessionState.Establishing) {
       if (this._outboundCallSids.has(callSid)) {
         (session as Inviter).cancel().catch((error: Error) => {
-          this._log.warn('Failed to cancel outgoing call', error);
+          this._log.error('Failed to cancel outgoing call', error);
+          this.emit('error', { error: { code: 31000, message: error.message }, callsid: callSid });
         });
       } else {
-        (session as unknown as Invitation).reject().catch((error: Error) => {
-          this._log.warn('Failed to reject invitation during hangup', error);
+        (session as Invitation).reject().catch((error: Error) => {
+          this._log.error('Failed to reject invitation during hangup', error);
+          this.emit('error', { error: { code: 31000, message: error.message }, callsid: callSid });
         });
       }
     }
@@ -372,8 +376,8 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
     voiceEventSid: string,
   ): void {
     const session = this._sessions.get(callSid);
-    if (!session) {
-      this._log.warn('sendMessage: no session for callSid', callSid);
+    if (!session || session.state !== SessionState.Established) {
+      this._log.warn('sendMessage: no established session for callSid', callSid);
       return;
     }
     session.message({

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -1913,7 +1913,8 @@ describe('Device', function() {
               const stub = sinon.stub();
               device['_audio']!['_updateUserOptions'] = stub;
               device['_setupAudioHelper']();
-              assert.deepEqual(stub.getCall(0).args[0].beforeSetInputDevice(), Promise.resolve());
+              const result = await stub.getCall(0).args[0].beforeSetInputDevice();
+              assert.strictEqual(result, undefined);
             });
           });
 

--- a/tests/unit/sipsignalingadapter.ts
+++ b/tests/unit/sipsignalingadapter.ts
@@ -1,10 +1,9 @@
 import * as assert from 'assert';
-import { EventEmitter } from 'events';
 import * as sinon from 'sinon';
 import { SipSignalingAdapter } from '../../lib/twilio/signaling/sipsignalingadapter';
 
 /**
- * Stub that mimics a SIP.js Registerer's stateChange emitter.
+ * Stub that mimics a SIP.js Registerer/Session stateChange emitter.
  */
 class StateChangeEmitter {
   private _listeners: Function[] = [];
@@ -27,6 +26,49 @@ function createRegistererStub() {
   };
 }
 
+function createSessionStub(initialState: string = 'Initial') {
+  const stateChange = new StateChangeEmitter();
+  return {
+    state: initialState,
+    stateChange,
+    delegate: undefined as any,
+    bye: sinon.stub().resolves(),
+    cancel: sinon.stub().resolves(),
+    invite: sinon.stub().resolves(),
+    info: sinon.stub().resolves(),
+    message: sinon.stub().resolves(),
+    _simulateState(state: string) {
+      this.state = state;
+      stateChange.notify(state);
+    },
+  };
+}
+
+function createInviterStub() {
+  const stub = createSessionStub('Initial');
+  let requestDelegate: any = null;
+  stub.invite = sinon.stub().callsFake((opts?: any) => {
+    requestDelegate = opts?.requestDelegate;
+    return Promise.resolve();
+  });
+  return {
+    ...stub,
+    _getRequestDelegate() { return requestDelegate; },
+  };
+}
+
+function createInvitationStub() {
+  const stub = createSessionStub('Initial');
+  return {
+    ...stub,
+    id: 'inv-session-id-123',
+    body: 'v=0\r\no=- 123 456 IN IP4 0.0.0.0\r\n',
+    remoteIdentity: { uri: { toString: () => 'sip:bob@example.com' } },
+    accept: sinon.stub().resolves(),
+    reject: sinon.stub().resolves(),
+  };
+}
+
 function createUserAgentStub() {
   let delegate: any = {};
   return {
@@ -44,6 +86,7 @@ function createUserAgentStub() {
 function createAdapter(overrides?: Partial<any>) {
   const uaStub = createUserAgentStub();
   const regStub = createRegistererStub();
+  const inviterStub = createInviterStub();
 
   const adapter = new SipSignalingAdapter({
     sipDomain: 'sip.ashburn.dev.twilio.com',
@@ -52,17 +95,19 @@ function createAdapter(overrides?: Partial<any>) {
     credentials: { username: 'alice', password: 'secret' },
     region: 'ashburn',
     createUserAgent(config: any) {
-      // Capture the delegate so our stub can trigger events
       uaStub._setDelegate(config.delegate);
       return uaStub as any;
     },
     createRegisterer() {
       return regStub as any;
     },
+    createInviter() {
+      return inviterStub as any;
+    },
     ...overrides,
   });
 
-  return { adapter, uaStub, regStub };
+  return { adapter, uaStub, regStub, inviterStub };
 }
 
 describe('SipSignalingAdapter', () => {
@@ -301,48 +346,273 @@ describe('SipSignalingAdapter', () => {
     });
   });
 
-  describe('call signaling stubs', () => {
-    it('invite() should throw NotSupportedError', () => {
-      const { adapter } = createAdapter();
-      assert.throws(() => adapter.invite('sdp', 'sid', 'params'), /not yet implemented/);
+  describe('invite()', () => {
+    it('should create an Inviter and call invite()', () => {
+      const { adapter, inviterStub } = createAdapter();
+      adapter.invite('sdp', 'call-1', 'To=bob');
+      assert(inviterStub.invite.calledOnce);
     });
 
-    it('answer() should throw NotSupportedError', () => {
-      const { adapter } = createAdapter();
-      assert.throws(() => adapter.answer('sdp', 'sid'), /not yet implemented/);
+    it('should emit "ringing" on requestDelegate.onProgress', (done) => {
+      const { adapter, inviterStub } = createAdapter();
+      adapter.on('ringing', (payload: any) => {
+        assert.strictEqual(payload.callsid, 'call-1');
+        done();
+      });
+      adapter.invite('sdp', 'call-1', 'To=bob');
+      const rd = inviterStub._getRequestDelegate();
+      rd.onProgress({});
     });
 
-    it('hangup() should throw NotSupportedError', () => {
-      const { adapter } = createAdapter();
-      assert.throws(() => adapter.hangup('sid'), /not yet implemented/);
+    it('should emit "answer" on requestDelegate.onAccept', (done) => {
+      const { adapter, inviterStub } = createAdapter();
+      adapter.on('answer', (payload: any) => {
+        assert.strictEqual(payload.callsid, 'call-1');
+        done();
+      });
+      adapter.invite('sdp', 'call-1', 'To=bob');
+      const rd = inviterStub._getRequestDelegate();
+      rd.onAccept({});
     });
 
-    it('reject() should throw NotSupportedError', () => {
-      const { adapter } = createAdapter();
-      assert.throws(() => adapter.reject('sid'), /not yet implemented/);
+    it('should emit "hangup" with error on requestDelegate.onReject', (done) => {
+      const { adapter, inviterStub } = createAdapter();
+      adapter.on('hangup', (payload: any) => {
+        assert.strictEqual(payload.callsid, 'call-1');
+        assert(payload.error);
+        done();
+      });
+      adapter.invite('sdp', 'call-1', 'To=bob');
+      const rd = inviterStub._getRequestDelegate();
+      rd.onReject({ message: { statusCode: 486, reasonPhrase: 'Busy Here' } });
     });
 
-    it('reinvite() should throw NotSupportedError', () => {
-      const { adapter } = createAdapter();
-      assert.throws(() => adapter.reinvite('sdp', 'sid'), /not yet implemented/);
+    it('should emit "error" if invite() promise rejects', (done) => {
+      const failInviterStub = createInviterStub();
+      failInviterStub.invite = sinon.stub().rejects(new Error('transport down'));
+      const { adapter } = createAdapter({
+        createInviter() { return failInviterStub as any; },
+      });
+      adapter.on('error', (payload: any) => {
+        assert.strictEqual(payload.error.code, 31000);
+        assert(payload.error.message.includes('transport down'));
+        done();
+      });
+      adapter.invite('sdp', 'call-1', 'To=bob');
     });
 
-    it('reconnect() should throw NotSupportedError', () => {
-      const { adapter } = createAdapter();
-      assert.throws(() => adapter.reconnect('sdp', 'sid', 'token'), /not yet implemented/);
+    it('should clean up session on SessionState.Terminated', () => {
+      const { adapter, inviterStub } = createAdapter();
+      adapter.invite('sdp', 'call-1', 'To=bob');
+      inviterStub._simulateState('Terminated');
+      // Subsequent hangup should warn (no session found) — just verifying no crash
+      assert.doesNotThrow(() => adapter.hangup('call-1'));
+    });
+  });
+
+  describe('reconnect()', () => {
+    it('should create an Inviter and call invite()', () => {
+      const { adapter, inviterStub } = createAdapter();
+      adapter.reconnect('sdp', 'call-1', 'rtoken');
+      assert(inviterStub.invite.calledOnce);
     });
 
-    it('dtmf() should throw NotSupportedError', () => {
-      const { adapter } = createAdapter();
-      assert.throws(() => adapter.dtmf('sid', '123'), /not yet implemented/);
+    it('should include reconnect token in answer payload', (done) => {
+      const { adapter, inviterStub } = createAdapter();
+      adapter.on('answer', (payload: any) => {
+        assert.strictEqual(payload.reconnect, 'rtoken');
+        done();
+      });
+      adapter.reconnect('sdp', 'call-1', 'rtoken');
+      const rd = inviterStub._getRequestDelegate();
+      rd.onAccept({});
+    });
+  });
+
+  describe('incoming call (onInvite)', () => {
+    it('should emit "invite" with callsid, sdp, parameters', (done) => {
+      const { adapter, uaStub } = createAdapter();
+      const inv = createInvitationStub();
+      adapter.on('invite', (payload: any) => {
+        assert.strictEqual(payload.callsid, inv.id);
+        assert.strictEqual(payload.sdp, inv.body);
+        assert.strictEqual(payload.parameters.CallSid, inv.id);
+        assert.strictEqual(payload.parameters.From, 'sip:bob@example.com');
+        done();
+      });
+      uaStub._triggerInvite(inv);
     });
 
-    it('sendMessage() should throw NotSupportedError', () => {
+    it('should emit "cancel" when invitation.delegate.onCancel fires', (done) => {
+      const { adapter, uaStub } = createAdapter();
+      const inv = createInvitationStub();
+      adapter.on('cancel', (payload: any) => {
+        assert.strictEqual(payload.callsid, inv.id);
+        done();
+      });
+      uaStub._triggerInvite(inv);
+      inv.delegate.onCancel();
+    });
+
+    it('should emit "hangup" when session.delegate.onBye fires', (done) => {
+      const { adapter, uaStub } = createAdapter();
+      const inv = createInvitationStub();
+      adapter.on('hangup', (payload: any) => {
+        assert.strictEqual(payload.callsid, inv.id);
+        done();
+      });
+      uaStub._triggerInvite(inv);
+      inv.delegate.onBye();
+    });
+  });
+
+  describe('answer()', () => {
+    it('should call invitation.accept()', () => {
+      const { adapter, uaStub } = createAdapter();
+      const inv = createInvitationStub();
+      uaStub._triggerInvite(inv);
+      adapter.answer('sdp-answer', inv.id);
+      assert(inv.accept.calledOnce);
+    });
+
+    it('should warn if no pending invitation', () => {
       const { adapter } = createAdapter();
-      assert.throws(
-        () => adapter.sendMessage('sid', 'hi', 'text/plain', 'user-msg', 'evt1'),
-        /not yet implemented/,
-      );
+      // Should not throw — just warns
+      assert.doesNotThrow(() => adapter.answer('sdp', 'unknown-id'));
+    });
+  });
+
+  describe('reject()', () => {
+    it('should call invitation.reject()', () => {
+      const { adapter, uaStub } = createAdapter();
+      const inv = createInvitationStub();
+      uaStub._triggerInvite(inv);
+      adapter.reject(inv.id);
+      assert(inv.reject.calledOnce);
+    });
+
+    it('should warn if no pending invitation', () => {
+      const { adapter } = createAdapter();
+      assert.doesNotThrow(() => adapter.reject('unknown-id'));
+    });
+  });
+
+  describe('hangup()', () => {
+    it('should call session.bye() when state is Established', () => {
+      const { adapter, inviterStub } = createAdapter();
+      adapter.invite('sdp', 'call-1', 'To=bob');
+      inviterStub.state = 'Established';
+      adapter.hangup('call-1');
+      assert(inviterStub.bye.calledOnce);
+    });
+
+    it('should call inviter.cancel() when state is Establishing', () => {
+      const { adapter, inviterStub } = createAdapter();
+      adapter.invite('sdp', 'call-1', 'To=bob');
+      inviterStub.state = 'Establishing';
+      adapter.hangup('call-1');
+      assert(inviterStub.cancel.calledOnce);
+    });
+
+    it('should reject pending invitation during hangup', () => {
+      const { adapter, uaStub } = createAdapter();
+      const inv = createInvitationStub();
+      uaStub._triggerInvite(inv);
+      adapter.hangup(inv.id);
+      assert(inv.reject.calledOnce);
+    });
+
+    it('should not throw for unknown callSid', () => {
+      const { adapter } = createAdapter();
+      assert.doesNotThrow(() => adapter.hangup('unknown'));
+    });
+  });
+
+  describe('reinvite()', () => {
+    it('should call session.invite() for established sessions', () => {
+      const { adapter, inviterStub } = createAdapter();
+      adapter.invite('sdp', 'call-1', 'To=bob');
+      inviterStub.state = 'Established';
+      adapter.reinvite('new-sdp', 'call-1');
+      // session.invite is the re-INVITE call (distinct from inviter.invite for initial INVITE)
+      // inviterStub.invite is called once for initial, then once for reinvite = 2 total
+      assert.strictEqual(inviterStub.invite.callCount, 2);
+    });
+
+    it('should not throw for non-established session', () => {
+      const { adapter } = createAdapter();
+      assert.doesNotThrow(() => adapter.reinvite('sdp', 'unknown'));
+    });
+  });
+
+  describe('dtmf()', () => {
+    it('should call session.info() for each digit', async () => {
+      const { adapter, inviterStub } = createAdapter();
+      adapter.invite('sdp', 'call-1', 'To=bob');
+      inviterStub.state = 'Established';
+      adapter.dtmf('call-1', '12');
+      // Allow async sends to complete
+      await new Promise(resolve => setTimeout(resolve, 10));
+      assert.strictEqual(inviterStub.info.callCount, 2);
+    });
+
+    it('should not throw for non-established session', () => {
+      const { adapter } = createAdapter();
+      assert.doesNotThrow(() => adapter.dtmf('unknown', '1'));
+    });
+  });
+
+  describe('sendMessage()', () => {
+    it('should call session.message() and emit "ack"', (done) => {
+      const { adapter, inviterStub } = createAdapter();
+      adapter.invite('sdp', 'call-1', 'To=bob');
+      inviterStub.state = 'Established';
+      adapter.on('ack', (payload: any) => {
+        assert.strictEqual(payload.acktype, 'message');
+        assert.strictEqual(payload.callsid, 'call-1');
+        assert.strictEqual(payload.voiceeventsid, 'evt-1');
+        done();
+      });
+      adapter.sendMessage('call-1', '{"hello":"world"}', 'application/json', 'user-msg', 'evt-1');
+    });
+
+    it('should emit "error" if message() fails', (done) => {
+      const failInviterStub = createInviterStub();
+      failInviterStub.message = sinon.stub().rejects(new Error('send failed'));
+      const { adapter } = createAdapter({
+        createInviter() { return failInviterStub as any; },
+      });
+      adapter.invite('sdp', 'call-1', 'To=bob');
+      (failInviterStub as any).state = 'Established';
+      adapter.on('error', (payload: any) => {
+        assert.strictEqual(payload.voiceeventsid, 'evt-1');
+        done();
+      });
+      adapter.sendMessage('call-1', 'hi', 'text/plain', 'user-msg', 'evt-1');
+    });
+
+    it('should not throw for unknown callSid', () => {
+      const { adapter } = createAdapter();
+      assert.doesNotThrow(() => adapter.sendMessage('unknown', 'hi', 'text/plain', 'msg', 'evt'));
+    });
+  });
+
+  describe('lifecycle cleanup', () => {
+    it('destroy() should bye established sessions and clear maps', () => {
+      const { adapter, inviterStub } = createAdapter();
+      adapter.invite('sdp', 'call-1', 'To=bob');
+      inviterStub.state = 'Established';
+      adapter.destroy();
+      assert(inviterStub.bye.calledOnce);
+    });
+
+    it('transport disconnect should clear session maps', () => {
+      const { adapter, uaStub, inviterStub } = createAdapter();
+      uaStub._triggerConnect();
+      adapter.invite('sdp', 'call-1', 'To=bob');
+      uaStub._triggerDisconnect();
+      // Session map cleared — hangup should not find session
+      assert.doesNotThrow(() => adapter.hangup('call-1'));
     });
   });
 });

--- a/tests/unit/sipsignalingadapter.ts
+++ b/tests/unit/sipsignalingadapter.ts
@@ -464,6 +464,18 @@ describe('SipSignalingAdapter', () => {
       uaStub._triggerInvite(inv);
       inv.delegate.onBye();
     });
+
+    it('should emit "hangup" via onBye after answering an inbound call', (done) => {
+      const { adapter, uaStub } = createAdapter();
+      const inv = createInvitationStub();
+      uaStub._triggerInvite(inv);
+      adapter.answer('sdp-answer', inv.id);
+      adapter.on('hangup', (payload: any) => {
+        assert.strictEqual(payload.callsid, inv.id);
+        done();
+      });
+      inv.delegate.onBye();
+    });
   });
 
   describe('answer()', () => {
@@ -480,6 +492,20 @@ describe('SipSignalingAdapter', () => {
       // Should not throw — just warns
       assert.doesNotThrow(() => adapter.answer('sdp', 'unknown-id'));
     });
+
+    it('should emit "error" if accept() fails', (done) => {
+      const { adapter, uaStub } = createAdapter();
+      const inv = createInvitationStub();
+      inv.accept = sinon.stub().rejects(new Error('accept failed'));
+      uaStub._triggerInvite(inv);
+      adapter.on('error', (payload: any) => {
+        assert.strictEqual(payload.error.code, 31000);
+        assert.strictEqual(payload.error.message, 'accept failed');
+        assert.strictEqual(payload.callsid, inv.id);
+        done();
+      });
+      adapter.answer('sdp-answer', inv.id);
+    });
   });
 
   describe('reject()', () => {
@@ -494,6 +520,20 @@ describe('SipSignalingAdapter', () => {
     it('should warn if no pending invitation', () => {
       const { adapter } = createAdapter();
       assert.doesNotThrow(() => adapter.reject('unknown-id'));
+    });
+
+    it('should emit "error" if reject() fails', (done) => {
+      const { adapter, uaStub } = createAdapter();
+      const inv = createInvitationStub();
+      inv.reject = sinon.stub().rejects(new Error('reject failed'));
+      uaStub._triggerInvite(inv);
+      adapter.on('error', (payload: any) => {
+        assert.strictEqual(payload.error.code, 31000);
+        assert.strictEqual(payload.error.message, 'reject failed');
+        assert.strictEqual(payload.callsid, inv.id);
+        done();
+      });
+      adapter.reject(inv.id);
     });
   });
 
@@ -543,6 +583,28 @@ describe('SipSignalingAdapter', () => {
       const { adapter } = createAdapter();
       assert.doesNotThrow(() => adapter.reinvite('sdp', 'unknown'));
     });
+
+    it('should emit "answer" on requestDelegate.onAccept', (done) => {
+      const { adapter, inviterStub } = createAdapter();
+      adapter.invite('sdp', 'call-1', 'To=bob');
+      inviterStub.state = 'Established';
+      adapter.on('answer', (payload: any) => {
+        assert.strictEqual(payload.callsid, 'call-1');
+        done();
+      });
+      adapter.reinvite('new-sdp', 'call-1');
+      const rd = inviterStub.invite.lastCall.args[0]?.requestDelegate;
+      rd.onAccept();
+    });
+
+    it('should warn but not throw on requestDelegate.onReject', () => {
+      const { adapter, inviterStub } = createAdapter();
+      adapter.invite('sdp', 'call-1', 'To=bob');
+      inviterStub.state = 'Established';
+      adapter.reinvite('new-sdp', 'call-1');
+      const rd = inviterStub.invite.lastCall.args[0]?.requestDelegate;
+      assert.doesNotThrow(() => rd.onReject({ message: { statusCode: 488 } }));
+    });
   });
 
   describe('dtmf()', () => {
@@ -583,7 +645,7 @@ describe('SipSignalingAdapter', () => {
         createInviter() { return failInviterStub as any; },
       });
       adapter.invite('sdp', 'call-1', 'To=bob');
-      (failInviterStub as any).state = 'Established';
+      failInviterStub._simulateState('Established');
       adapter.on('error', (payload: any) => {
         assert.strictEqual(payload.voiceeventsid, 'evt-1');
         done();

--- a/tests/unit/sipsignalingadapter.ts
+++ b/tests/unit/sipsignalingadapter.ts
@@ -57,13 +57,18 @@ function createInviterStub() {
   };
 }
 
-function createInvitationStub() {
+function createInvitationStub(headers?: Record<string, string>) {
+  const defaultHeaders: Record<string, string> = {
+    'X-Twilio-CallSid': 'CA-test-call-sid',
+    ...headers,
+  };
   const stub = createSessionStub('Initial');
   return {
     ...stub,
     id: 'inv-session-id-123',
     body: 'v=0\r\no=- 123 456 IN IP4 0.0.0.0\r\n',
     remoteIdentity: { uri: { toString: () => 'sip:bob@example.com' } },
+    request: { getHeader: (name: string) => defaultHeaders[name] },
     accept: sinon.stub().resolves(),
     reject: sinon.stub().resolves(),
   };
@@ -430,24 +435,43 @@ describe('SipSignalingAdapter', () => {
   });
 
   describe('incoming call (onInvite)', () => {
-    it('should emit "invite" with callsid, sdp, parameters', (done) => {
+    it('should emit "invite" with callsid from X-Twilio-CallSid header', (done) => {
       const { adapter, uaStub } = createAdapter();
       const inv = createInvitationStub();
       adapter.on('invite', (payload: any) => {
-        assert.strictEqual(payload.callsid, inv.id);
+        assert.strictEqual(payload.callsid, 'CA-test-call-sid');
         assert.strictEqual(payload.sdp, inv.body);
-        assert.strictEqual(payload.parameters.CallSid, inv.id);
+        assert.strictEqual(payload.parameters.CallSid, 'CA-test-call-sid');
         assert.strictEqual(payload.parameters.From, 'sip:bob@example.com');
         done();
       });
       uaStub._triggerInvite(inv);
     });
 
+    it('should reject invitation when X-Twilio-CallSid header is missing', () => {
+      const { adapter, uaStub } = createAdapter();
+      const stub = createSessionStub('Initial');
+      const inv = {
+        ...stub,
+        id: 'inv-session-id-123',
+        body: '',
+        remoteIdentity: { uri: { toString: () => 'sip:bob@example.com' } },
+        request: { getHeader: () => undefined },
+        accept: sinon.stub().resolves(),
+        reject: sinon.stub().resolves(),
+      };
+      let inviteEmitted = false;
+      adapter.on('invite', () => { inviteEmitted = true; });
+      uaStub._triggerInvite(inv);
+      assert.strictEqual(inviteEmitted, false);
+      assert(inv.reject.calledOnce);
+    });
+
     it('should emit "cancel" when invitation.delegate.onCancel fires', (done) => {
       const { adapter, uaStub } = createAdapter();
       const inv = createInvitationStub();
       adapter.on('cancel', (payload: any) => {
-        assert.strictEqual(payload.callsid, inv.id);
+        assert.strictEqual(payload.callsid, 'CA-test-call-sid');
         done();
       });
       uaStub._triggerInvite(inv);
@@ -458,7 +482,7 @@ describe('SipSignalingAdapter', () => {
       const { adapter, uaStub } = createAdapter();
       const inv = createInvitationStub();
       adapter.on('hangup', (payload: any) => {
-        assert.strictEqual(payload.callsid, inv.id);
+        assert.strictEqual(payload.callsid, 'CA-test-call-sid');
         done();
       });
       uaStub._triggerInvite(inv);
@@ -469,9 +493,9 @@ describe('SipSignalingAdapter', () => {
       const { adapter, uaStub } = createAdapter();
       const inv = createInvitationStub();
       uaStub._triggerInvite(inv);
-      adapter.answer('sdp-answer', inv.id);
+      adapter.answer('sdp-answer', 'CA-test-call-sid');
       adapter.on('hangup', (payload: any) => {
-        assert.strictEqual(payload.callsid, inv.id);
+        assert.strictEqual(payload.callsid, 'CA-test-call-sid');
         done();
       });
       inv.delegate.onBye();
@@ -483,7 +507,7 @@ describe('SipSignalingAdapter', () => {
       const { adapter, uaStub } = createAdapter();
       const inv = createInvitationStub();
       uaStub._triggerInvite(inv);
-      adapter.answer('sdp-answer', inv.id);
+      adapter.answer('sdp-answer', 'CA-test-call-sid');
       assert(inv.accept.calledOnce);
     });
 
@@ -501,10 +525,10 @@ describe('SipSignalingAdapter', () => {
       adapter.on('error', (payload: any) => {
         assert.strictEqual(payload.error.code, 31000);
         assert.strictEqual(payload.error.message, 'accept failed');
-        assert.strictEqual(payload.callsid, inv.id);
+        assert.strictEqual(payload.callsid, 'CA-test-call-sid');
         done();
       });
-      adapter.answer('sdp-answer', inv.id);
+      adapter.answer('sdp-answer', 'CA-test-call-sid');
     });
   });
 
@@ -513,7 +537,7 @@ describe('SipSignalingAdapter', () => {
       const { adapter, uaStub } = createAdapter();
       const inv = createInvitationStub();
       uaStub._triggerInvite(inv);
-      adapter.reject(inv.id);
+      adapter.reject('CA-test-call-sid');
       assert(inv.reject.calledOnce);
     });
 
@@ -530,10 +554,10 @@ describe('SipSignalingAdapter', () => {
       adapter.on('error', (payload: any) => {
         assert.strictEqual(payload.error.code, 31000);
         assert.strictEqual(payload.error.message, 'reject failed');
-        assert.strictEqual(payload.callsid, inv.id);
+        assert.strictEqual(payload.callsid, 'CA-test-call-sid');
         done();
       });
-      adapter.reject(inv.id);
+      adapter.reject('CA-test-call-sid');
     });
   });
 
@@ -558,7 +582,7 @@ describe('SipSignalingAdapter', () => {
       const { adapter, uaStub } = createAdapter();
       const inv = createInvitationStub();
       uaStub._triggerInvite(inv);
-      adapter.hangup(inv.id);
+      adapter.hangup('CA-test-call-sid');
       assert(inv.reject.calledOnce);
     });
 


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

https://twilio-engineering.atlassian.net/browse/VBLOCKS-6374

### Description

  - Implement call signaling methods (invite, answer, hangup, reject, reinvite, reconnect, dtmf, sendMessage) on SipSignalingAdapter, replacing NotSupportedError stubs
  - Track active sessions and pending inbound invitations via maps keyed by callSid
  - Map SIP.js session events to SignalingAdapter events (ringing, answer, hangup, cancel, ack, error) matching the payloads Call.ts and Device.ts expect
  - Clean up session state on hangup, destroy, and transport disconnect
  - SDP relay through SIP.js deferred to VBLOCKS-6372
  - Replace stub tests with full call signaling test coverage

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Ready for review
