### PR TITLE
[VBLOCKS-6372] feat: sdh implementation

### DIFF
--- a/lib/twilio/call.ts
+++ b/lib/twilio/call.ts
@@ -685,24 +685,71 @@ class Call extends EventEmitter {
       }
 
       this._signalingAdapter.addListener('hangup', this._onHangup);
+      this._signalingAdapter.on('answer', this._onAnswer);
 
-      if (this._direction === Call.CallDirection.Incoming) {
+      const callSid = this.parameters.CallSid;
+
+      if (this._options.useSip) {
+        // PeerConnection.onopen fires from multiple stable-state observers,
+        // so we gate onAnswer to a single call.
+        const previousOnOpen = this._mediaHandler.onopen;
+        let onAnswerFired = false;
+        this._mediaHandler.onopen = () => {
+          previousOnOpen();
+          if (!onAnswerFired && this._mediaHandler.version?.pc) {
+            onAnswerFired = true;
+            onAnswer(this._mediaHandler.version.pc);
+          }
+        };
+      }
+
+      const params = Array.from(this.customParameters.entries()).map(pair =>
+        `${encodeURIComponent(pair[0])}=${encodeURIComponent(pair[1])}`).join('&');
+      const outgoingCallSid = this._options.reconnectCallSid || this.outboundConnectionId!;
+
+      const answerViaSip = () => {
         this._isAnswered = true;
-        this._signalingAdapter.on('answer', this._onAnswer);
-        this._mediaHandler.answerIncomingCall(this.parameters.CallSid,
-          this._options.offerSdp, rtcConfiguration,
+        this._signalingAdapter.answer(callSid, {
+          sdp: this._options.offerSdp || '',
+          peerConnection: this._mediaHandler,
+          rtcConfiguration,
+        });
+      };
+
+      const answerViaMediaHandler = () => {
+        this._isAnswered = true;
+        this._mediaHandler.answerIncomingCall(
+          callSid,
+          this._options.offerSdp,
+          rtcConfiguration,
           (answerSdp: string) => {
-            const answerConfig: AnswerConfig = { sdp: answerSdp };
-            this._signalingAdapter.answer(this.parameters.CallSid, answerConfig);
+            this._signalingAdapter.answer(callSid, { sdp: answerSdp });
           },
-          onAnswer);
-      } else {
-        const params = Array.from(this.customParameters.entries()).map(pair =>
-         `${encodeURIComponent(pair[0])}=${encodeURIComponent(pair[1])}`).join('&');
-        this._signalingAdapter.on('answer', this._onAnswer);
+          onAnswer,
+        );
+      };
 
-        const outgoingCallSid = this._options.reconnectCallSid || this.outboundConnectionId!;
+      const inviteViaSip = () => {
+        if (this._signalingReconnectToken) {
+          const reconnectConfig: ReconnectConfig = {
+            sdp: '',
+            reconnectToken: this._signalingReconnectToken,
+            peerConnection: this._mediaHandler,
+            rtcConfiguration,
+          };
+          this._signalingAdapter.reconnect(outgoingCallSid, reconnectConfig);
+        } else {
+          const inviteConfig: InviteConfig = {
+            sdp: '',
+            params,
+            peerConnection: this._mediaHandler,
+            rtcConfiguration,
+          };
+          this._signalingAdapter.invite(outgoingCallSid, inviteConfig);
+        }
+      };
 
+      const inviteViaMediaHandler = () => {
         this._mediaHandler.makeOutgoingCall(outgoingCallSid, rtcConfiguration, (offerSdp: string) => {
           const onPstreamAnswerOrRinging = (payload: any) => {
             if (!payload.sdp) { return; }
@@ -732,7 +779,12 @@ class Call extends EventEmitter {
           // self._setupDTLSTransport in the media handler after this method
           // finishes. See peerconnection.makeOutgoingCall.
         });
+      };
+
+      if (this._direction === Call.CallDirection.Incoming) {
+        return this._options.useSip ? answerViaSip() : answerViaMediaHandler();
       }
+      return this._options.useSip ? inviteViaSip() : inviteViaMediaHandler();
     };
 
     if (this._options.beforeAccept) {
@@ -2139,6 +2191,13 @@ namespace Call {
      * TwiML params for the call. May be set for either outgoing or incoming calls.
      */
     twimlParams?: Record<string, any>;
+
+    /**
+     * When true, the call uses the SIP.js-backed signaling path. The SDP
+     * exchange runs through SipSessionDescriptionHandler instead of being
+     * performed eagerly by Call.
+     */
+    useSip?: boolean;
 
     /**
      * Voice event SID generator.

--- a/lib/twilio/call.ts
+++ b/lib/twilio/call.ts
@@ -189,6 +189,14 @@ class Call extends EventEmitter {
   private _isAnswered: boolean = false;
 
   /**
+   * Whether the SIP-path onopen wrapper has already been installed. Guards
+   * against repeated `accept()` invocations chaining wrappers onto the
+   * previous one (each layer would retain its own onAnswerFired closure
+   * and fire independently against stale state).
+   */
+  private _sipOnOpenWrapped: boolean = false;
+
+  /**
    * Whether the call has been cancelled.
    */
   private _isCancelled: boolean = false;
@@ -689,9 +697,11 @@ class Call extends EventEmitter {
 
       const callSid = this.parameters.CallSid;
 
-      if (this._options.useSip) {
+      if (this._options.useSip && !this._sipOnOpenWrapped) {
         // PeerConnection.onopen fires from multiple stable-state observers,
-        // so we gate onAnswer to a single call.
+        // so we gate onAnswer to a single call. _sipOnOpenWrapped prevents a
+        // repeat accept() from chaining another wrapper over this one.
+        this._sipOnOpenWrapped = true;
         const previousOnOpen = this._mediaHandler.onopen;
         let onAnswerFired = false;
         this._mediaHandler.onopen = () => {
@@ -709,8 +719,9 @@ class Call extends EventEmitter {
 
       const answerViaSip = () => {
         this._isAnswered = true;
+        // SDP intentionally omitted: the SIP adapter derives the answer
+        // from the invitation body via its SDH, not from the caller.
         this._signalingAdapter.answer(callSid, {
-          sdp: this._options.offerSdp || '',
           peerConnection: this._mediaHandler,
           rtcConfiguration,
         });
@@ -739,9 +750,11 @@ class Call extends EventEmitter {
           };
           this._signalingAdapter.reconnect(outgoingCallSid, reconnectConfig);
         } else {
+          // params are intentionally omitted: the SIP adapter does not
+          // currently embed caller-supplied params in the INVITE. If/when
+          // that's added, pass them as extraHeaders through InviteConfig.
           const inviteConfig: InviteConfig = {
             sdp: '',
-            params,
             peerConnection: this._mediaHandler,
             rtcConfiguration,
           };

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -1587,9 +1587,16 @@ class Device extends EventEmitter {
       // plain `sip:user@host` or `sip:user@host:port` forms; URIs with
       // parameters (e.g. `;transport=tcp`) would parse incorrectly. Twilio-
       // issued SIP URIs don't carry parameters today — revisit if that changes.
-      const parsedUri = new URL(sipOpts.sipUri.replace(/^sip:/, 'http://'));
+      let parsedUri: URL;
+      try {
+        parsedUri = new URL(sipOpts.sipUri.replace(/^sip:/, 'http://'));
+      } catch {
+        throw new InvalidArgumentError(
+          '`signalingOptions.sipUri` must be a valid SIP URI of the form `sip:user@host` or `sip:user@host:port`',
+        );
+      }
       return new SipSignalingAdapter({
-        sipDomain: parsedUri.hostname,
+        sipDomain: parsedUri.host,
         sipUri: sipOpts.sipUri,
         sipTransportServer: sipOpts.sipServer,
         credentials: sipOpts.sipCredentials,

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -994,6 +994,9 @@ class Device extends EventEmitter {
     if (typeof opts.sipServer !== 'string' || !opts.sipServer) {
       throw new InvalidArgumentError('`signalingOptions.sipServer` is required when `useSignalingMethod` is "sip"');
     }
+    if (typeof opts.sipUri !== 'string' || !opts.sipUri) {
+      throw new InvalidArgumentError('`signalingOptions.sipUri` is required when `useSignalingMethod` is "sip"');
+    }
     if (typeof opts.sipCredentials?.username !== 'string' || !opts.sipCredentials.username
         || typeof opts.sipCredentials?.password !== 'string' || !opts.sipCredentials.password) {
       throw new InvalidArgumentError(
@@ -1075,6 +1078,7 @@ class Device extends EventEmitter {
     options = Object.assign({
       MediaStream: this._options.MediaStream,
       RTCPeerConnection: this._options.RTCPeerConnection,
+      useSip: this._options.signalingOptions?.useSignalingMethod === 'sip',
       beforeAccept: (currentCall: Call) => {
         if (!this._activeCall || this._activeCall === currentCall) {
           return;
@@ -1579,13 +1583,17 @@ class Device extends EventEmitter {
     if (this._options.signalingOptions?.useSignalingMethod === 'sip') {
       this._log.info('Setting up SIP signaling');
       const sipOpts = this._options.signalingOptions as Device.SIPSignalingOptions;
-      const domain = new URL(sipOpts.sipServer).hostname;
+      // Reuse the browser's URL parser by swapping the scheme. Only safe for
+      // plain `sip:user@host` or `sip:user@host:port` forms; URIs with
+      // parameters (e.g. `;transport=tcp`) would parse incorrectly. Twilio-
+      // issued SIP URIs don't carry parameters today — revisit if that changes.
+      const parsedUri = new URL(sipOpts.sipUri.replace(/^sip:/, 'http://'));
       return new SipSignalingAdapter({
-        sipDomain: domain,
-        sipUri: `sip:${sipOpts.sipCredentials.username}@${domain}`,
+        sipDomain: parsedUri.hostname,
+        sipUri: sipOpts.sipUri,
         sipTransportServer: sipOpts.sipServer,
         credentials: sipOpts.sipCredentials,
-        region: sipOpts.region || domain.split('.')[1],
+        region: sipOpts.region,
       });
     }
 
@@ -1941,8 +1949,14 @@ namespace Device {
    */
   export interface SIPSignalingOptions {
     useSignalingMethod: 'sip';
-    /** The SIP WebSocket server URL (e.g. `'wss://sip.example.com'`). */
+    /** The SIP WebSocket transport URL (e.g. `'wss://sip.example.com'`). */
     sipServer: string;
+    /**
+     * The SIP identity URI for this client
+     * (e.g. `'sip:alice@registrar.example.com'`). The domain portion is the
+     * SIP registrar, which can differ from the WebSocket transport host.
+     */
+    sipUri: string;
     /** SIP digest authentication credentials. */
     sipCredentials: { username: string; password: string };
     /** Optional region hint for edge/region metadata (e.g. `'ashburn'`). */

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -1589,14 +1589,21 @@ class Device extends EventEmitter {
       // issued SIP URIs don't carry parameters today — revisit if that changes.
       let parsedUri: URL;
       try {
-        parsedUri = new URL(sipOpts.sipUri.replace(/^sip:/, 'http://'));
+        // Case-insensitive scheme match — RFC 3261 allows `SIP:` as well.
+        // `sips:` is not supported: Twilio's SIP-over-WebSocket relies on
+        // the WSS transport for security, and Twilio-issued URIs use `sip:`.
+        parsedUri = new URL(sipOpts.sipUri.replace(/^sip:/i, 'http://'));
       } catch {
         throw new InvalidArgumentError(
           '`signalingOptions.sipUri` must be a valid SIP URI of the form `sip:user@host` or `sip:user@host:port`',
         );
       }
       return new SipSignalingAdapter({
-        sipDomain: parsedUri.host,
+        // Use hostname (not host) so any port in the sipUri is dropped —
+        // the target Request-URI should be `sip:host`, with transport/port
+        // handled by the WebSocket transport config. Twilio-issued SIP URIs
+        // don't currently carry ports.
+        sipDomain: parsedUri.hostname,
         sipUri: sipOpts.sipUri,
         sipTransportServer: sipOpts.sipServer,
         credentials: sipOpts.sipCredentials,

--- a/lib/twilio/signaling/pstreamsignalingadapter.ts
+++ b/lib/twilio/signaling/pstreamsignalingadapter.ts
@@ -66,6 +66,9 @@ export class PStreamSignalingAdapter extends EventEmitter implements SignalingAd
   }
 
   answer(callSid: string, { sdp }: AnswerConfig): void {
+    if (typeof sdp !== 'string') {
+      throw new Error('PStreamSignalingAdapter.answer: sdp is required');
+    }
     this._pstream.answer(sdp, callSid);
   }
 

--- a/lib/twilio/signaling/signalingadapter.ts
+++ b/lib/twilio/signaling/signalingadapter.ts
@@ -5,13 +5,19 @@ export type SignalingAdapterStatus = 'disconnected' | 'connected' | 'ready' | 'o
 
 export interface InviteConfig {
   sdp: string;
-  params: string;
+  // Optional: PStream encodes these as the INVITE body; reconnect flows
+  // and the SIP adapter don't carry caller-supplied params, so callers
+  // can omit this field instead of passing a dummy empty string.
+  params?: string;
   peerConnection?: IPeerConnection;
   rtcConfiguration?: RTCConfiguration;
 }
 
 export interface AnswerConfig {
-  sdp: string;
+  // Optional because the SIP adapter derives the answer SDP from the
+  // invitation body via the SDH, rather than receiving it from the
+  // caller. The PStream adapter requires it and will reject undefined.
+  sdp?: string;
   peerConnection?: IPeerConnection;
   rtcConfiguration?: RTCConfiguration;
 }

--- a/lib/twilio/signaling/signalingadapter.ts
+++ b/lib/twilio/signaling/signalingadapter.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events';
-import { IPeerConnection } from './sipsessiondescriptionhandler';
+import type { IPeerConnection } from './sipsessiondescriptionhandler';
 
 export type SignalingAdapterStatus = 'disconnected' | 'connected' | 'ready' | 'offline';
 

--- a/lib/twilio/signaling/signalingadapter.ts
+++ b/lib/twilio/signaling/signalingadapter.ts
@@ -1,14 +1,19 @@
 import { EventEmitter } from 'events';
+import { IPeerConnection } from './sipsessiondescriptionhandler';
 
 export type SignalingAdapterStatus = 'disconnected' | 'connected' | 'ready' | 'offline';
 
 export interface InviteConfig {
   sdp: string;
   params: string;
+  peerConnection?: IPeerConnection;
+  rtcConfiguration?: RTCConfiguration;
 }
 
 export interface AnswerConfig {
   sdp: string;
+  peerConnection?: IPeerConnection;
+  rtcConfiguration?: RTCConfiguration;
 }
 
 export interface HangupConfig {
@@ -22,6 +27,8 @@ export interface ReinviteConfig {
 export interface ReconnectConfig {
   sdp: string;
   reconnectToken: string;
+  peerConnection?: IPeerConnection;
+  rtcConfiguration?: RTCConfiguration;
 }
 
 export interface DtmfConfig {

--- a/lib/twilio/signaling/sipsessiondescriptionhandler.ts
+++ b/lib/twilio/signaling/sipsessiondescriptionhandler.ts
@@ -1,0 +1,100 @@
+import { BodyAndContentType, SessionDescriptionHandler } from 'sip.js';
+
+/**
+ * Narrow view of the SDK's PeerConnection class containing only the
+ * methods that SipSessionDescriptionHandler depends on. The real
+ * PeerConnection class (lib/twilio/rtc/peerconnection.ts) structurally
+ * satisfies this interface.
+ */
+export interface IPeerConnection {
+  makeOutgoingCall(
+    callSid: string,
+    rtcConfiguration: RTCConfiguration,
+    onOfferReady: (offerSdp: string) => void,
+  ): void;
+
+  answerIncomingCall(
+    callSid: string,
+    sdp: string,
+    rtcConfiguration: RTCConfiguration,
+    onAnswerReady: (answerSdp: string) => void,
+    onMediaStarted: (pc: RTCPeerConnection) => void,
+  ): void;
+
+  processAnswer(
+    sdp: string,
+    onMediaStarted: (pc: RTCPeerConnection) => void,
+  ): void;
+
+  close(): void;
+}
+
+const APPLICATION_SDP = 'application/sdp';
+
+/**
+ * Bridges SIP.js's SessionDescriptionHandler interface to the SDK's
+ * PeerConnection. The SDH does not own the RTCPeerConnection — it
+ * delegates offer/answer creation and remote-SDP processing to
+ * PeerConnection. Its job is to translate between SIP.js's Promise-
+ * based SDH contract and PeerConnection's callback-based API.
+ *
+ * Call flows:
+ *   Outbound: getDescription() -> makeOutgoingCall produces offer
+ *             setDescription() -> processAnswer consumes remote answer
+ *   Inbound:  setDescription() -> answerIncomingCall consumes offer and
+ *                                 produces an answer (cached)
+ *             getDescription() -> returns the cached answer
+ */
+export class SipSessionDescriptionHandler implements SessionDescriptionHandler {
+  private _cachedAnswer: string | null = null;
+  private _hasSentOffer: boolean = false;
+
+  constructor(
+    private _pc: IPeerConnection,
+    private _callSid: string,
+    private _rtcConfiguration: RTCConfiguration = {},
+  ) {}
+
+  getDescription(): Promise<BodyAndContentType> {
+    if (this._cachedAnswer !== null) {
+      const body = this._cachedAnswer;
+      this._cachedAnswer = null;
+      return Promise.resolve({ body, contentType: APPLICATION_SDP });
+    }
+    return new Promise<BodyAndContentType>((resolve) => {
+      this._pc.makeOutgoingCall(this._callSid, this._rtcConfiguration, (offerSdp) => {
+        this._hasSentOffer = true;
+        resolve({ body: offerSdp, contentType: APPLICATION_SDP });
+      });
+    });
+  }
+
+  hasDescription(contentType: string): boolean {
+    return contentType === APPLICATION_SDP;
+  }
+
+  setDescription(sdp: string): Promise<void> {
+    if (this._hasSentOffer) {
+      return new Promise<void>((resolve) => {
+        this._pc.processAnswer(sdp, () => resolve());
+      });
+    }
+    return new Promise<void>((resolve) => {
+      this._pc.answerIncomingCall(
+        this._callSid,
+        sdp,
+        this._rtcConfiguration,
+        (answerSdp) => { this._cachedAnswer = answerSdp; },
+        () => resolve(),
+      );
+    });
+  }
+
+  close(): void {
+    this._pc.close();
+  }
+
+  sendDtmf(_tones: string): boolean {
+    return false;
+  }
+}

--- a/lib/twilio/signaling/sipsessiondescriptionhandler.ts
+++ b/lib/twilio/signaling/sipsessiondescriptionhandler.ts
@@ -64,9 +64,11 @@ export class SipSessionDescriptionHandler implements SessionDescriptionHandler {
   private _cachedAnswer: string | null = null;
   private _hasSentOffer: boolean = false;
   // PeerConnection reports failures via onerror, not the success callbacks
-  // we pass in. When an operation is pending we store its reject handler
-  // here; the onerror hook in the constructor triggers it.
-  private _rejectPending: ((error: Error) => void) | null = null;
+  // we pass in. Every in-flight operation adds its reject handler here;
+  // the onerror hook in the constructor rejects all of them. SIP.js can
+  // issue overlapping setDescription calls (e.g. PRACK/UPDATE during early
+  // media), so a single-slot field would let earlier Promises hang.
+  private _pendingRejects: Set<(error: Error) => void> = new Set();
 
   constructor(
     private _pc: IPeerConnection,
@@ -101,7 +103,14 @@ export class SipSessionDescriptionHandler implements SessionDescriptionHandler {
   setDescription(sdp: string): Promise<void> {
     if (this._hasSentOffer) {
       return this._awaitOperation<void>((resolve) => {
-        this._pc.processAnswer(sdp, () => resolve());
+        this._pc.processAnswer(sdp, () => {
+          // Outbound offer/answer exchange complete. Clear the flag so a
+          // subsequent re-INVITE on the same session (SIP.js memoizes the
+          // SDH per Session) can route correctly — inbound re-INVITE must
+          // go down answerIncomingCall, outbound must set the flag again.
+          this._hasSentOffer = false;
+          resolve();
+        });
       });
     }
     return this._awaitOperation<void>((resolve) => {
@@ -116,29 +125,32 @@ export class SipSessionDescriptionHandler implements SessionDescriptionHandler {
   }
 
   close(): void {
+    // Call owns the PeerConnection lifecycle and closes it in its own
+    // teardown paths. SIP.js invokes close() on the SDH at session end —
+    // we must NOT close the PC here, or it would be closed twice (risking
+    // duplicate close events or log warnings on torn-down handlers).
     this._failPending(new Error('SipSessionDescriptionHandler closed'));
-    this._pc.close();
   }
 
   sendDtmf(_tones: string): boolean {
+    // DTMF is routed through SipSignalingAdapter.dtmf() as SIP INFO, not
+    // the SDH path. Returning false tells SIP.js "I don't implement DTMF."
     return false;
   }
 
   private _awaitOperation<T>(start: (resolve: (value: T) => void) => void): Promise<T> {
     return new Promise<T>((resolve, reject) => {
-      this._rejectPending = reject;
+      this._pendingRejects.add(reject);
       start((value) => {
-        this._rejectPending = null;
+        this._pendingRejects.delete(reject);
         resolve(value);
       });
     });
   }
 
   private _failPending(error: Error): void {
-    const reject = this._rejectPending;
-    if (reject) {
-      this._rejectPending = null;
-      reject(error);
-    }
+    const rejects = Array.from(this._pendingRejects);
+    this._pendingRejects.clear();
+    rejects.forEach((reject) => reject(error));
   }
 }

--- a/lib/twilio/signaling/sipsessiondescriptionhandler.ts
+++ b/lib/twilio/signaling/sipsessiondescriptionhandler.ts
@@ -1,12 +1,21 @@
 import { BodyAndContentType, SessionDescriptionHandler } from 'sip.js';
 
 /**
+ * Shape of error payloads emitted by PeerConnection.onerror.
+ */
+interface PeerConnectionError {
+  info: { code: number; message: string; twilioError?: Error };
+}
+
+/**
  * Narrow view of the SDK's PeerConnection class containing only the
  * methods that SipSessionDescriptionHandler depends on. The real
  * PeerConnection class (lib/twilio/rtc/peerconnection.ts) structurally
  * satisfies this interface.
  */
 export interface IPeerConnection {
+  onerror: (error: PeerConnectionError) => void;
+
   makeOutgoingCall(
     callSid: string,
     rtcConfiguration: RTCConfiguration,
@@ -44,16 +53,32 @@ const APPLICATION_SDP = 'application/sdp';
  *   Inbound:  setDescription() -> answerIncomingCall consumes offer and
  *                                 produces an answer (cached)
  *             getDescription() -> returns the cached answer
+ *
+ * Error handling: PeerConnection reports failures via its `onerror`
+ * callback, not through the success-only callbacks we pass in. While a
+ * PeerConnection call is pending, the SDH subscribes to `onerror` and
+ * rejects the current Promise if it fires. The previous handler (Call
+ * owns it) is still invoked so Call can emit its own error event.
  */
 export class SipSessionDescriptionHandler implements SessionDescriptionHandler {
   private _cachedAnswer: string | null = null;
   private _hasSentOffer: boolean = false;
+  // PeerConnection reports failures via onerror, not the success callbacks
+  // we pass in. When an operation is pending we store its reject handler
+  // here; the onerror hook in the constructor triggers it.
+  private _rejectPending: ((error: Error) => void) | null = null;
 
   constructor(
     private _pc: IPeerConnection,
     private _callSid: string,
     private _rtcConfiguration: RTCConfiguration = {},
-  ) {}
+  ) {
+    const previousOnError = this._pc.onerror;
+    this._pc.onerror = (error: PeerConnectionError) => {
+      this._failPending(error?.info?.twilioError || new Error(error?.info?.message || 'PeerConnection error'));
+      previousOnError(error);
+    };
+  }
 
   getDescription(): Promise<BodyAndContentType> {
     if (this._cachedAnswer !== null) {
@@ -61,7 +86,7 @@ export class SipSessionDescriptionHandler implements SessionDescriptionHandler {
       this._cachedAnswer = null;
       return Promise.resolve({ body, contentType: APPLICATION_SDP });
     }
-    return new Promise<BodyAndContentType>((resolve) => {
+    return this._awaitOperation<BodyAndContentType>((resolve) => {
       this._pc.makeOutgoingCall(this._callSid, this._rtcConfiguration, (offerSdp) => {
         this._hasSentOffer = true;
         resolve({ body: offerSdp, contentType: APPLICATION_SDP });
@@ -75,11 +100,11 @@ export class SipSessionDescriptionHandler implements SessionDescriptionHandler {
 
   setDescription(sdp: string): Promise<void> {
     if (this._hasSentOffer) {
-      return new Promise<void>((resolve) => {
+      return this._awaitOperation<void>((resolve) => {
         this._pc.processAnswer(sdp, () => resolve());
       });
     }
-    return new Promise<void>((resolve) => {
+    return this._awaitOperation<void>((resolve) => {
       this._pc.answerIncomingCall(
         this._callSid,
         sdp,
@@ -91,10 +116,29 @@ export class SipSessionDescriptionHandler implements SessionDescriptionHandler {
   }
 
   close(): void {
+    this._failPending(new Error('SipSessionDescriptionHandler closed'));
     this._pc.close();
   }
 
   sendDtmf(_tones: string): boolean {
     return false;
+  }
+
+  private _awaitOperation<T>(start: (resolve: (value: T) => void) => void): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      this._rejectPending = reject;
+      start((value) => {
+        this._rejectPending = null;
+        resolve(value);
+      });
+    });
+  }
+
+  private _failPending(error: Error): void {
+    const reject = this._rejectPending;
+    if (reject) {
+      this._rejectPending = null;
+      reject(error);
+    }
   }
 }

--- a/lib/twilio/signaling/sipsignalingadapter.ts
+++ b/lib/twilio/signaling/sipsignalingadapter.ts
@@ -103,7 +103,7 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
       authorizationUsername: options.credentials.username,
       authorizationPassword: options.credentials.password,
       sessionDescriptionHandlerFactory: (session: Session) => {
-        const binding = this._consumeSdhBinding(session);
+        const binding = this._getSdhBinding(session);
         return new SipSessionDescriptionHandler(
           binding.peerConnection,
           binding.callSid,
@@ -483,7 +483,7 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
     });
   }
 
-  private _consumeSdhBinding(session: Session): SdhBinding {
+  private _getSdhBinding(session: Session): SdhBinding {
     const binding = this._sessionBindings.get(session);
     if (!binding) {
       throw new Error('SipSignalingAdapter: no PeerConnection binding registered for SIP session');

--- a/lib/twilio/signaling/sipsignalingadapter.ts
+++ b/lib/twilio/signaling/sipsignalingadapter.ts
@@ -5,6 +5,7 @@ import {
   InviterOptions,
   Registerer,
   RegistererState,
+  SessionDescriptionHandler,
   Session,
   SessionState,
   URI,
@@ -63,6 +64,25 @@ interface SdhBinding {
 }
 
 /**
+ * Fallback SDH returned from the factory when no binding is registered
+ * for a session. Every operation rejects with a clear error so SIP.js's
+ * Promise-based accept/invite paths fail cleanly instead of crashing
+ * synchronously inside setupSessionDescriptionHandler.
+ */
+function createUnboundSdh(): SessionDescriptionHandler {
+  const reject = () => Promise.reject(
+    new Error('SipSignalingAdapter: no PeerConnection binding registered for SIP session'),
+  );
+  return {
+    getDescription: reject,
+    hasDescription: () => false,
+    setDescription: reject,
+    sendDtmf: () => false,
+    close: () => { /* no-op */ },
+  };
+}
+
+/**
  * SignalingAdapter implementation backed by SIP.js. Handles WebSocket
  * connection, SIP registration lifecycle, and call-level signaling
  * (INVITE, BYE, re-INVITE, INFO, MESSAGE).
@@ -103,7 +123,17 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
       authorizationUsername: options.credentials.username,
       authorizationPassword: options.credentials.password,
       sessionDescriptionHandlerFactory: (session: Session) => {
-        const binding = this._getSdhBinding(session);
+        // Throwing here would bubble through SIP.js's synchronous setup path
+        // (session.js setupSessionDescriptionHandler) in non-obvious ways. If
+        // the binding is missing (programming error — answer() forgot to bind,
+        // or SIP.js calls the factory earlier than expected), return a
+        // fail-safe SDH that rejects every Promise. SIP.js catches rejections
+        // in setOfferAndGetAnswer/getOffer, so the session terminates cleanly.
+        const binding = this._sessionBindings.get(session);
+        if (!binding) {
+          this._log.error('sessionDescriptionHandlerFactory: no binding for session');
+          return createUnboundSdh();
+        }
         return new SipSessionDescriptionHandler(
           binding.peerConnection,
           binding.callSid,
@@ -279,6 +309,15 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
     this._bindSession(invitation, callSid, config);
     invitation.accept().catch((error: Error) => {
       this._log.error('Failed to accept invitation', error);
+      // Drop the half-bound session so a later hangup/retry for this callSid
+      // doesn't dispatch against a Terminated-but-still-mapped invitation.
+      this._inboundSessions.delete(callSid);
+      this._sessionBindings.delete(invitation);
+      // TODO(VBLOCKS-6604): when the SIP.js error carries a response
+      // statusCode (486, 480, 503, ...), translate it through
+      // getPreciseSignalingErrorByCode rather than hardcoding 31000.
+      // Consistent treatment needed across reject()/hangup()/reconnect()/
+      // sendMessage() as well.
       this.emit('error', { error: { code: 31000, message: error.message }, callsid: callSid });
     });
   }
@@ -338,7 +377,6 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
   reconnect(callSid: string, config: ReconnectConfig): void {
     this._sendInvite(callSid, {
       sdp: config.sdp,
-      params: '',
       peerConnection: config.peerConnection,
       rtcConfiguration: config.rtcConfiguration,
     }, config.reconnectToken);
@@ -483,14 +521,6 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
     });
   }
 
-  private _getSdhBinding(session: Session): SdhBinding {
-    const binding = this._sessionBindings.get(session);
-    if (!binding) {
-      throw new Error('SipSignalingAdapter: no PeerConnection binding registered for SIP session');
-    }
-    return binding;
-  }
-
   private _handleIncomingInvite(invitation: Invitation): void {
     const callSid = invitation.request.getHeader('X-Twilio-CallSid');
     if (!callSid) {
@@ -579,6 +609,13 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
           if (serverCallSid && serverCallSid !== callSid) {
             this._outboundSessions.delete(callSid);
             this._outboundSessions.set(serverCallSid, inviter);
+            // Keep the SdhBinding in sync so any future reader (debug
+            // logging, SDH refactors that construct lazily) sees the
+            // server-issued CallSid rather than the client temp sid.
+            const binding = this._sessionBindings.get(inviter);
+            if (binding) {
+              binding.callSid = serverCallSid;
+            }
             callSid = serverCallSid;
           }
           const payload: Record<string, any> = {

--- a/lib/twilio/signaling/sipsignalingadapter.ts
+++ b/lib/twilio/signaling/sipsignalingadapter.ts
@@ -22,6 +22,10 @@ import {
   SignalingAdapterStatus,
   SendMessageConfig,
 } from './signalingadapter';
+import {
+  IPeerConnection,
+  SipSessionDescriptionHandler,
+} from './sipsessiondescriptionhandler';
 
 type SipSendMessageConfig = Pick<SendMessageConfig, 'content' | 'contentType' | 'voiceEventSid'>;
 
@@ -49,25 +53,13 @@ export interface SipSignalingAdapterOptions {
 }
 
 /**
- * A no-op SessionDescriptionHandler for SIP.js. SDP relay through
- * SIP.js is deferred to VBLOCKS-6372 (SipSessionDescriptionHandler).
- * This stub satisfies the SIP.js SDH interface without doing any
- * real media work — actual SDP exchange is handled out-of-band by
- * PeerConnection via Call.ts.
+ * Binding registered on the adapter before a SIP.js Session is created,
+ * carrying everything the SDH factory needs to construct a real SDH.
  */
-function createNoOpSDH(): any {
-  return {
-    close(): void { /* no-op */ },
-    getDescription(): Promise<any> {
-      return Promise.resolve({ body: '', contentType: 'application/sdp' });
-    },
-    hasDescription(contentType: string): boolean {
-      return contentType === 'application/sdp';
-    },
-    setDescription(): Promise<void> {
-      return Promise.resolve();
-    },
-  };
+interface SdhBinding {
+  callSid: string;
+  peerConnection: IPeerConnection;
+  rtcConfiguration?: RTCConfiguration;
 }
 
 /**
@@ -81,6 +73,7 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
   private _inboundSessions: Map<string, Invitation> = new Map();
   private _outboundSessions: Map<string, Inviter> = new Map();
   private _pendingInvitations: Map<string, Invitation> = new Map();
+  private _sessionBindings: WeakMap<Session, SdhBinding> = new WeakMap();
   private _registerer: any | null = null;
   private _region: string | undefined;
   private _status: SignalingAdapterStatus = 'disconnected';
@@ -109,7 +102,14 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
       },
       authorizationUsername: options.credentials.username,
       authorizationPassword: options.credentials.password,
-      sessionDescriptionHandlerFactory: () => createNoOpSDH(),
+      sessionDescriptionHandlerFactory: (session: Session) => {
+        const binding = this._consumeSdhBinding(session);
+        return new SipSessionDescriptionHandler(
+          binding.peerConnection,
+          binding.callSid,
+          binding.rtcConfiguration,
+        );
+      },
       delegate: {
         onConnect: () => this._onTransportConnect(),
         onDisconnect: (error?: Error) => this._onTransportDisconnect(error),
@@ -264,8 +264,8 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
   // Call signaling
   // ---------------------------------------------------------------------------
 
-  invite(callSid: string, { sdp, params }: InviteConfig): void {
-    this._sendInvite(sdp, callSid, params);
+  invite(callSid: string, config: InviteConfig): void {
+    this._sendInvite(callSid, config);
   }
 
   answer(callSid: string, config: AnswerConfig): void {
@@ -276,6 +276,7 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
     }
     this._pendingInvitations.delete(callSid);
     this._inboundSessions.set(callSid, invitation);
+    this._bindSession(invitation, callSid, config);
     invitation.accept().catch((error: Error) => {
       this._log.error('Failed to accept invitation', error);
       this.emit('error', { error: { code: 31000, message: error.message }, callsid: callSid });
@@ -334,8 +335,13 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
     });
   }
 
-  reconnect(callSid: string, { sdp, reconnectToken }: ReconnectConfig): void {
-    this._sendInvite(sdp, callSid, undefined, reconnectToken);
+  reconnect(callSid: string, config: ReconnectConfig): void {
+    this._sendInvite(callSid, {
+      sdp: config.sdp,
+      params: '',
+      peerConnection: config.peerConnection,
+      rtcConfiguration: config.rtcConfiguration,
+    }, config.reconnectToken);
   }
 
   dtmf(callSid: string, { digits }: DtmfConfig): void {
@@ -462,6 +468,29 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
     return this._outboundSessions.get(callSid) || this._inboundSessions.get(callSid);
   }
 
+  private _bindSession(
+    session: Session,
+    callSid: string,
+    config: { peerConnection?: IPeerConnection; rtcConfiguration?: RTCConfiguration },
+  ): void {
+    if (!config.peerConnection) {
+      throw new Error('SipSignalingAdapter: peerConnection is required on the SIP path');
+    }
+    this._sessionBindings.set(session, {
+      callSid,
+      peerConnection: config.peerConnection,
+      rtcConfiguration: config.rtcConfiguration,
+    });
+  }
+
+  private _consumeSdhBinding(session: Session): SdhBinding {
+    const binding = this._sessionBindings.get(session);
+    if (!binding) {
+      throw new Error('SipSignalingAdapter: no PeerConnection binding registered for SIP session');
+    }
+    return binding;
+  }
+
   private _handleIncomingInvite(invitation: Invitation): void {
     const callSid = invitation.request.getHeader('X-Twilio-CallSid');
     if (!callSid) {
@@ -503,7 +532,7 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
     });
   }
 
-  private _sendInvite(sdp: string, callSid: string, params?: string, reconnectToken?: string): void {
+  private _sendInvite(tempCallSid: string, config: InviteConfig, reconnectToken?: string): void {
     if (!this._userAgent) {
       this._log.warn('Cannot invite: UserAgent not initialized');
       return;
@@ -512,7 +541,7 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
     const targetUri = UserAgent.makeURI(`sip:${this._options.sipDomain}`);
     if (!targetUri) {
       this._log.error('Failed to create target URI for invite');
-      this.emit('error', { error: { code: 31000, message: 'Invalid SIP target URI' }, callsid: callSid });
+      this.emit('error', { error: { code: 31000, message: 'Invalid SIP target URI' }, callsid: tempCallSid });
       return;
     }
 
@@ -520,6 +549,11 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
       || ((ua: UserAgent, uri: URI, opts?: InviterOptions) => new Inviter(ua, uri, opts));
     const inviter = createInv(this._userAgent, targetUri);
 
+    // Starts as the client-generated temp sid; replaced with the server-issued
+    // CallSid from the 200 OK's X-Twilio-CallSid header once the INVITE is accepted.
+    let callSid = tempCallSid;
+
+    this._bindSession(inviter, tempCallSid, config);
     this._outboundSessions.set(callSid, inviter);
 
     inviter.delegate = {
@@ -540,8 +574,17 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
         onProgress: () => {
           this.emit('ringing', { callsid: callSid });
         },
-        onAccept: () => {
-          const payload: Record<string, any> = { callsid: callSid, sdp: '' };
+        onAccept: (response: any) => {
+          const serverCallSid = response?.message?.getHeader?.('X-Twilio-CallSid');
+          if (serverCallSid && serverCallSid !== callSid) {
+            this._outboundSessions.delete(callSid);
+            this._outboundSessions.set(serverCallSid, inviter);
+            callSid = serverCallSid;
+          }
+          const payload: Record<string, any> = {
+            callsid: callSid,
+            sdp: '',
+          };
           if (reconnectToken) {
             payload.reconnect = reconnectToken;
           }

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -122,3 +122,4 @@ require('./unit/cdn/viewerresponse/test');
 require('./unit/rtcpc');
 require('./unit/pstreamsignalingadapter');
 require('./unit/sipsignalingadapter');
+require('./unit/sipsessiondescriptionhandler');

--- a/tests/unit/call.ts
+++ b/tests/unit/call.ts
@@ -754,6 +754,32 @@ describe('Call', function() {
           });
         });
 
+        it('should install the onopen wrapper at most once across repeat accept() calls', () => {
+          conn.accept();
+          return wait.then(() => {
+            const afterFirst = mediaHandler.onopen;
+            // Force the Call back to Pending so a second accept() actually
+            // proceeds. This simulates any future bug where accept's guard is
+            // bypassed; the wrapper must NOT chain a second layer.
+            (conn as any)._status = Call.State.Pending;
+            conn.accept();
+            return wait.then(() => {
+              assert.strictEqual(mediaHandler.onopen, afterFirst,
+                'onopen should not have been re-wrapped on the second accept()');
+              // Also verify firing it once fires onAnswer exactly once (not
+              // twice from stacked wrappers).
+              const publisherInfo = publisher.info as sinon.SinonSpy;
+              publisherInfo.resetHistory();
+              mediaHandler.onopen();
+              const answeredCalls = publisherInfo.getCalls().filter(
+                (c: sinon.SinonSpyCall) => c.args[1] === 'accepted-by-remote' || c.args[1] === 'accepted-by-local',
+              );
+              assert.strictEqual(answeredCalls.length, 1,
+                'onAnswer should fire once, not once per stacked wrapper');
+            });
+          });
+        });
+
         it('should call signalingAdapter.reconnect when reconnectToken is set', () => {
           setupSip({ reconnectToken: 'testReconnectToken' });
           conn.accept();
@@ -771,13 +797,13 @@ describe('Call', function() {
           setupSip({ callParameters: { CallSid: 'CA-inbound' }, offerSdp: 'remote-offer-sdp' });
         });
 
-        it('should call signalingAdapter.answer with peerConnection and the remote offer sdp', () => {
+        it('should call signalingAdapter.answer with peerConnection and no sdp (SDH derives it)', () => {
           conn.accept();
           return wait.then(() => {
             sinon.assert.calledOnce(pstream.answer);
             const answerConfig = pstream.answer.args[0][1];
             assert.strictEqual(answerConfig.peerConnection, mediaHandler);
-            assert.strictEqual(answerConfig.sdp, 'remote-offer-sdp');
+            assert.strictEqual(answerConfig.sdp, undefined);
           });
         });
 

--- a/tests/unit/call.ts
+++ b/tests/unit/call.ts
@@ -717,6 +717,79 @@ describe('Call', function() {
       });
     });
 
+    context('when useSip is true', () => {
+      let getInputStream: () => any;
+      let wait: Promise<any>;
+
+      const setupSip = (callOptions: any = {}) => {
+        getInputStream = sinon.spy(() => 'foo');
+        Object.assign(options, { getInputStream, useSip: true, twimlParams: { To: 'foo' }, ...callOptions });
+        conn = new Call(config, options);
+        mediaHandler.setInputTracksFromStream = sinon.spy(() => {
+          const p = Promise.resolve();
+          wait = p.then(() => Promise.resolve());
+          return p;
+        });
+      };
+
+      context('outgoing', () => {
+        beforeEach(() => setupSip());
+
+        it('should call signalingAdapter.invite with peerConnection and rtcConfiguration', () => {
+          const rtcConfiguration = { iceServers: [{ urls: 'stun:foo' }] };
+          conn.accept({ rtcConfiguration });
+          return wait.then(() => {
+            sinon.assert.calledOnce(pstream.invite);
+            const inviteConfig = pstream.invite.args[0][1];
+            assert.strictEqual(inviteConfig.peerConnection, mediaHandler);
+            assert.deepStrictEqual(inviteConfig.rtcConfiguration, rtcConfiguration);
+            assert.strictEqual(inviteConfig.sdp, '');
+          });
+        });
+
+        it('should not call mediaHandler.makeOutgoingCall (SDH drives SDP instead)', () => {
+          conn.accept();
+          return wait.then(() => {
+            sinon.assert.notCalled(mediaHandler.makeOutgoingCall);
+          });
+        });
+
+        it('should call signalingAdapter.reconnect when reconnectToken is set', () => {
+          setupSip({ reconnectToken: 'testReconnectToken' });
+          conn.accept();
+          return wait.then(() => {
+            sinon.assert.calledOnce(pstream.reconnect);
+            const reconnectConfig = pstream.reconnect.args[0][1];
+            assert.strictEqual(reconnectConfig.peerConnection, mediaHandler);
+            assert.strictEqual(reconnectConfig.reconnectToken, 'testReconnectToken');
+          });
+        });
+      });
+
+      context('incoming', () => {
+        beforeEach(() => {
+          setupSip({ callParameters: { CallSid: 'CA-inbound' }, offerSdp: 'remote-offer-sdp' });
+        });
+
+        it('should call signalingAdapter.answer with peerConnection and the remote offer sdp', () => {
+          conn.accept();
+          return wait.then(() => {
+            sinon.assert.calledOnce(pstream.answer);
+            const answerConfig = pstream.answer.args[0][1];
+            assert.strictEqual(answerConfig.peerConnection, mediaHandler);
+            assert.strictEqual(answerConfig.sdp, 'remote-offer-sdp');
+          });
+        });
+
+        it('should not call mediaHandler.answerIncomingCall (SDH drives SDP instead)', () => {
+          conn.accept();
+          return wait.then(() => {
+            sinon.assert.notCalled(mediaHandler.answerIncomingCall);
+          });
+        });
+      });
+    });
+
     context('when getInputStream is present and fails with 31208', () => {
       let getInputStream: () => any;
       let wait: Promise<any>;

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -755,10 +755,24 @@ describe('Device', function() {
               () => device.updateOptions({
                 signalingOptions: {
                   useSignalingMethod: 'sip',
+                  sipUri: 'sip:u@registrar.example.com',
                   sipCredentials: { username: 'u', password: 'p' },
                 } as any,
               }),
               /sipServer.*required/,
+            );
+          });
+
+          it('should throw if useSignalingMethod is sip but sipUri is missing', () => {
+            assert.throws(
+              () => device.updateOptions({
+                signalingOptions: {
+                  useSignalingMethod: 'sip',
+                  sipServer: 'wss://sip.example.com',
+                  sipCredentials: { username: 'u', password: 'p' },
+                } as any,
+              }),
+              /sipUri.*required/,
             );
           });
 
@@ -768,6 +782,7 @@ describe('Device', function() {
                 signalingOptions: {
                   useSignalingMethod: 'sip',
                   sipServer: 'wss://sip.example.com',
+                  sipUri: 'sip:u@registrar.example.com',
                 } as any,
               }),
               /sipCredentials.*required/,
@@ -780,6 +795,7 @@ describe('Device', function() {
                 signalingOptions: {
                   useSignalingMethod: 'sip',
                   sipServer: 'wss://sip.example.com',
+                  sipUri: 'sip:u@registrar.example.com',
                   sipCredentials: { username: '', password: 'p' },
                 },
               }),
@@ -793,6 +809,7 @@ describe('Device', function() {
                 signalingOptions: {
                   useSignalingMethod: 'sip',
                   sipServer: 'wss://sip.example.com',
+                  sipUri: 'sip:u@registrar.example.com',
                   sipCredentials: { username: 'u', password: '' },
                 },
               }),
@@ -805,6 +822,7 @@ describe('Device', function() {
               signalingOptions: {
                 useSignalingMethod: 'sip',
                 sipServer: 'wss://sip.example.com',
+                sipUri: 'sip:u@registrar.example.com',
                 sipCredentials: { username: 'u', password: 'p' },
               },
             }));

--- a/tests/unit/sipsessiondescriptionhandler.ts
+++ b/tests/unit/sipsessiondescriptionhandler.ts
@@ -92,6 +92,38 @@ describe('SipSessionDescriptionHandler', () => {
       assert.strictEqual(pc.processAnswer.firstCall.args[0], ANSWER_SDP);
       sinon.assert.notCalled(pc.answerIncomingCall);
     });
+
+    it('routes a subsequent inbound re-INVITE through answerIncomingCall (hasSentOffer resets after exchange)', async () => {
+      // SIP.js memoizes the SDH on the Session, so the same SDH may see a
+      // follow-up inbound re-INVITE after an outbound exchange completes.
+      const pc = createPeerConnectionStub({
+        makeOutgoingCall: sinon.stub().callsFake(
+          (_sid: string, _cfg: RTCConfiguration, cb: (sdp: string) => void) => cb(OFFER_SDP),
+        ) as sinon.SinonStub,
+        processAnswer: sinon.stub().callsFake(
+          (_sdp: string, cb: (pc: RTCPeerConnection) => void) => cb({} as RTCPeerConnection),
+        ) as sinon.SinonStub,
+        answerIncomingCall: sinon.stub().callsFake(
+          (
+            _sid: string,
+            _sdp: string,
+            _cfg: RTCConfiguration,
+            onAnswerReady: (answer: string) => void,
+            onMediaStarted: (pc: RTCPeerConnection) => void,
+          ) => {
+            onAnswerReady(ANSWER_SDP);
+            onMediaStarted({} as RTCPeerConnection);
+          },
+        ) as sinon.SinonStub,
+      });
+      const { handler } = createHandler(pc);
+      // Outbound exchange: offer -> answer.
+      await handler.getDescription();
+      await handler.setDescription(ANSWER_SDP);
+      // Simulated inbound re-INVITE: remote sends us an offer.
+      await handler.setDescription(OFFER_SDP);
+      sinon.assert.calledOnce(pc.answerIncomingCall);
+    });
   });
 
   describe('setDescription without prior offer (inbound)', () => {
@@ -143,11 +175,11 @@ describe('SipSessionDescriptionHandler', () => {
   });
 
   describe('close', () => {
-    it('delegates to pc.close', () => {
+    it('does not close the PeerConnection (Call owns its lifecycle)', () => {
       const pc = createPeerConnectionStub();
       const { handler } = createHandler(pc);
       handler.close();
-      sinon.assert.calledOnce(pc.close);
+      sinon.assert.notCalled(pc.close);
     });
 
     it('rejects any pending operation promises', async () => {
@@ -207,6 +239,20 @@ describe('SipSessionDescriptionHandler', () => {
       const errorPayload = { info: { code: 31000, message: 'boom' } };
       pc.onerror(errorPayload);
       sinon.assert.calledOnceWithExactly(previousOnError, errorPayload);
+    });
+
+    it('rejects every concurrently-pending operation when pc.onerror fires', async () => {
+      // SIP.js can issue overlapping setDescription calls (PRACK/UPDATE
+      // during early media); all pending Promises must settle on error.
+      const pc = createPeerConnectionStub(); // no callbacks fire — both ops stay pending
+      const { handler } = createHandler(pc);
+      const first = handler.getDescription();
+      const second = handler.setDescription(OFFER_SDP);
+      pc.onerror({ info: { code: 31000, message: 'bulk failure' } });
+      await Promise.all([
+        assert.rejects(first, /bulk failure/),
+        assert.rejects(second, /bulk failure/),
+      ]);
     });
 
     it('does not reject after the operation resolves', async () => {

--- a/tests/unit/sipsessiondescriptionhandler.ts
+++ b/tests/unit/sipsessiondescriptionhandler.ts
@@ -1,0 +1,159 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import {
+  IPeerConnection,
+  SipSessionDescriptionHandler,
+} from '../../lib/twilio/signaling/sipsessiondescriptionhandler';
+
+const APPLICATION_SDP = 'application/sdp';
+const CALL_SID = 'CA1234567890';
+const OFFER_SDP = 'v=0\r\no=offerer\r\n';
+const ANSWER_SDP = 'v=0\r\no=answerer\r\n';
+
+interface PcStub extends IPeerConnection {
+  makeOutgoingCall: sinon.SinonStub;
+  answerIncomingCall: sinon.SinonStub;
+  processAnswer: sinon.SinonStub;
+  close: sinon.SinonStub;
+}
+
+function createPeerConnectionStub(overrides: Partial<PcStub> = {}): PcStub {
+  const stub: PcStub = {
+    makeOutgoingCall: sinon.stub(),
+    answerIncomingCall: sinon.stub(),
+    processAnswer: sinon.stub(),
+    close: sinon.stub(),
+    ...overrides,
+  };
+  return stub;
+}
+
+function createHandler(pc?: PcStub, rtcConfig: RTCConfiguration = {}) {
+  const pcStub = pc || createPeerConnectionStub();
+  const handler = new SipSessionDescriptionHandler(pcStub, CALL_SID, rtcConfig);
+  return { handler, pc: pcStub };
+}
+
+describe('SipSessionDescriptionHandler', () => {
+  describe('hasDescription', () => {
+    it('returns true for application/sdp', () => {
+      const { handler } = createHandler();
+      assert.strictEqual(handler.hasDescription(APPLICATION_SDP), true);
+    });
+
+    it('returns false for other content types', () => {
+      const { handler } = createHandler();
+      assert.strictEqual(handler.hasDescription('text/plain'), false);
+      assert.strictEqual(handler.hasDescription(''), false);
+      assert.strictEqual(handler.hasDescription('application/json'), false);
+    });
+  });
+
+  describe('getDescription (outbound)', () => {
+    it('delegates to pc.makeOutgoingCall with the callSid and rtcConfig', () => {
+      const rtcConfig: RTCConfiguration = { iceServers: [{ urls: 'stun:example.com' }] };
+      const pc = createPeerConnectionStub();
+      const { handler } = createHandler(pc, rtcConfig);
+      handler.getDescription();
+      sinon.assert.calledOnce(pc.makeOutgoingCall);
+      const [callSid, config] = pc.makeOutgoingCall.firstCall.args;
+      assert.strictEqual(callSid, CALL_SID);
+      assert.deepStrictEqual(config, rtcConfig);
+    });
+
+    it('resolves with {body, contentType: application/sdp} when the offer callback fires', async () => {
+      const pc = createPeerConnectionStub({
+        makeOutgoingCall: sinon.stub().callsFake(
+          (_sid: string, _cfg: RTCConfiguration, cb: (sdp: string) => void) => cb(OFFER_SDP),
+        ) as sinon.SinonStub,
+      });
+      const { handler } = createHandler(pc);
+      const description = await handler.getDescription();
+      assert.deepStrictEqual(description, { body: OFFER_SDP, contentType: APPLICATION_SDP });
+    });
+
+  });
+
+  describe('setDescription after offer (outbound answer)', () => {
+    it('delegates to pc.processAnswer with the remote sdp', async () => {
+      const pc = createPeerConnectionStub({
+        makeOutgoingCall: sinon.stub().callsFake(
+          (_sid: string, _cfg: RTCConfiguration, cb: (sdp: string) => void) => cb(OFFER_SDP),
+        ) as sinon.SinonStub,
+        processAnswer: sinon.stub().callsFake(
+          (_sdp: string, cb: (pc: RTCPeerConnection) => void) => cb({} as RTCPeerConnection),
+        ) as sinon.SinonStub,
+      });
+      const { handler } = createHandler(pc);
+      await handler.getDescription();
+      await handler.setDescription(ANSWER_SDP);
+      sinon.assert.calledOnce(pc.processAnswer);
+      assert.strictEqual(pc.processAnswer.firstCall.args[0], ANSWER_SDP);
+      sinon.assert.notCalled(pc.answerIncomingCall);
+    });
+  });
+
+  describe('setDescription without prior offer (inbound)', () => {
+    it('delegates to pc.answerIncomingCall with the remote sdp and resolves when media starts', async () => {
+      const pc = createPeerConnectionStub({
+        answerIncomingCall: sinon.stub().callsFake(
+          (
+            _sid: string,
+            _sdp: string,
+            _cfg: RTCConfiguration,
+            onAnswerReady: (answer: string) => void,
+            onMediaStarted: (pc: RTCPeerConnection) => void,
+          ) => {
+            onAnswerReady(ANSWER_SDP);
+            onMediaStarted({} as RTCPeerConnection);
+          },
+        ) as sinon.SinonStub,
+      });
+      const { handler } = createHandler(pc);
+      await handler.setDescription(OFFER_SDP);
+      sinon.assert.calledOnce(pc.answerIncomingCall);
+      const [sid, sdp] = pc.answerIncomingCall.firstCall.args;
+      assert.strictEqual(sid, CALL_SID);
+      assert.strictEqual(sdp, OFFER_SDP);
+      sinon.assert.notCalled(pc.processAnswer);
+    });
+
+    it('caches the local answer so the next getDescription returns it synchronously', async () => {
+      const pc = createPeerConnectionStub({
+        answerIncomingCall: sinon.stub().callsFake(
+          (
+            _sid: string,
+            _sdp: string,
+            _cfg: RTCConfiguration,
+            onAnswerReady: (answer: string) => void,
+            onMediaStarted: (pc: RTCPeerConnection) => void,
+          ) => {
+            onAnswerReady(ANSWER_SDP);
+            onMediaStarted({} as RTCPeerConnection);
+          },
+        ) as sinon.SinonStub,
+      });
+      const { handler } = createHandler(pc);
+      await handler.setDescription(OFFER_SDP);
+      const description = await handler.getDescription();
+      assert.deepStrictEqual(description, { body: ANSWER_SDP, contentType: APPLICATION_SDP });
+      sinon.assert.notCalled(pc.makeOutgoingCall);
+    });
+  });
+
+  describe('close', () => {
+    it('delegates to pc.close', () => {
+      const pc = createPeerConnectionStub();
+      const { handler } = createHandler(pc);
+      handler.close();
+      sinon.assert.calledOnce(pc.close);
+    });
+  });
+
+  describe('sendDtmf', () => {
+    it('returns false (DTMF is routed outside the SDH)', () => {
+      const { handler } = createHandler();
+      assert.strictEqual(handler.sendDtmf('1'), false);
+    });
+  });
+});

--- a/tests/unit/sipsessiondescriptionhandler.ts
+++ b/tests/unit/sipsessiondescriptionhandler.ts
@@ -19,6 +19,7 @@ interface PcStub extends IPeerConnection {
 
 function createPeerConnectionStub(overrides: Partial<PcStub> = {}): PcStub {
   const stub: PcStub = {
+    onerror: () => { /* replaced by SDH constructor */ },
     makeOutgoingCall: sinon.stub(),
     answerIncomingCall: sinon.stub(),
     processAnswer: sinon.stub(),
@@ -147,6 +148,78 @@ describe('SipSessionDescriptionHandler', () => {
       const { handler } = createHandler(pc);
       handler.close();
       sinon.assert.calledOnce(pc.close);
+    });
+
+    it('rejects any pending operation promises', async () => {
+      const pc = createPeerConnectionStub(); // makeOutgoingCall never calls back
+      const { handler } = createHandler(pc);
+      const pending = handler.getDescription();
+      handler.close();
+      await assert.rejects(pending, /closed/);
+    });
+  });
+
+  describe('error propagation', () => {
+    it('rejects getDescription if pc.onerror fires before the callback', async () => {
+      const pc = createPeerConnectionStub();
+      const { handler } = createHandler(pc);
+      const pending = handler.getDescription();
+      const twilioError = new Error('media failure');
+      pc.onerror({ info: { code: 31000, message: 'media failure', twilioError } });
+      await assert.rejects(pending, /media failure/);
+    });
+
+    it('rejects with the twilioError instance when one is provided', async () => {
+      class FakeTwilioError extends Error { constructor() { super('twilio-flavored'); } }
+      const twilioError = new FakeTwilioError();
+      const pc = createPeerConnectionStub();
+      const { handler } = createHandler(pc);
+      const pending = handler.getDescription();
+      pc.onerror({ info: { code: 31000, message: 'ignored', twilioError } });
+      await assert.rejects(pending, (err: Error) => err === twilioError);
+    });
+
+    it('rejects setDescription (processAnswer path) if pc.onerror fires', async () => {
+      const pc = createPeerConnectionStub({
+        makeOutgoingCall: sinon.stub().callsFake(
+          (_sid: string, _cfg: RTCConfiguration, cb: (sdp: string) => void) => cb(OFFER_SDP),
+        ) as sinon.SinonStub,
+      });
+      const { handler } = createHandler(pc);
+      await handler.getDescription();
+      const pending = handler.setDescription(ANSWER_SDP);
+      pc.onerror({ info: { code: 31000, message: 'answer failed' } });
+      await assert.rejects(pending, /answer failed/);
+    });
+
+    it('rejects setDescription (answerIncomingCall path) if pc.onerror fires', async () => {
+      const pc = createPeerConnectionStub();
+      const { handler } = createHandler(pc);
+      const pending = handler.setDescription(OFFER_SDP);
+      pc.onerror({ info: { code: 31000, message: 'answer creation failed' } });
+      await assert.rejects(pending, /answer creation failed/);
+    });
+
+    it('still invokes the previous onerror handler (so Call can emit error)', () => {
+      const previousOnError = sinon.spy();
+      const pc = createPeerConnectionStub({ onerror: previousOnError });
+      createHandler(pc);
+      const errorPayload = { info: { code: 31000, message: 'boom' } };
+      pc.onerror(errorPayload);
+      sinon.assert.calledOnceWithExactly(previousOnError, errorPayload);
+    });
+
+    it('does not reject after the operation resolves', async () => {
+      const pc = createPeerConnectionStub({
+        makeOutgoingCall: sinon.stub().callsFake(
+          (_sid: string, _cfg: RTCConfiguration, cb: (sdp: string) => void) => cb(OFFER_SDP),
+        ) as sinon.SinonStub,
+      });
+      const { handler } = createHandler(pc);
+      const description = await handler.getDescription();
+      assert.strictEqual(description.body, OFFER_SDP);
+      // Firing onerror after the Promise resolved must not throw or cause issues.
+      assert.doesNotThrow(() => pc.onerror({ info: { code: 31000, message: 'late error' } }));
     });
   });
 

--- a/tests/unit/sipsignalingadapter.ts
+++ b/tests/unit/sipsignalingadapter.ts
@@ -14,8 +14,6 @@ function createPeerConnectionStub(): IPeerConnection {
   };
 }
 
-const pc = (): IPeerConnection => createPeerConnectionStub();
-
 /**
  * Stub that mimics a SIP.js Registerer/Session stateChange emitter.
  */
@@ -376,7 +374,7 @@ describe('SipSignalingAdapter', () => {
   describe('invite()', () => {
     it('should create an Inviter and call invite()', () => {
       const { adapter, inviterStub } = createAdapter();
-      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: createPeerConnectionStub() });
       assert(inviterStub.invite.calledOnce);
     });
 
@@ -386,7 +384,7 @@ describe('SipSignalingAdapter', () => {
         assert.strictEqual(payload.callsid, 'call-1');
         done();
       });
-      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: createPeerConnectionStub() });
       const rd = inviterStub._getRequestDelegate();
       rd.onProgress({});
     });
@@ -397,7 +395,7 @@ describe('SipSignalingAdapter', () => {
         assert.strictEqual(payload.callsid, 'call-1');
         done();
       });
-      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: createPeerConnectionStub() });
       const rd = inviterStub._getRequestDelegate();
       rd.onAccept({});
     });
@@ -409,7 +407,7 @@ describe('SipSignalingAdapter', () => {
         assert(payload.error);
         done();
       });
-      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: createPeerConnectionStub() });
       const rd = inviterStub._getRequestDelegate();
       rd.onReject({ message: { statusCode: 486, reasonPhrase: 'Busy Here' } });
     });
@@ -425,12 +423,12 @@ describe('SipSignalingAdapter', () => {
         assert(payload.error.message.includes('transport down'));
         done();
       });
-      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: createPeerConnectionStub() });
     });
 
     it('should clean up session on SessionState.Terminated', () => {
       const { adapter, inviterStub } = createAdapter();
-      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: createPeerConnectionStub() });
       inviterStub._simulateState('Terminated');
       // Subsequent hangup should warn (no session found) — just verifying no crash
       assert.doesNotThrow(() => adapter.hangup('call-1', {}));
@@ -438,7 +436,7 @@ describe('SipSignalingAdapter', () => {
 
     it('should rekey outbound session when 200 OK carries a server CallSid', () => {
       const { adapter, inviterStub } = createAdapter();
-      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: createPeerConnectionStub() });
       const rd = inviterStub._getRequestDelegate();
       rd.onAccept({ message: { getHeader: (name: string) => name === 'X-Twilio-CallSid' ? 'CA-server-123' : undefined } });
       // Original temp sid should no longer resolve; the server sid should.
@@ -447,13 +445,30 @@ describe('SipSignalingAdapter', () => {
       assert(inviterStub.bye.calledOnce, 'bye should be sent when hanging up with the server-assigned CallSid');
     });
 
+    it('should update the SdhBinding callSid when the session is rekeyed', () => {
+      // Binding must track the server CallSid so a later SDH construction
+      // (e.g. re-INVITE where SIP.js lazily creates a fresh SDH) uses the
+      // current identifier, not the stale temp sid.
+      const { adapter, inviterStub, getSdhFactory } = createAdapter();
+      const peerConnection = createPeerConnectionStub();
+      adapter.invite('call-temp', { sdp: 'sdp', params: 'To=bob', peerConnection });
+      const rd = inviterStub._getRequestDelegate();
+      rd.onAccept({ message: { getHeader: (name: string) => name === 'X-Twilio-CallSid' ? 'CA-server-789' : undefined } });
+      // Rebuild an SDH from the (now-rekeyed) binding and prove it drives
+      // PeerConnection with the server CallSid, not 'call-temp'.
+      const sdh = getSdhFactory()(inviterStub);
+      sdh.getDescription();
+      const makeOutgoingCall = peerConnection.makeOutgoingCall as sinon.SinonStub;
+      assert.strictEqual(makeOutgoingCall.firstCall.args[0], 'CA-server-789');
+    });
+
     it('should emit "answer" with server CallSid from X-Twilio-CallSid header', (done) => {
       const { adapter, inviterStub } = createAdapter();
       adapter.on('answer', (payload: any) => {
         assert.strictEqual(payload.callsid, 'CA-server-456');
         done();
       });
-      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: createPeerConnectionStub() });
       const rd = inviterStub._getRequestDelegate();
       rd.onAccept({ message: { getHeader: (name: string) => name === 'X-Twilio-CallSid' ? 'CA-server-456' : undefined } });
     });
@@ -462,7 +477,7 @@ describe('SipSignalingAdapter', () => {
   describe('reconnect()', () => {
     it('should create an Inviter and call invite()', () => {
       const { adapter, inviterStub } = createAdapter();
-      adapter.reconnect('call-1', { sdp: 'sdp', reconnectToken: 'rtoken', peerConnection: pc() });
+      adapter.reconnect('call-1', { sdp: 'sdp', reconnectToken: 'rtoken', peerConnection: createPeerConnectionStub() });
       assert(inviterStub.invite.calledOnce);
     });
 
@@ -472,7 +487,7 @@ describe('SipSignalingAdapter', () => {
         assert.strictEqual(payload.reconnect, 'rtoken');
         done();
       });
-      adapter.reconnect('call-1', { sdp: 'sdp', reconnectToken: 'rtoken', peerConnection: pc() });
+      adapter.reconnect('call-1', { sdp: 'sdp', reconnectToken: 'rtoken', peerConnection: createPeerConnectionStub() });
       const rd = inviterStub._getRequestDelegate();
       rd.onAccept({});
     });
@@ -537,7 +552,7 @@ describe('SipSignalingAdapter', () => {
       const { adapter, uaStub } = createAdapter();
       const inv = createInvitationStub();
       uaStub._triggerInvite(inv);
-      adapter.answer('CA-test-call-sid', { sdp: 'sdp-answer', peerConnection: pc() });
+      adapter.answer('CA-test-call-sid', { sdp: 'sdp-answer', peerConnection: createPeerConnectionStub() });
       adapter.on('hangup', (payload: any) => {
         assert.strictEqual(payload.callsid, 'CA-test-call-sid');
         done();
@@ -551,14 +566,14 @@ describe('SipSignalingAdapter', () => {
       const { adapter, uaStub } = createAdapter();
       const inv = createInvitationStub();
       uaStub._triggerInvite(inv);
-      adapter.answer('CA-test-call-sid', { sdp: 'sdp-answer', peerConnection: pc() });
+      adapter.answer('CA-test-call-sid', { sdp: 'sdp-answer', peerConnection: createPeerConnectionStub() });
       assert(inv.accept.calledOnce);
     });
 
     it('should warn if no pending invitation', () => {
       const { adapter } = createAdapter();
       // Should not throw — just warns
-      assert.doesNotThrow(() => adapter.answer('unknown-id', { sdp: 'sdp', peerConnection: pc() }));
+      assert.doesNotThrow(() => adapter.answer('unknown-id', { sdp: 'sdp', peerConnection: createPeerConnectionStub() }));
     });
 
     it('should emit "error" if accept() fails', (done) => {
@@ -572,7 +587,25 @@ describe('SipSignalingAdapter', () => {
         assert.strictEqual(payload.callsid, 'CA-test-call-sid');
         done();
       });
-      adapter.answer('CA-test-call-sid', { sdp: 'sdp-answer', peerConnection: pc() });
+      adapter.answer('CA-test-call-sid', { sdp: 'sdp-answer', peerConnection: createPeerConnectionStub() });
+    });
+
+    it('should drop the inbound session when accept() fails, so a later hangup is a no-op', async () => {
+      const { adapter, uaStub } = createAdapter();
+      const inv = createInvitationStub();
+      inv.accept = sinon.stub().rejects(new Error('accept failed'));
+      uaStub._triggerInvite(inv);
+      adapter.on('error', () => { /* swallow */ });
+      adapter.answer('CA-test-call-sid', { sdp: 'sdp-answer', peerConnection: createPeerConnectionStub() });
+      // Wait a tick so the rejected accept() promise resolves its catch handler.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      inv.bye = sinon.stub().resolves();
+      inv.reject = sinon.stub().resolves();
+      adapter.hangup('CA-test-call-sid', {});
+      // Session was cleaned up — hangup should not dispatch bye/reject on the
+      // half-bound invitation.
+      assert.strictEqual((inv.bye as sinon.SinonStub).callCount, 0);
+      assert.strictEqual((inv.reject as sinon.SinonStub).callCount, 0);
     });
   });
 
@@ -608,7 +641,7 @@ describe('SipSignalingAdapter', () => {
   describe('hangup()', () => {
     it('should call session.bye() when state is Established', () => {
       const { adapter, inviterStub } = createAdapter();
-      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: createPeerConnectionStub() });
       inviterStub.state = 'Established';
       adapter.hangup('call-1', {});
       assert(inviterStub.bye.calledOnce);
@@ -616,7 +649,7 @@ describe('SipSignalingAdapter', () => {
 
     it('should call inviter.cancel() when state is Establishing', () => {
       const { adapter, inviterStub } = createAdapter();
-      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: createPeerConnectionStub() });
       inviterStub.state = 'Establishing';
       adapter.hangup('call-1', {});
       assert(inviterStub.cancel.calledOnce);
@@ -639,7 +672,7 @@ describe('SipSignalingAdapter', () => {
   describe('reinvite()', () => {
     it('should call session.invite() for established sessions', () => {
       const { adapter, inviterStub } = createAdapter();
-      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: createPeerConnectionStub() });
       inviterStub.state = 'Established';
       adapter.reinvite('call-1', { sdp: 'new-sdp' });
       // session.invite is the re-INVITE call (distinct from inviter.invite for initial INVITE)
@@ -654,7 +687,7 @@ describe('SipSignalingAdapter', () => {
 
     it('should emit "answer" on requestDelegate.onAccept', (done) => {
       const { adapter, inviterStub } = createAdapter();
-      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: createPeerConnectionStub() });
       inviterStub.state = 'Established';
       adapter.on('answer', (payload: any) => {
         assert.strictEqual(payload.callsid, 'call-1');
@@ -667,7 +700,7 @@ describe('SipSignalingAdapter', () => {
 
     it('should warn but not throw on requestDelegate.onReject', () => {
       const { adapter, inviterStub } = createAdapter();
-      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: createPeerConnectionStub() });
       inviterStub.state = 'Established';
       adapter.reinvite('call-1', { sdp: 'new-sdp' });
       const rd = inviterStub.invite.lastCall.args[0]?.requestDelegate;
@@ -678,7 +711,7 @@ describe('SipSignalingAdapter', () => {
   describe('dtmf()', () => {
     it('should call session.info() for each digit', async () => {
       const { adapter, inviterStub } = createAdapter();
-      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: createPeerConnectionStub() });
       inviterStub.state = 'Established';
       adapter.dtmf('call-1', { digits: '12' });
       // Allow async sends to complete
@@ -695,7 +728,7 @@ describe('SipSignalingAdapter', () => {
   describe('sendMessage()', () => {
     it('should call session.message() and emit "ack"', (done) => {
       const { adapter, inviterStub } = createAdapter();
-      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: createPeerConnectionStub() });
       inviterStub.state = 'Established';
       adapter.on('ack', (payload: any) => {
         assert.strictEqual(payload.acktype, 'message');
@@ -712,7 +745,7 @@ describe('SipSignalingAdapter', () => {
       const { adapter } = createAdapter({
         createInviter() { return failInviterStub as any; },
       });
-      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: createPeerConnectionStub() });
       failInviterStub._simulateState('Established');
       adapter.on('error', (payload: any) => {
         assert.strictEqual(payload.voiceeventsid, 'evt-1');
@@ -730,7 +763,7 @@ describe('SipSignalingAdapter', () => {
   describe('lifecycle cleanup', () => {
     it('destroy() should bye established sessions and clear maps', () => {
       const { adapter, inviterStub } = createAdapter();
-      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: createPeerConnectionStub() });
       inviterStub.state = 'Established';
       adapter.destroy();
       assert(inviterStub.bye.calledOnce);
@@ -739,7 +772,7 @@ describe('SipSignalingAdapter', () => {
     it('transport disconnect should clear session maps', () => {
       const { adapter, uaStub, inviterStub } = createAdapter();
       uaStub._triggerConnect();
-      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: createPeerConnectionStub() });
       uaStub._triggerDisconnect();
       // Session map cleared — hangup should not find session
       assert.doesNotThrow(() => adapter.hangup('call-1', {}));
@@ -749,7 +782,7 @@ describe('SipSignalingAdapter', () => {
   describe('sessionDescriptionHandlerFactory', () => {
     it('should construct a real SipSessionDescriptionHandler with the bound PeerConnection and callSid', () => {
       const { adapter, inviterStub, getSdhFactory } = createAdapter();
-      const peerConnection = pc();
+      const peerConnection = createPeerConnectionStub();
       adapter.invite('call-abc', { sdp: 'sdp', params: 'To=bob', peerConnection });
       const sdh = getSdhFactory()(inviterStub);
       assert(sdh instanceof SipSessionDescriptionHandler);
@@ -760,16 +793,63 @@ describe('SipSignalingAdapter', () => {
       assert.strictEqual(makeOutgoingCall.firstCall.args[0], 'call-abc');
     });
 
-    it('should throw if no binding is registered for the session', () => {
+    it('should return a fail-safe SDH whose ops reject if no binding is registered', async () => {
       const { getSdhFactory, inviterStub } = createAdapter();
-      assert.throws(() => getSdhFactory()(inviterStub), /no PeerConnection binding/);
+      // Factory must NOT throw — a throw would bubble synchronously through
+      // SIP.js's setupSessionDescriptionHandler and corrupt session state.
+      const sdh = getSdhFactory()(inviterStub);
+      assert.strictEqual(sdh.hasDescription('application/sdp'), false);
+      await assert.rejects(sdh.getDescription(), /no PeerConnection binding/);
+      await assert.rejects(sdh.setDescription('v=0\r\n'), /no PeerConnection binding/);
+    });
+
+    it('should return the fail-safe SDH for an inbound invitation when answer() has not yet bound', async () => {
+      // Guard against the H4 scenario the reviewer flagged: if SIP.js were
+      // ever to invoke the factory before answer() registers the binding
+      // (e.g. eager SDH construction on INVITE receipt), we must not throw.
+      const { uaStub, getSdhFactory } = createAdapter();
+      const invitation = createInvitationStub();
+      uaStub._triggerInvite(invitation);
+      // Note: no adapter.answer() call — binding intentionally absent.
+      const sdh = getSdhFactory()(invitation);
+      await assert.rejects(sdh.getDescription(), /no PeerConnection binding/);
+    });
+
+    it('preserves a pre-assigned pc.onerror handler when the SDH wraps it (end-to-end ordering)', async () => {
+      // Ordering contract: Call assigns _mediaHandler.onerror in its
+      // constructor, BEFORE accept() triggers the SIP.js factory that
+      // constructs the SDH. The SDH wraps that handler so PC errors still
+      // reach Call (which emits 'error'), while also rejecting any SDH
+      // promise in flight. This test locks that contract in so a future
+      // refactor that constructs the SDH earlier or reorders Call can't
+      // silently break error propagation.
+      const { adapter, uaStub, getSdhFactory } = createAdapter();
+      const peerConnection = createPeerConnectionStub();
+      // Simulate Call wiring its handler first — this is the pre-assigned
+      // handler the SDH must preserve.
+      const callLevelOnError = sinon.spy();
+      peerConnection.onerror = callLevelOnError;
+
+      const invitation = createInvitationStub();
+      uaStub._triggerInvite(invitation);
+      adapter.answer('CA-test-call-sid', { peerConnection });
+      // SIP.js calls the factory inside accept(); simulate that order.
+      const sdh = getSdhFactory()(invitation) as SipSessionDescriptionHandler;
+
+      // With an SDH promise pending, fire an error on the PC: the SDH must
+      // reject the pending promise AND invoke Call's original handler.
+      const pending = sdh.getDescription();
+      const errorPayload = { info: { code: 31000, message: 'media failure' } };
+      peerConnection.onerror(errorPayload);
+      await assert.rejects(pending, /media failure/);
+      sinon.assert.calledOnceWithExactly(callLevelOnError, errorPayload);
     });
 
     it('should bind on answer() for inbound calls', () => {
       const { adapter, uaStub, getSdhFactory } = createAdapter();
       const invitation = createInvitationStub();
       uaStub._triggerInvite(invitation);
-      const peerConnection = pc();
+      const peerConnection = createPeerConnectionStub();
       adapter.answer('CA-test-call-sid', { sdp: 'sdp-offer', peerConnection });
       const sdh = getSdhFactory()(invitation);
       assert(sdh instanceof SipSessionDescriptionHandler);

--- a/tests/unit/sipsignalingadapter.ts
+++ b/tests/unit/sipsignalingadapter.ts
@@ -2,6 +2,18 @@ import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { SignalingAdapter } from '../../lib/twilio/signaling/signalingadapter';
 import { SipSignalingAdapter } from '../../lib/twilio/signaling/sipsignalingadapter';
+import { IPeerConnection, SipSessionDescriptionHandler } from '../../lib/twilio/signaling/sipsessiondescriptionhandler';
+
+function createPeerConnectionStub(): IPeerConnection {
+  return {
+    makeOutgoingCall: sinon.stub(),
+    answerIncomingCall: sinon.stub(),
+    processAnswer: sinon.stub(),
+    close: sinon.stub(),
+  };
+}
+
+const pc = (): IPeerConnection => createPeerConnectionStub();
 
 /**
  * Stub that mimics a SIP.js Registerer/Session stateChange emitter.
@@ -93,6 +105,7 @@ function createAdapter(overrides?: Partial<any>) {
   const uaStub = createUserAgentStub();
   const regStub = createRegistererStub();
   const inviterStub = createInviterStub();
+  let capturedSdhFactory: any = null;
 
   const adapter = new SipSignalingAdapter({
     sipDomain: 'sip.ashburn.dev.twilio.com',
@@ -102,6 +115,7 @@ function createAdapter(overrides?: Partial<any>) {
     region: 'ashburn',
     createUserAgent(config: any) {
       uaStub._setDelegate(config.delegate);
+      capturedSdhFactory = config.sessionDescriptionHandlerFactory;
       return uaStub as any;
     },
     createRegisterer() {
@@ -113,7 +127,13 @@ function createAdapter(overrides?: Partial<any>) {
     ...overrides,
   });
 
-  return { adapter: adapter as SignalingAdapter, uaStub, regStub, inviterStub };
+  return {
+    adapter: adapter as SignalingAdapter,
+    uaStub,
+    regStub,
+    inviterStub,
+    getSdhFactory: () => capturedSdhFactory,
+  };
 }
 
 describe('SipSignalingAdapter', () => {
@@ -355,7 +375,7 @@ describe('SipSignalingAdapter', () => {
   describe('invite()', () => {
     it('should create an Inviter and call invite()', () => {
       const { adapter, inviterStub } = createAdapter();
-      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
       assert(inviterStub.invite.calledOnce);
     });
 
@@ -365,7 +385,7 @@ describe('SipSignalingAdapter', () => {
         assert.strictEqual(payload.callsid, 'call-1');
         done();
       });
-      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
       const rd = inviterStub._getRequestDelegate();
       rd.onProgress({});
     });
@@ -376,7 +396,7 @@ describe('SipSignalingAdapter', () => {
         assert.strictEqual(payload.callsid, 'call-1');
         done();
       });
-      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
       const rd = inviterStub._getRequestDelegate();
       rd.onAccept({});
     });
@@ -388,7 +408,7 @@ describe('SipSignalingAdapter', () => {
         assert(payload.error);
         done();
       });
-      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
       const rd = inviterStub._getRequestDelegate();
       rd.onReject({ message: { statusCode: 486, reasonPhrase: 'Busy Here' } });
     });
@@ -404,22 +424,44 @@ describe('SipSignalingAdapter', () => {
         assert(payload.error.message.includes('transport down'));
         done();
       });
-      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
     });
 
     it('should clean up session on SessionState.Terminated', () => {
       const { adapter, inviterStub } = createAdapter();
-      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
       inviterStub._simulateState('Terminated');
       // Subsequent hangup should warn (no session found) — just verifying no crash
       assert.doesNotThrow(() => adapter.hangup('call-1', {}));
+    });
+
+    it('should rekey outbound session when 200 OK carries a server CallSid', () => {
+      const { adapter, inviterStub } = createAdapter();
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
+      const rd = inviterStub._getRequestDelegate();
+      rd.onAccept({ message: { getHeader: (name: string) => name === 'X-Twilio-CallSid' ? 'CA-server-123' : undefined } });
+      // Original temp sid should no longer resolve; the server sid should.
+      inviterStub.state = 'Established';
+      adapter.hangup('CA-server-123', {});
+      assert(inviterStub.bye.calledOnce, 'bye should be sent when hanging up with the server-assigned CallSid');
+    });
+
+    it('should emit "answer" with server CallSid from X-Twilio-CallSid header', (done) => {
+      const { adapter, inviterStub } = createAdapter();
+      adapter.on('answer', (payload: any) => {
+        assert.strictEqual(payload.callsid, 'CA-server-456');
+        done();
+      });
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
+      const rd = inviterStub._getRequestDelegate();
+      rd.onAccept({ message: { getHeader: (name: string) => name === 'X-Twilio-CallSid' ? 'CA-server-456' : undefined } });
     });
   });
 
   describe('reconnect()', () => {
     it('should create an Inviter and call invite()', () => {
       const { adapter, inviterStub } = createAdapter();
-      adapter.reconnect('call-1', { sdp: 'sdp', reconnectToken: 'rtoken' });
+      adapter.reconnect('call-1', { sdp: 'sdp', reconnectToken: 'rtoken', peerConnection: pc() });
       assert(inviterStub.invite.calledOnce);
     });
 
@@ -429,7 +471,7 @@ describe('SipSignalingAdapter', () => {
         assert.strictEqual(payload.reconnect, 'rtoken');
         done();
       });
-      adapter.reconnect('call-1', { sdp: 'sdp', reconnectToken: 'rtoken' });
+      adapter.reconnect('call-1', { sdp: 'sdp', reconnectToken: 'rtoken', peerConnection: pc() });
       const rd = inviterStub._getRequestDelegate();
       rd.onAccept({});
     });
@@ -494,7 +536,7 @@ describe('SipSignalingAdapter', () => {
       const { adapter, uaStub } = createAdapter();
       const inv = createInvitationStub();
       uaStub._triggerInvite(inv);
-      adapter.answer('CA-test-call-sid', { sdp: 'sdp-answer' });
+      adapter.answer('CA-test-call-sid', { sdp: 'sdp-answer', peerConnection: pc() });
       adapter.on('hangup', (payload: any) => {
         assert.strictEqual(payload.callsid, 'CA-test-call-sid');
         done();
@@ -508,14 +550,14 @@ describe('SipSignalingAdapter', () => {
       const { adapter, uaStub } = createAdapter();
       const inv = createInvitationStub();
       uaStub._triggerInvite(inv);
-      adapter.answer('CA-test-call-sid', { sdp: 'sdp-answer' });
+      adapter.answer('CA-test-call-sid', { sdp: 'sdp-answer', peerConnection: pc() });
       assert(inv.accept.calledOnce);
     });
 
     it('should warn if no pending invitation', () => {
       const { adapter } = createAdapter();
       // Should not throw — just warns
-      assert.doesNotThrow(() => adapter.answer('unknown-id', { sdp: 'sdp' }));
+      assert.doesNotThrow(() => adapter.answer('unknown-id', { sdp: 'sdp', peerConnection: pc() }));
     });
 
     it('should emit "error" if accept() fails', (done) => {
@@ -529,7 +571,7 @@ describe('SipSignalingAdapter', () => {
         assert.strictEqual(payload.callsid, 'CA-test-call-sid');
         done();
       });
-      adapter.answer('CA-test-call-sid', { sdp: 'sdp-answer' });
+      adapter.answer('CA-test-call-sid', { sdp: 'sdp-answer', peerConnection: pc() });
     });
   });
 
@@ -565,7 +607,7 @@ describe('SipSignalingAdapter', () => {
   describe('hangup()', () => {
     it('should call session.bye() when state is Established', () => {
       const { adapter, inviterStub } = createAdapter();
-      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
       inviterStub.state = 'Established';
       adapter.hangup('call-1', {});
       assert(inviterStub.bye.calledOnce);
@@ -573,7 +615,7 @@ describe('SipSignalingAdapter', () => {
 
     it('should call inviter.cancel() when state is Establishing', () => {
       const { adapter, inviterStub } = createAdapter();
-      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
       inviterStub.state = 'Establishing';
       adapter.hangup('call-1', {});
       assert(inviterStub.cancel.calledOnce);
@@ -596,7 +638,7 @@ describe('SipSignalingAdapter', () => {
   describe('reinvite()', () => {
     it('should call session.invite() for established sessions', () => {
       const { adapter, inviterStub } = createAdapter();
-      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
       inviterStub.state = 'Established';
       adapter.reinvite('call-1', { sdp: 'new-sdp' });
       // session.invite is the re-INVITE call (distinct from inviter.invite for initial INVITE)
@@ -611,7 +653,7 @@ describe('SipSignalingAdapter', () => {
 
     it('should emit "answer" on requestDelegate.onAccept', (done) => {
       const { adapter, inviterStub } = createAdapter();
-      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
       inviterStub.state = 'Established';
       adapter.on('answer', (payload: any) => {
         assert.strictEqual(payload.callsid, 'call-1');
@@ -624,7 +666,7 @@ describe('SipSignalingAdapter', () => {
 
     it('should warn but not throw on requestDelegate.onReject', () => {
       const { adapter, inviterStub } = createAdapter();
-      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
       inviterStub.state = 'Established';
       adapter.reinvite('call-1', { sdp: 'new-sdp' });
       const rd = inviterStub.invite.lastCall.args[0]?.requestDelegate;
@@ -635,7 +677,7 @@ describe('SipSignalingAdapter', () => {
   describe('dtmf()', () => {
     it('should call session.info() for each digit', async () => {
       const { adapter, inviterStub } = createAdapter();
-      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
       inviterStub.state = 'Established';
       adapter.dtmf('call-1', { digits: '12' });
       // Allow async sends to complete
@@ -652,7 +694,7 @@ describe('SipSignalingAdapter', () => {
   describe('sendMessage()', () => {
     it('should call session.message() and emit "ack"', (done) => {
       const { adapter, inviterStub } = createAdapter();
-      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
       inviterStub.state = 'Established';
       adapter.on('ack', (payload: any) => {
         assert.strictEqual(payload.acktype, 'message');
@@ -669,7 +711,7 @@ describe('SipSignalingAdapter', () => {
       const { adapter } = createAdapter({
         createInviter() { return failInviterStub as any; },
       });
-      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
       failInviterStub._simulateState('Established');
       adapter.on('error', (payload: any) => {
         assert.strictEqual(payload.voiceeventsid, 'evt-1');
@@ -687,7 +729,7 @@ describe('SipSignalingAdapter', () => {
   describe('lifecycle cleanup', () => {
     it('destroy() should bye established sessions and clear maps', () => {
       const { adapter, inviterStub } = createAdapter();
-      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
       inviterStub.state = 'Established';
       adapter.destroy();
       assert(inviterStub.bye.calledOnce);
@@ -696,10 +738,44 @@ describe('SipSignalingAdapter', () => {
     it('transport disconnect should clear session maps', () => {
       const { adapter, uaStub, inviterStub } = createAdapter();
       uaStub._triggerConnect();
-      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob' });
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: pc() });
       uaStub._triggerDisconnect();
       // Session map cleared — hangup should not find session
       assert.doesNotThrow(() => adapter.hangup('call-1', {}));
+    });
+  });
+
+  describe('sessionDescriptionHandlerFactory', () => {
+    it('should construct a real SipSessionDescriptionHandler with the bound PeerConnection and callSid', () => {
+      const { adapter, inviterStub, getSdhFactory } = createAdapter();
+      const peerConnection = pc();
+      adapter.invite('call-abc', { sdp: 'sdp', params: 'To=bob', peerConnection });
+      const sdh = getSdhFactory()(inviterStub);
+      assert(sdh instanceof SipSessionDescriptionHandler);
+      // Drive the SDH through getDescription to prove it delegates to the bound PC.
+      sdh.getDescription();
+      const makeOutgoingCall = peerConnection.makeOutgoingCall as sinon.SinonStub;
+      assert(makeOutgoingCall.calledOnce);
+      assert.strictEqual(makeOutgoingCall.firstCall.args[0], 'call-abc');
+    });
+
+    it('should throw if no binding is registered for the session', () => {
+      const { getSdhFactory, inviterStub } = createAdapter();
+      assert.throws(() => getSdhFactory()(inviterStub), /no PeerConnection binding/);
+    });
+
+    it('should bind on answer() for inbound calls', () => {
+      const { adapter, uaStub, getSdhFactory } = createAdapter();
+      const invitation = createInvitationStub();
+      uaStub._triggerInvite(invitation);
+      const peerConnection = pc();
+      adapter.answer('CA-test-call-sid', { sdp: 'sdp-offer', peerConnection });
+      const sdh = getSdhFactory()(invitation);
+      assert(sdh instanceof SipSessionDescriptionHandler);
+      sdh.setDescription('v=0\r\no=remote\r\n');
+      const answerIncomingCall = peerConnection.answerIncomingCall as sinon.SinonStub;
+      assert(answerIncomingCall.calledOnce);
+      assert.strictEqual(answerIncomingCall.firstCall.args[0], 'CA-test-call-sid');
     });
   });
 });

--- a/tests/unit/sipsignalingadapter.ts
+++ b/tests/unit/sipsignalingadapter.ts
@@ -6,6 +6,7 @@ import { IPeerConnection, SipSessionDescriptionHandler } from '../../lib/twilio/
 
 function createPeerConnectionStub(): IPeerConnection {
   return {
+    onerror: () => { /* replaced by SDH constructor when used */ },
     makeOutgoingCall: sinon.stub(),
     answerIncomingCall: sinon.stub(),
     processAnswer: sinon.stub(),


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

https://twilio-engineering.atlassian.net/browse/VBLOCKS-6372

Successfully tested happy path outgoing call

### Description

  - Replace the no-op SessionDescriptionHandler stub with SipSessionDescriptionHandler, a thin SDP relay that bridges
  SIP.js's Promise-based interface to the SDK's existing PeerConnection via a narrow IPeerConnection contract
  - SipSignalingAdapter registers the real SDH factory and tracks per-call PeerConnection bindings via a
  WeakMap<Session, SdhBinding>; on 200 OK, X-Twilio-CallSid rekeys the outbound session map from temp to server-issued
   sid
  - Call.ts adds a useSip option that skips eager makeOutgoingCall/answerIncomingCall on the SIP path and passes the
  PeerConnection through invite/answer/reconnect configs; onopen decorator fires onAnswer(pc) exactly once when media
  stabilizes
  - Device.SIPSignalingOptions now requires sipUri (SIP identity URI, separate from sipServer transport URL) so the
  SIP registrar can differ from the WebSocket edge host

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Ready for review
