### PR TITLE
chore(call): simplify permission error name comparison

### DIFF
--- a/lib/twilio/call.ts
+++ b/lib/twilio/call.ts
@@ -685,7 +685,7 @@ class Call extends EventEmitter {
       let twilioError;
 
       if (error.code === 31208
-        || ['PermissionDeniedError', 'NotAllowedError'].indexOf(error.name) !== -1) {
+        || ['PermissionDeniedError', 'NotAllowedError'].includes(error.name)) {
         twilioError = new UserMediaErrors.PermissionDeniedError();
         this._publisher.error('get-user-media', 'denied', {
           data: {


### PR DESCRIPTION
## Pull Request Details

### Description

Use `.includes()` instead of `indexOf() !== -1` in the permission error check

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [x] Ready for review
