### PR TITLE
[VBLOCKS-6480] chore: npm publishing hardening

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  test-visibility-circleci-orb: datadog/test-visibility-circleci-orb@1.2.7
+  test-visibility-circleci-orb: datadog/test-visibility-circleci-orb@1.1.0
 
 ###
 # Parameters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  test-visibility-circleci-orb: datadog/test-visibility-circleci-orb@1
+  test-visibility-circleci-orb: datadog/test-visibility-circleci-orb@1.2.7
 
 ###
 # Parameters
@@ -67,14 +67,14 @@ commands:
     steps:
       - get-code
       - restore_cache:
-          key: dependency-cache-{{ arch }}-{{ checksum "package.json" }}
+          key: dependency-cache-{{ arch }}-{{ checksum "package-lock.json" }}
       - run:
           name: Installing dependencies
-          command: node -v && npm install
+          command: node -v && npm ci
       - save_cache:
-          key: dependency-cache-{{ arch }}-{{ checksum "package.json" }}
+          key: dependency-cache-{{ arch }}-{{ checksum "package-lock.json" }}
           paths:
-            - ./node_modules
+            - ~/.npm
   build:
     steps:
       - get-code-and-dependencies
@@ -260,7 +260,7 @@ jobs:
 
   trigger-qe-tests:
     docker:
-      - image: circleci/node:latest
+      - image: cimg/node:24.15.0
     steps:
       - run:
           name: Trigger QE tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ commands:
           key: dependency-cache-{{ arch }}-{{ checksum "package-lock.json" }}
       - run:
           name: Installing dependencies
-          command: node -v && npm ci
+          command: npm ci
       - save_cache:
           key: dependency-cache-{{ arch }}-{{ checksum "package-lock.json" }}
           paths:
@@ -260,7 +260,7 @@ jobs:
 
   trigger-qe-tests:
     docker:
-      - image: cimg/node:24.15.0
+      - image: cimg/node:24.15.0@sha256:0a67b6fa151ceac233d469a5915ca75a4a1c9e3854502ed7cc236f18c3a4f5c3
     steps:
       - run:
           name: Trigger QE tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ parameters:
 executors:
   machine-executor:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2004:2024.11.1
       docker_layer_caching: true
   docker-with-browser:
     parameters:

--- a/.circleci/images/docker-compose.yml
+++ b/.circleci/images/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - /opt/app/node_modules
   integrationTests: # runs integration tets. Expects that sources are mounted.
     <<: *runtimeDefaults
-    command: bash -c "npm install && npm run build && ls -la /root && ls -la /root/.npm && npm run test:network"
+    command: bash -c "npm ci && npm run build && ls -la /root && ls -la /root/.npm && npm run test:network"
   bash: # runs bash shell inside container. helpful for debugging
     <<: *runtimeDefaults
     command: bash


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

https://twilio-engineering.atlassian.net/browse/VBLOCKS-6480

### Description

  1. Datadog orb: @1 → @1.1.0
  2. Cache key (2 occurrences): checksum "package.json" → checksum "package-lock.json"
  3. npm install → npm ci (2 occurrences): in config.yml and docker-compose.yml
  4. Cache path: ./node_modules → ~/.npm
  5. Docker image: circleci/node:latest → cimg/node:24.15.0

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Ready for review
