### PR TITLE
[VBLOCKS-6500] refactor: callsignaling methods to config objects

### DIFF
--- a/lib/twilio/call.ts
+++ b/lib/twilio/call.ts
@@ -2,7 +2,16 @@ import { EventEmitter } from 'events';
 import Backoff from './backoff';
 import Device from './device';
 import DialtonePlayer from './dialtonePlayer';
-import { SignalingAdapter } from './signaling/signalingadapter';
+import {
+  AnswerConfig,
+  DtmfConfig,
+  HangupConfig,
+  InviteConfig,
+  ReconnectConfig,
+  ReinviteConfig,
+  SendMessageConfig,
+  SignalingAdapter,
+} from './signaling/signalingadapter';
 import {
   GeneralErrors,
   getPreciseSignalingErrorByCode,
@@ -373,7 +382,8 @@ class Call extends EventEmitter {
 
         this._signalingAdapter.on('answer', onAnswerOrRinging);
         this._signalingAdapter.on('hangup', onHangup);
-        this._signalingAdapter.reinvite(offerSdp, this.parameters.CallSid);
+        const reinviteConfig: ReinviteConfig = { sdp: offerSdp };
+        this._signalingAdapter.reinvite(this.parameters.CallSid, reinviteConfig);
       });
     });
 
@@ -682,7 +692,8 @@ class Call extends EventEmitter {
         this._mediaHandler.answerIncomingCall(this.parameters.CallSid,
           this._options.offerSdp, rtcConfiguration,
           (answerSdp: string) => {
-            this._signalingAdapter.answer(answerSdp, this.parameters.CallSid);
+            const answerConfig: AnswerConfig = { sdp: answerSdp };
+            this._signalingAdapter.answer(this.parameters.CallSid, answerConfig);
           },
           onAnswer);
       } else {
@@ -708,9 +719,11 @@ class Call extends EventEmitter {
           this._signalingAdapter.on('ringing', onPstreamAnswerOrRinging);
 
           if (this._signalingReconnectToken) {
-            this._signalingAdapter.reconnect(offerSdp, outgoingCallSid, this._signalingReconnectToken);
+            const reconnectConfig: ReconnectConfig = { sdp: offerSdp, reconnectToken: this._signalingReconnectToken };
+            this._signalingAdapter.reconnect(outgoingCallSid, reconnectConfig);
           } else {
-            this._signalingAdapter.invite(offerSdp, outgoingCallSid, params);
+            const inviteConfig: InviteConfig = { sdp: offerSdp, params };
+            this._signalingAdapter.invite(outgoingCallSid, inviteConfig);
           }
 
           // NOTE(VBLOCKS-6417): in the original implementation, the RTC DTLS
@@ -947,7 +960,8 @@ class Call extends EventEmitter {
     this._log.info('Sending digits over PStream');
 
     if (this._signalingAdapter !== null && this._signalingAdapter.status !== 'disconnected') {
-      this._signalingAdapter.dtmf(this.parameters.CallSid, digits);
+      const dtmfConfig: DtmfConfig = { digits };
+      this._signalingAdapter.dtmf(this.parameters.CallSid, dtmfConfig);
     } else {
       const error = new GeneralErrors.ConnectionError('Could not send DTMF: Signaling channel is disconnected');
       this._log.debug('#error', error);
@@ -997,7 +1011,8 @@ class Call extends EventEmitter {
 
     const voiceEventSid = this._voiceEventSidGenerator();
     this._messages.set(voiceEventSid, { content, contentType, messageType, voiceEventSid });
-    this._signalingAdapter.sendMessage(callSid!, content, contentType, messageType, voiceEventSid);
+    const sendMessageConfig: SendMessageConfig = { content, contentType, messageType, voiceEventSid };
+    this._signalingAdapter.sendMessage(callSid!, sendMessageConfig);
     return voiceEventSid;
   }
 
@@ -1115,7 +1130,8 @@ class Call extends EventEmitter {
     if (this._signalingAdapter !== null && this._signalingAdapter.status !== 'disconnected' && this._shouldSendHangup) {
       const callsid: string | undefined = this.parameters.CallSid || this.outboundConnectionId;
       if (callsid) {
-        this._signalingAdapter.hangup(callsid, message);
+        const hangupConfig: HangupConfig | undefined = message != null ? { message } : undefined;
+        this._signalingAdapter.hangup(callsid, hangupConfig);
       }
     }
 
@@ -1252,11 +1268,11 @@ class Call extends EventEmitter {
   private _onConnected = (): void => {
     this._log.info('Received connected from pstream');
     if (this._signalingReconnectToken && this._mediaHandler.version) {
-      this._signalingAdapter.reconnect(
-        this._mediaHandler.version.getSDP(),
-        this.parameters.CallSid,
-        this._signalingReconnectToken,
-      );
+      const reconnectConfig: ReconnectConfig = {
+        sdp: this._mediaHandler.version.getSDP(),
+        reconnectToken: this._signalingReconnectToken,
+      };
+      this._signalingAdapter.reconnect(this.parameters.CallSid, reconnectConfig);
     }
   }
 

--- a/lib/twilio/call.ts
+++ b/lib/twilio/call.ts
@@ -1130,7 +1130,7 @@ class Call extends EventEmitter {
     if (this._signalingAdapter !== null && this._signalingAdapter.status !== 'disconnected' && this._shouldSendHangup) {
       const callsid: string | undefined = this.parameters.CallSid || this.outboundConnectionId;
       if (callsid) {
-        const hangupConfig: HangupConfig | undefined = message != null ? { message } : undefined;
+        const hangupConfig: HangupConfig = message != null ? { message } : {};
         this._signalingAdapter.hangup(callsid, hangupConfig);
       }
     }

--- a/lib/twilio/signaling/pstreamsignalingadapter.ts
+++ b/lib/twilio/signaling/pstreamsignalingadapter.ts
@@ -71,8 +71,9 @@ export class PStreamSignalingAdapter extends EventEmitter implements SignalingAd
     this._pstream.answer(sdp, callSid);
   }
 
-  hangup(callSid: string, config?: HangupConfig): void {
-    this._pstream.hangup(callSid, config?.message);
+  hangup(callSid: string, config: HangupConfig = {}): void {
+    const { message } = config;
+    this._pstream.hangup(callSid, message);
   }
 
   reject(callSid: string): void {

--- a/lib/twilio/signaling/pstreamsignalingadapter.ts
+++ b/lib/twilio/signaling/pstreamsignalingadapter.ts
@@ -1,5 +1,15 @@
 import { EventEmitter } from 'events';
-import { SignalingAdapter, SignalingAdapterStatus } from './signalingadapter';
+import {
+  AnswerConfig,
+  DtmfConfig,
+  HangupConfig,
+  InviteConfig,
+  ReconnectConfig,
+  ReinviteConfig,
+  SendMessageConfig,
+  SignalingAdapter,
+  SignalingAdapterStatus,
+} from './signalingadapter';
 
 const EVENTS_TO_FORWARD = [
   'ack', 'answer', 'cancel', 'candidate', 'close', 'connected',
@@ -51,41 +61,41 @@ export class PStreamSignalingAdapter extends EventEmitter implements SignalingAd
     this._pstream.updateURIs(uris);
   }
 
-  invite(sdp: string, callSid: string, params: string): void {
+  invite(callSid: string, config: InviteConfig): void {
+    const { sdp, params } = config;
     this._pstream.invite(sdp, callSid, params);
   }
 
-  answer(sdp: string, callSid: string): void {
+  answer(callSid: string, config: AnswerConfig): void {
+    const { sdp } = config;
     this._pstream.answer(sdp, callSid);
   }
 
-  hangup(callSid: string, message?: string | null): void {
-    this._pstream.hangup(callSid, message);
+  hangup(callSid: string, config?: HangupConfig): void {
+    this._pstream.hangup(callSid, config?.message);
   }
 
   reject(callSid: string): void {
     this._pstream.reject(callSid);
   }
 
-  reinvite(sdp: string, callSid: string): void {
+  reinvite(callSid: string, config: ReinviteConfig): void {
+    const { sdp } = config;
     this._pstream.reinvite(sdp, callSid);
   }
 
-  reconnect(sdp: string, callSid: string, reconnectToken: string): void {
+  reconnect(callSid: string, config: ReconnectConfig): void {
+    const { sdp, reconnectToken } = config;
     this._pstream.reconnect(sdp, callSid, reconnectToken);
   }
 
-  dtmf(callSid: string, digits: string): void {
+  dtmf(callSid: string, config: DtmfConfig): void {
+    const { digits } = config;
     this._pstream.dtmf(callSid, digits);
   }
 
-  sendMessage(
-    callSid: string,
-    content: string,
-    contentType: string | undefined,
-    messageType: string,
-    voiceEventSid: string,
-  ): void {
+  sendMessage(callSid: string, config: SendMessageConfig): void {
+    const { content, contentType, messageType, voiceEventSid } = config;
     this._pstream.sendMessage(callSid, content, contentType, messageType, voiceEventSid);
   }
 

--- a/lib/twilio/signaling/pstreamsignalingadapter.ts
+++ b/lib/twilio/signaling/pstreamsignalingadapter.ts
@@ -61,18 +61,15 @@ export class PStreamSignalingAdapter extends EventEmitter implements SignalingAd
     this._pstream.updateURIs(uris);
   }
 
-  invite(callSid: string, config: InviteConfig): void {
-    const { sdp, params } = config;
+  invite(callSid: string, { sdp, params }: InviteConfig): void {
     this._pstream.invite(sdp, callSid, params);
   }
 
-  answer(callSid: string, config: AnswerConfig): void {
-    const { sdp } = config;
+  answer(callSid: string, { sdp }: AnswerConfig): void {
     this._pstream.answer(sdp, callSid);
   }
 
-  hangup(callSid: string, config: HangupConfig = {}): void {
-    const { message } = config;
+  hangup(callSid: string, { message }: HangupConfig = {}): void {
     this._pstream.hangup(callSid, message);
   }
 
@@ -80,23 +77,19 @@ export class PStreamSignalingAdapter extends EventEmitter implements SignalingAd
     this._pstream.reject(callSid);
   }
 
-  reinvite(callSid: string, config: ReinviteConfig): void {
-    const { sdp } = config;
+  reinvite(callSid: string, { sdp }: ReinviteConfig): void {
     this._pstream.reinvite(sdp, callSid);
   }
 
-  reconnect(callSid: string, config: ReconnectConfig): void {
-    const { sdp, reconnectToken } = config;
+  reconnect(callSid: string, { sdp, reconnectToken }: ReconnectConfig): void {
     this._pstream.reconnect(sdp, callSid, reconnectToken);
   }
 
-  dtmf(callSid: string, config: DtmfConfig): void {
-    const { digits } = config;
+  dtmf(callSid: string, { digits }: DtmfConfig): void {
     this._pstream.dtmf(callSid, digits);
   }
 
-  sendMessage(callSid: string, config: SendMessageConfig): void {
-    const { content, contentType, messageType, voiceEventSid } = config;
+  sendMessage(callSid: string, { content, contentType, messageType, voiceEventSid }: SendMessageConfig): void {
     this._pstream.sendMessage(callSid, content, contentType, messageType, voiceEventSid);
   }
 

--- a/lib/twilio/signaling/signalingadapter.ts
+++ b/lib/twilio/signaling/signalingadapter.ts
@@ -12,7 +12,7 @@ export interface AnswerConfig {
 }
 
 export interface HangupConfig {
-  message?: string | null;
+  message?: string;
 }
 
 export interface ReinviteConfig {
@@ -30,7 +30,7 @@ export interface DtmfConfig {
 
 export interface SendMessageConfig {
   content: string;
-  contentType: string | undefined;
+  contentType?: string;
   messageType: string;
   voiceEventSid: string;
 }
@@ -48,7 +48,7 @@ export interface SignalingAdapter extends EventEmitter {
 
   invite(callSid: string, config: InviteConfig): void;
   answer(callSid: string, config: AnswerConfig): void;
-  hangup(callSid: string, config?: HangupConfig): void;
+  hangup(callSid: string, config: HangupConfig): void;
   reject(callSid: string): void;
   reinvite(callSid: string, config: ReinviteConfig): void;
   reconnect(callSid: string, config: ReconnectConfig): void;

--- a/lib/twilio/signaling/signalingadapter.ts
+++ b/lib/twilio/signaling/signalingadapter.ts
@@ -2,6 +2,39 @@ import { EventEmitter } from 'events';
 
 export type SignalingAdapterStatus = 'disconnected' | 'connected' | 'ready' | 'offline';
 
+export interface InviteConfig {
+  sdp: string;
+  params: string;
+}
+
+export interface AnswerConfig {
+  sdp: string;
+}
+
+export interface HangupConfig {
+  message?: string | null;
+}
+
+export interface ReinviteConfig {
+  sdp: string;
+}
+
+export interface ReconnectConfig {
+  sdp: string;
+  reconnectToken: string;
+}
+
+export interface DtmfConfig {
+  digits: string;
+}
+
+export interface SendMessageConfig {
+  content: string;
+  contentType: string | undefined;
+  messageType: string;
+  voiceEventSid: string;
+}
+
 export interface SignalingAdapter extends EventEmitter {
   status: SignalingAdapterStatus;
   uri: string;
@@ -13,16 +46,15 @@ export interface SignalingAdapter extends EventEmitter {
   updatePreferredURI(uri: string | null): void;
   updateURIs(uris: string[]): void;
 
-  invite(sdp: string, callSid: string, params: string): void;
-  answer(sdp: string, callSid: string): void;
-  hangup(callSid: string, message?: string | null): void;
+  invite(callSid: string, config: InviteConfig): void;
+  answer(callSid: string, config: AnswerConfig): void;
+  hangup(callSid: string, config?: HangupConfig): void;
   reject(callSid: string): void;
-  reinvite(sdp: string, callSid: string): void;
-  reconnect(sdp: string, callSid: string, reconnectToken: string): void;
+  reinvite(callSid: string, config: ReinviteConfig): void;
+  reconnect(callSid: string, config: ReconnectConfig): void;
 
-  dtmf(callSid: string, digits: string): void;
-  sendMessage(callSid: string, content: string, contentType: string | undefined,
-              messageType: string, voiceEventSid: string): void;
+  dtmf(callSid: string, config: DtmfConfig): void;
+  sendMessage(callSid: string, config: SendMessageConfig): void;
   register(mediaCapabilities: Record<string, any>): void;
 }
 

--- a/lib/twilio/signaling/sipsignalingadapter.ts
+++ b/lib/twilio/signaling/sipsignalingadapter.ts
@@ -264,8 +264,7 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
   // Call signaling
   // ---------------------------------------------------------------------------
 
-  invite(callSid: string, config: InviteConfig): void {
-    const { sdp, params } = config;
+  invite(callSid: string, { sdp, params }: InviteConfig): void {
     this._sendInvite(sdp, callSid, params);
   }
 
@@ -335,13 +334,11 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
     });
   }
 
-  reconnect(callSid: string, config: ReconnectConfig): void {
-    const { sdp, reconnectToken } = config;
+  reconnect(callSid: string, { sdp, reconnectToken }: ReconnectConfig): void {
     this._sendInvite(sdp, callSid, undefined, reconnectToken);
   }
 
-  dtmf(callSid: string, config: DtmfConfig): void {
-    const { digits } = config;
+  dtmf(callSid: string, { digits }: DtmfConfig): void {
     const session = this._getSession(callSid);
     if (!session || session.state !== SessionState.Established) {
       this._log.warn('dtmf: no established session for callSid', callSid);
@@ -367,8 +364,7 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
     sendDigits();
   }
 
-  sendMessage(callSid: string, config: SipSendMessageConfig): void {
-    const { content, contentType, voiceEventSid } = config;
+  sendMessage(callSid: string, { content, contentType, voiceEventSid }: SipSendMessageConfig): void {
     const session = this._getSession(callSid);
     if (!session || session.state !== SessionState.Established) {
       this._log.warn('sendMessage: no established session for callSid', callSid);

--- a/lib/twilio/signaling/sipsignalingadapter.ts
+++ b/lib/twilio/signaling/sipsignalingadapter.ts
@@ -11,7 +11,22 @@ import {
   UserAgent,
 } from 'sip.js';
 import Log from '../log';
-import { SignalingAdapter, SignalingAdapterStatus } from './signalingadapter';
+import {
+  AnswerConfig,
+  DtmfConfig,
+  HangupConfig,
+  InviteConfig,
+  ReconnectConfig,
+  ReinviteConfig,
+  SignalingAdapter,
+  SignalingAdapterStatus,
+} from './signalingadapter';
+
+interface SipSendMessageConfig {
+  content: string;
+  contentType: string | undefined;
+  voiceEventSid: string;
+}
 
 /**
  * Options for constructing a SipSignalingAdapter.
@@ -252,11 +267,12 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
   // Call signaling
   // ---------------------------------------------------------------------------
 
-  invite(sdp: string, callSid: string, params: string): void {
+  invite(callSid: string, config: InviteConfig): void {
+    const { sdp, params } = config;
     this._sendInvite(sdp, callSid, params);
   }
 
-  answer(sdp: string, callSid: string): void {
+  answer(callSid: string, config: AnswerConfig): void {
     const invitation = this._pendingInvitations.get(callSid);
     if (!invitation) {
       this._log.warn('answer: no pending invitation for callSid', callSid);
@@ -270,7 +286,7 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
     });
   }
 
-  hangup(callSid: string, _message?: string | null): void {
+  hangup(callSid: string, _config?: HangupConfig): void {
     const pendingInvitation = this._pendingInvitations.get(callSid);
     if (pendingInvitation) {
       return this._hangupPendingInvitation(pendingInvitation, callSid);
@@ -302,7 +318,7 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
     });
   }
 
-  reinvite(sdp: string, callSid: string): void {
+  reinvite(callSid: string, config: ReinviteConfig): void {
     const session = this._getSession(callSid);
     if (!session || session.state !== SessionState.Established) {
       this._log.warn('reinvite: no established session for callSid', callSid);
@@ -322,11 +338,13 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
     });
   }
 
-  reconnect(sdp: string, callSid: string, reconnectToken: string): void {
+  reconnect(callSid: string, config: ReconnectConfig): void {
+    const { sdp, reconnectToken } = config;
     this._sendInvite(sdp, callSid, undefined, reconnectToken);
   }
 
-  dtmf(callSid: string, digits: string): void {
+  dtmf(callSid: string, config: DtmfConfig): void {
+    const { digits } = config;
     const session = this._getSession(callSid);
     if (!session || session.state !== SessionState.Established) {
       this._log.warn('dtmf: no established session for callSid', callSid);
@@ -352,13 +370,8 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
     sendDigits();
   }
 
-  sendMessage(
-    callSid: string,
-    content: string,
-    contentType: string | undefined,
-    _messageType: string, // PStream-specific; no SIP MESSAGE equivalent
-    voiceEventSid: string,
-  ): void {
+  sendMessage(callSid: string, config: SipSendMessageConfig): void {
+    const { content, contentType, voiceEventSid } = config;
     const session = this._getSession(callSid);
     if (!session || session.state !== SessionState.Established) {
       this._log.warn('sendMessage: no established session for callSid', callSid);

--- a/lib/twilio/signaling/sipsignalingadapter.ts
+++ b/lib/twilio/signaling/sipsignalingadapter.ts
@@ -20,13 +20,10 @@ import {
   ReinviteConfig,
   SignalingAdapter,
   SignalingAdapterStatus,
+  SendMessageConfig,
 } from './signalingadapter';
 
-interface SipSendMessageConfig {
-  content: string;
-  contentType: string | undefined;
-  voiceEventSid: string;
-}
+type SipSendMessageConfig = Pick<SendMessageConfig, 'content' | 'contentType' | 'voiceEventSid'>;
 
 /**
  * Options for constructing a SipSignalingAdapter.
@@ -286,7 +283,7 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
     });
   }
 
-  hangup(callSid: string, _config?: HangupConfig): void {
+  hangup(callSid: string, _config: HangupConfig = {}): void {
     const pendingInvitation = this._pendingInvitations.get(callSid);
     if (pendingInvitation) {
       return this._hangupPendingInvitation(pendingInvitation, callSid);

--- a/tests/unit/call.ts
+++ b/tests/unit/call.ts
@@ -627,8 +627,8 @@ describe('Call', function() {
           return wait.then(() => {
             onOfferReady('offer-sdp');
             sinon.assert.calledOnce(pstream.invite);
-            assert.equal(pstream.invite.args[0][0], 'offer-sdp');
-            assert.equal(pstream.invite.args[0][2],
+            assert.equal(pstream.invite.args[0][1].sdp, 'offer-sdp');
+            assert.equal(pstream.invite.args[0][1].params,
               'To=foo&a=undefined&b=true&c=false&d=&e=123&f=123&g=null&h=undefined&i=null&j=0&k=0&l=a%24b%26c%3Fd%3De');
           });
         });
@@ -639,8 +639,8 @@ describe('Call', function() {
           return wait.then(() => {
             onOfferReady('offer-sdp');
             sinon.assert.calledOnce(pstream.reconnect);
-            assert.equal(pstream.reconnect.args[0][0], 'offer-sdp');
-            assert.equal(pstream.reconnect.args[0][2], 'testReconnectToken');
+            assert.equal(pstream.reconnect.args[0][1].sdp, 'offer-sdp');
+            assert.equal(pstream.reconnect.args[0][1].reconnectToken, 'testReconnectToken');
           });
         });
 
@@ -1213,10 +1213,12 @@ describe('Call', function() {
       sinon.assert.calledOnceWithExactly(
         pstream.sendMessage,
         mockCallSid,
-        message.content,
-        undefined,
-        'user-defined-message',
-        'foobar-voice-event-sid',
+        {
+          content: message.content,
+          contentType: undefined,
+          messageType: 'user-defined-message',
+          voiceEventSid: 'foobar-voice-event-sid',
+        },
       );
     });
 
@@ -1341,7 +1343,7 @@ describe('Call', function() {
 
     it('should call pstream.dtmf if connected', () => {
       conn.sendDigits('123');
-      sinon.assert.calledWith(pstream.dtmf, conn.parameters.CallSid, '123');
+      sinon.assert.calledWith(pstream.dtmf, conn.parameters.CallSid, { digits: '123' });
     });
 
     it('should emit error if pstream is disconnected', (done) => {
@@ -1490,7 +1492,7 @@ describe('Call', function() {
 
             it('should call pstream.hangup with error message', () => {
               mediaHandler.onerror(Object.assign({ disconnect: true }, baseError));
-              sinon.assert.calledWith(pstream.hangup, conn.outboundConnectionId, 'foo');
+              sinon.assert.calledWith(pstream.hangup, conn.outboundConnectionId, { message: 'foo' });
             });
 
             it('should call mediaHandler.close', () => {
@@ -1957,7 +1959,7 @@ describe('Call', function() {
               doesMediaHandlerVersionExist && signalingReconnectToken ? '' : 'not '
             }call pstream.reconnect()`, async () => {
               if (doesMediaHandlerVersionExist && signalingReconnectToken) {
-                sinon.assert.calledWith(pstream.reconnect, mediaHandler.version.getSDP(), 'CA1234', signalingReconnectToken);
+                sinon.assert.calledWith(pstream.reconnect, 'CA1234', { sdp: mediaHandler.version.getSDP(), reconnectToken: signalingReconnectToken });
               } else {
                 sinon.assert.notCalled(pstream.reconnect);
               }

--- a/tests/unit/pstreamsignalingadapter.ts
+++ b/tests/unit/pstreamsignalingadapter.ts
@@ -34,17 +34,17 @@ describe('PStreamSignalingAdapter', () => {
   });
 
   it('should delegate invite() to pstream', () => {
-    adapter.invite('sdp', 'callSid', 'params');
+    adapter.invite('callSid', { sdp: 'sdp', params: 'params' });
     assert(pstream.invite.calledWith('sdp', 'callSid', 'params'));
   });
 
   it('should delegate answer() to pstream', () => {
-    adapter.answer('sdp', 'callSid');
+    adapter.answer('callSid', { sdp: 'sdp' });
     assert(pstream.answer.calledWith('sdp', 'callSid'));
   });
 
   it('should delegate hangup() to pstream', () => {
-    adapter.hangup('callSid', 'msg');
+    adapter.hangup('callSid', { message: 'msg' });
     assert(pstream.hangup.calledWith('callSid', 'msg'));
   });
 
@@ -54,22 +54,22 @@ describe('PStreamSignalingAdapter', () => {
   });
 
   it('should delegate reinvite() to pstream', () => {
-    adapter.reinvite('sdp', 'callSid');
+    adapter.reinvite('callSid', { sdp: 'sdp' });
     assert(pstream.reinvite.calledWith('sdp', 'callSid'));
   });
 
   it('should delegate reconnect() to pstream', () => {
-    adapter.reconnect('sdp', 'callSid', 'token');
+    adapter.reconnect('callSid', { sdp: 'sdp', reconnectToken: 'token' });
     assert(pstream.reconnect.calledWith('sdp', 'callSid', 'token'));
   });
 
   it('should delegate dtmf() to pstream', () => {
-    adapter.dtmf('callSid', '123');
+    adapter.dtmf('callSid', { digits: '123' });
     assert(pstream.dtmf.calledWith('callSid', '123'));
   });
 
   it('should delegate sendMessage() to pstream', () => {
-    adapter.sendMessage('callSid', 'hi', 'text/plain', 'user-msg', 'evt1');
+    adapter.sendMessage('callSid', { content: 'hi', contentType: 'text/plain', messageType: 'user-msg', voiceEventSid: 'evt1' });
     assert(pstream.sendMessage.calledWith('callSid', 'hi', 'text/plain', 'user-msg', 'evt1'));
   });
 

--- a/tests/unit/sipsignalingadapter.ts
+++ b/tests/unit/sipsignalingadapter.ts
@@ -412,7 +412,7 @@ describe('SipSignalingAdapter', () => {
       adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
       inviterStub._simulateState('Terminated');
       // Subsequent hangup should warn (no session found) — just verifying no crash
-      assert.doesNotThrow(() => adapter.hangup('call-1'));
+      assert.doesNotThrow(() => adapter.hangup('call-1', {}));
     });
   });
 
@@ -567,7 +567,7 @@ describe('SipSignalingAdapter', () => {
       const { adapter, inviterStub } = createAdapter();
       adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
       inviterStub.state = 'Established';
-      adapter.hangup('call-1');
+      adapter.hangup('call-1', {});
       assert(inviterStub.bye.calledOnce);
     });
 
@@ -575,7 +575,7 @@ describe('SipSignalingAdapter', () => {
       const { adapter, inviterStub } = createAdapter();
       adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
       inviterStub.state = 'Establishing';
-      adapter.hangup('call-1');
+      adapter.hangup('call-1', {});
       assert(inviterStub.cancel.calledOnce);
     });
 
@@ -583,13 +583,13 @@ describe('SipSignalingAdapter', () => {
       const { adapter, uaStub } = createAdapter();
       const inv = createInvitationStub();
       uaStub._triggerInvite(inv);
-      adapter.hangup('CA-test-call-sid');
+      adapter.hangup('CA-test-call-sid', {});
       assert(inv.reject.calledOnce);
     });
 
     it('should not throw for unknown callSid', () => {
       const { adapter } = createAdapter();
-      assert.doesNotThrow(() => adapter.hangup('unknown'));
+      assert.doesNotThrow(() => adapter.hangup('unknown', {}));
     });
   });
 
@@ -699,7 +699,7 @@ describe('SipSignalingAdapter', () => {
       adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
       uaStub._triggerDisconnect();
       // Session map cleared — hangup should not find session
-      assert.doesNotThrow(() => adapter.hangup('call-1'));
+      assert.doesNotThrow(() => adapter.hangup('call-1', {}));
     });
   });
 });

--- a/tests/unit/sipsignalingadapter.ts
+++ b/tests/unit/sipsignalingadapter.ts
@@ -1,5 +1,6 @@
 import * as assert from 'assert';
 import * as sinon from 'sinon';
+import { SignalingAdapter } from '../../lib/twilio/signaling/signalingadapter';
 import { SipSignalingAdapter } from '../../lib/twilio/signaling/sipsignalingadapter';
 
 /**
@@ -112,7 +113,7 @@ function createAdapter(overrides?: Partial<any>) {
     ...overrides,
   });
 
-  return { adapter, uaStub, regStub, inviterStub };
+  return { adapter: adapter as SignalingAdapter, uaStub, regStub, inviterStub };
 }
 
 describe('SipSignalingAdapter', () => {
@@ -354,7 +355,7 @@ describe('SipSignalingAdapter', () => {
   describe('invite()', () => {
     it('should create an Inviter and call invite()', () => {
       const { adapter, inviterStub } = createAdapter();
-      adapter.invite('sdp', 'call-1', 'To=bob');
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
       assert(inviterStub.invite.calledOnce);
     });
 
@@ -364,7 +365,7 @@ describe('SipSignalingAdapter', () => {
         assert.strictEqual(payload.callsid, 'call-1');
         done();
       });
-      adapter.invite('sdp', 'call-1', 'To=bob');
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
       const rd = inviterStub._getRequestDelegate();
       rd.onProgress({});
     });
@@ -375,7 +376,7 @@ describe('SipSignalingAdapter', () => {
         assert.strictEqual(payload.callsid, 'call-1');
         done();
       });
-      adapter.invite('sdp', 'call-1', 'To=bob');
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
       const rd = inviterStub._getRequestDelegate();
       rd.onAccept({});
     });
@@ -387,7 +388,7 @@ describe('SipSignalingAdapter', () => {
         assert(payload.error);
         done();
       });
-      adapter.invite('sdp', 'call-1', 'To=bob');
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
       const rd = inviterStub._getRequestDelegate();
       rd.onReject({ message: { statusCode: 486, reasonPhrase: 'Busy Here' } });
     });
@@ -403,12 +404,12 @@ describe('SipSignalingAdapter', () => {
         assert(payload.error.message.includes('transport down'));
         done();
       });
-      adapter.invite('sdp', 'call-1', 'To=bob');
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
     });
 
     it('should clean up session on SessionState.Terminated', () => {
       const { adapter, inviterStub } = createAdapter();
-      adapter.invite('sdp', 'call-1', 'To=bob');
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
       inviterStub._simulateState('Terminated');
       // Subsequent hangup should warn (no session found) — just verifying no crash
       assert.doesNotThrow(() => adapter.hangup('call-1'));
@@ -418,7 +419,7 @@ describe('SipSignalingAdapter', () => {
   describe('reconnect()', () => {
     it('should create an Inviter and call invite()', () => {
       const { adapter, inviterStub } = createAdapter();
-      adapter.reconnect('sdp', 'call-1', 'rtoken');
+      adapter.reconnect('call-1', { sdp: 'sdp', reconnectToken: 'rtoken' });
       assert(inviterStub.invite.calledOnce);
     });
 
@@ -428,7 +429,7 @@ describe('SipSignalingAdapter', () => {
         assert.strictEqual(payload.reconnect, 'rtoken');
         done();
       });
-      adapter.reconnect('sdp', 'call-1', 'rtoken');
+      adapter.reconnect('call-1', { sdp: 'sdp', reconnectToken: 'rtoken' });
       const rd = inviterStub._getRequestDelegate();
       rd.onAccept({});
     });
@@ -493,7 +494,7 @@ describe('SipSignalingAdapter', () => {
       const { adapter, uaStub } = createAdapter();
       const inv = createInvitationStub();
       uaStub._triggerInvite(inv);
-      adapter.answer('sdp-answer', 'CA-test-call-sid');
+      adapter.answer('CA-test-call-sid', { sdp: 'sdp-answer' });
       adapter.on('hangup', (payload: any) => {
         assert.strictEqual(payload.callsid, 'CA-test-call-sid');
         done();
@@ -507,14 +508,14 @@ describe('SipSignalingAdapter', () => {
       const { adapter, uaStub } = createAdapter();
       const inv = createInvitationStub();
       uaStub._triggerInvite(inv);
-      adapter.answer('sdp-answer', 'CA-test-call-sid');
+      adapter.answer('CA-test-call-sid', { sdp: 'sdp-answer' });
       assert(inv.accept.calledOnce);
     });
 
     it('should warn if no pending invitation', () => {
       const { adapter } = createAdapter();
       // Should not throw — just warns
-      assert.doesNotThrow(() => adapter.answer('sdp', 'unknown-id'));
+      assert.doesNotThrow(() => adapter.answer('unknown-id', { sdp: 'sdp' }));
     });
 
     it('should emit "error" if accept() fails', (done) => {
@@ -528,7 +529,7 @@ describe('SipSignalingAdapter', () => {
         assert.strictEqual(payload.callsid, 'CA-test-call-sid');
         done();
       });
-      adapter.answer('sdp-answer', 'CA-test-call-sid');
+      adapter.answer('CA-test-call-sid', { sdp: 'sdp-answer' });
     });
   });
 
@@ -564,7 +565,7 @@ describe('SipSignalingAdapter', () => {
   describe('hangup()', () => {
     it('should call session.bye() when state is Established', () => {
       const { adapter, inviterStub } = createAdapter();
-      adapter.invite('sdp', 'call-1', 'To=bob');
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
       inviterStub.state = 'Established';
       adapter.hangup('call-1');
       assert(inviterStub.bye.calledOnce);
@@ -572,7 +573,7 @@ describe('SipSignalingAdapter', () => {
 
     it('should call inviter.cancel() when state is Establishing', () => {
       const { adapter, inviterStub } = createAdapter();
-      adapter.invite('sdp', 'call-1', 'To=bob');
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
       inviterStub.state = 'Establishing';
       adapter.hangup('call-1');
       assert(inviterStub.cancel.calledOnce);
@@ -595,9 +596,9 @@ describe('SipSignalingAdapter', () => {
   describe('reinvite()', () => {
     it('should call session.invite() for established sessions', () => {
       const { adapter, inviterStub } = createAdapter();
-      adapter.invite('sdp', 'call-1', 'To=bob');
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
       inviterStub.state = 'Established';
-      adapter.reinvite('new-sdp', 'call-1');
+      adapter.reinvite('call-1', { sdp: 'new-sdp' });
       // session.invite is the re-INVITE call (distinct from inviter.invite for initial INVITE)
       // inviterStub.invite is called once for initial, then once for reinvite = 2 total
       assert.strictEqual(inviterStub.invite.callCount, 2);
@@ -605,27 +606,27 @@ describe('SipSignalingAdapter', () => {
 
     it('should not throw for non-established session', () => {
       const { adapter } = createAdapter();
-      assert.doesNotThrow(() => adapter.reinvite('sdp', 'unknown'));
+      assert.doesNotThrow(() => adapter.reinvite('unknown', { sdp: 'sdp' }));
     });
 
     it('should emit "answer" on requestDelegate.onAccept', (done) => {
       const { adapter, inviterStub } = createAdapter();
-      adapter.invite('sdp', 'call-1', 'To=bob');
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
       inviterStub.state = 'Established';
       adapter.on('answer', (payload: any) => {
         assert.strictEqual(payload.callsid, 'call-1');
         done();
       });
-      adapter.reinvite('new-sdp', 'call-1');
+      adapter.reinvite('call-1', { sdp: 'new-sdp' });
       const rd = inviterStub.invite.lastCall.args[0]?.requestDelegate;
       rd.onAccept();
     });
 
     it('should warn but not throw on requestDelegate.onReject', () => {
       const { adapter, inviterStub } = createAdapter();
-      adapter.invite('sdp', 'call-1', 'To=bob');
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
       inviterStub.state = 'Established';
-      adapter.reinvite('new-sdp', 'call-1');
+      adapter.reinvite('call-1', { sdp: 'new-sdp' });
       const rd = inviterStub.invite.lastCall.args[0]?.requestDelegate;
       assert.doesNotThrow(() => rd.onReject({ message: { statusCode: 488 } }));
     });
@@ -634,9 +635,9 @@ describe('SipSignalingAdapter', () => {
   describe('dtmf()', () => {
     it('should call session.info() for each digit', async () => {
       const { adapter, inviterStub } = createAdapter();
-      adapter.invite('sdp', 'call-1', 'To=bob');
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
       inviterStub.state = 'Established';
-      adapter.dtmf('call-1', '12');
+      adapter.dtmf('call-1', { digits: '12' });
       // Allow async sends to complete
       await new Promise(resolve => setTimeout(resolve, 10));
       assert.strictEqual(inviterStub.info.callCount, 2);
@@ -644,14 +645,14 @@ describe('SipSignalingAdapter', () => {
 
     it('should not throw for non-established session', () => {
       const { adapter } = createAdapter();
-      assert.doesNotThrow(() => adapter.dtmf('unknown', '1'));
+      assert.doesNotThrow(() => adapter.dtmf('unknown', { digits: '1' }));
     });
   });
 
   describe('sendMessage()', () => {
     it('should call session.message() and emit "ack"', (done) => {
       const { adapter, inviterStub } = createAdapter();
-      adapter.invite('sdp', 'call-1', 'To=bob');
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
       inviterStub.state = 'Established';
       adapter.on('ack', (payload: any) => {
         assert.strictEqual(payload.acktype, 'message');
@@ -659,7 +660,7 @@ describe('SipSignalingAdapter', () => {
         assert.strictEqual(payload.voiceeventsid, 'evt-1');
         done();
       });
-      adapter.sendMessage('call-1', '{"hello":"world"}', 'application/json', 'user-msg', 'evt-1');
+      adapter.sendMessage('call-1', { content: '{"hello":"world"}', contentType: 'application/json', messageType: 'user-msg', voiceEventSid: 'evt-1' });
     });
 
     it('should emit "error" if message() fails', (done) => {
@@ -668,25 +669,25 @@ describe('SipSignalingAdapter', () => {
       const { adapter } = createAdapter({
         createInviter() { return failInviterStub as any; },
       });
-      adapter.invite('sdp', 'call-1', 'To=bob');
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
       failInviterStub._simulateState('Established');
       adapter.on('error', (payload: any) => {
         assert.strictEqual(payload.voiceeventsid, 'evt-1');
         done();
       });
-      adapter.sendMessage('call-1', 'hi', 'text/plain', 'user-msg', 'evt-1');
+      adapter.sendMessage('call-1', { content: 'hi', contentType: 'text/plain', messageType: 'user-msg', voiceEventSid: 'evt-1' });
     });
 
     it('should not throw for unknown callSid', () => {
       const { adapter } = createAdapter();
-      assert.doesNotThrow(() => adapter.sendMessage('unknown', 'hi', 'text/plain', 'msg', 'evt'));
+      assert.doesNotThrow(() => adapter.sendMessage('unknown', { content: 'hi', contentType: 'text/plain', messageType: 'msg', voiceEventSid: 'evt' }));
     });
   });
 
   describe('lifecycle cleanup', () => {
     it('destroy() should bye established sessions and clear maps', () => {
       const { adapter, inviterStub } = createAdapter();
-      adapter.invite('sdp', 'call-1', 'To=bob');
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
       inviterStub.state = 'Established';
       adapter.destroy();
       assert(inviterStub.bye.calledOnce);
@@ -695,7 +696,7 @@ describe('SipSignalingAdapter', () => {
     it('transport disconnect should clear session maps', () => {
       const { adapter, uaStub, inviterStub } = createAdapter();
       uaStub._triggerConnect();
-      adapter.invite('sdp', 'call-1', 'To=bob');
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
       uaStub._triggerDisconnect();
       // Session map cleared — hangup should not find session
       assert.doesNotThrow(() => adapter.hangup('call-1'));


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

https://twilio-engineering.atlassian.net/browse/VBLOCKS-6500

### Description

  - Refactor SignalingAdapter call-signaling methods from positional params to config objects (InviteConfig, AnswerConfig, HangupConfig, ReinviteConfig, ReconnectConfig, DtmfConfig, SendMessageConfig)
  - callSid remains as the first positional param; reject() unchanged (single param)
  - PStreamSignalingAdapter destructures each config and forwards positionally to PStream's existing API
  - SipSignalingAdapter destructures only the fields it needs; introduces SipSendMessageConfig to narrow the type (excludes PStream-specific messageType)
  - Call sites in call.ts build typed consts (e.g. const inviteConfig: InviteConfig = { ... }) before passing to adapter methods
  - Internal-only interface — no public API changes

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Ready for review
