### PR TITLE
[VBLOCKS-6375] feat: sdh ice restart support

### DIFF
--- a/lib/twilio/call.ts
+++ b/lib/twilio/call.ts
@@ -376,6 +376,10 @@ class Call extends EventEmitter {
       }
 
       const onAnswerOrRinging = (payload: any) => {
+        // The adapter is shared across concurrent calls; ignore events for
+        // other calls so their answer/hangup doesn't abort this call's
+        // in-flight ICE restart by removing the listeners below.
+        if (payload?.callsid !== callSid) { return; }
         this._signalingAdapter.removeListener('answer', onAnswerOrRinging);
         this._signalingAdapter.removeListener('hangup', onHangup);
 
@@ -391,7 +395,8 @@ class Call extends EventEmitter {
         this._mediaHandler.processAnswer(payload.sdp, () => { /* noop for ICE restart */ });
       };
 
-      const onHangup = () => {
+      const onHangup = (payload: any) => {
+        if (payload?.callsid !== callSid) { return; }
         this._signalingAdapter.removeListener('answer', onAnswerOrRinging);
         this._signalingAdapter.removeListener('hangup', onHangup);
       };

--- a/lib/twilio/call.ts
+++ b/lib/twilio/call.ts
@@ -8,7 +8,6 @@ import {
   HangupConfig,
   InviteConfig,
   ReconnectConfig,
-  ReinviteConfig,
   SendMessageConfig,
   SignalingAdapter,
 } from './signaling/signalingadapter';
@@ -370,34 +369,39 @@ class Call extends EventEmitter {
 
     this._mediaReconnectBackoff = new Backoff(BACKOFF_CONFIG);
     this._mediaReconnectBackoff.on('ready', () => {
-      this._mediaHandler.iceRestart((offerSdp: string) => {
-        const onAnswerOrRinging = (payload: any) => {
-          this._signalingAdapter.removeListener('answer', onAnswerOrRinging);
-          this._signalingAdapter.removeListener('hangup', onHangup);
+      const callSid = this.parameters.CallSid;
+      if (!callSid) {
+        this._log.warn('Cannot reinvite: CallSid is not set');
+        return;
+      }
 
-          if (!payload.sdp || !this._mediaHandler.version
-              || this._mediaHandler.version.pc.signalingState !== 'have-local-offer') {
-            return;
-          }
+      const onAnswerOrRinging = (payload: any) => {
+        this._signalingAdapter.removeListener('answer', onAnswerOrRinging);
+        this._signalingAdapter.removeListener('hangup', onHangup);
 
-          this._mediaHandler.processAnswer(payload.sdp, () => { /* noop for ICE restart */ });
-        };
-
-        const onHangup = () => {
-          this._signalingAdapter.removeListener('answer', onAnswerOrRinging);
-          this._signalingAdapter.removeListener('hangup', onHangup);
-        };
-
-        const callSid = this.parameters.CallSid;
-        if (!callSid) {
-          this._log.warn('Cannot reinvite: CallSid is not set');
+        // On the SIP path, the remote answer reaches PeerConnection via
+        // the SDH before the adapter emits 'answer', so payload.sdp is
+        // empty — the guard below skips a redundant processAnswer. On
+        // the PStream path, payload.sdp carries the real answer SDP.
+        if (!payload.sdp || !this._mediaHandler.version
+            || this._mediaHandler.version.pc.signalingState !== 'have-local-offer') {
           return;
         }
-        this._signalingAdapter.on('answer', onAnswerOrRinging);
-        this._signalingAdapter.on('hangup', onHangup);
-        const reinviteConfig: ReinviteConfig = { sdp: offerSdp };
-        this._signalingAdapter.reinvite(callSid, reinviteConfig);
-      });
+
+        this._mediaHandler.processAnswer(payload.sdp, () => { /* noop for ICE restart */ });
+      };
+
+      const onHangup = () => {
+        this._signalingAdapter.removeListener('answer', onAnswerOrRinging);
+        this._signalingAdapter.removeListener('hangup', onHangup);
+      };
+
+      this._signalingAdapter.on('answer', onAnswerOrRinging);
+      this._signalingAdapter.on('hangup', onHangup);
+      // Adapter encapsulates its own offer-generation strategy. On
+      // failure the adapter emits 'hangup' for this callSid so the
+      // cleanup listeners above run.
+      this._signalingAdapter.iceRestart(callSid, { mediaHandler: this._mediaHandler });
     });
 
     // temporary call sid to be used for outgoing calls

--- a/lib/twilio/signaling/mediahandler.ts
+++ b/lib/twilio/signaling/mediahandler.ts
@@ -1,0 +1,11 @@
+/**
+ * Narrow view of the media handler that PStreamSignalingAdapter.iceRestart()
+ * needs to produce a fresh-ICE offer. Satisfied structurally by PeerConnection.
+ *
+ * Lives outside signalingadapter.ts so the shared interface doesn't encode
+ * a PStream-specific detail: the SIP adapter produces its offer via SIP.js
+ * + SDH and does not use this type at runtime.
+ */
+export interface IMediaHandler {
+  iceRestart(onOfferReady: (offerSdp: string) => void): void;
+}

--- a/lib/twilio/signaling/pstreamsignalingadapter.ts
+++ b/lib/twilio/signaling/pstreamsignalingadapter.ts
@@ -83,9 +83,13 @@ export class PStreamSignalingAdapter extends EventEmitter implements SignalingAd
   iceRestart(callSid: string, { mediaHandler }: IceRestartConfig): void {
     // Call (on PStream) owns offer generation: mediaHandler produces a
     // fresh-ICE offer; we ship it via the existing reinvite wire.
-    mediaHandler.iceRestart((offerSdp: string) => {
-      this._pstream.reinvite(offerSdp, callSid);
-    });
+    try {
+      mediaHandler.iceRestart((offerSdp: string) => {
+        this._pstream.reinvite(offerSdp, callSid);
+      });
+    } catch {
+      this.emit('hangup', { callsid: callSid });
+    }
   }
 
   reconnect(callSid: string, { sdp, reconnectToken }: ReconnectConfig): void {

--- a/lib/twilio/signaling/pstreamsignalingadapter.ts
+++ b/lib/twilio/signaling/pstreamsignalingadapter.ts
@@ -3,9 +3,9 @@ import {
   AnswerConfig,
   DtmfConfig,
   HangupConfig,
+  IceRestartConfig,
   InviteConfig,
   ReconnectConfig,
-  ReinviteConfig,
   SendMessageConfig,
   SignalingAdapter,
   SignalingAdapterStatus,
@@ -80,8 +80,12 @@ export class PStreamSignalingAdapter extends EventEmitter implements SignalingAd
     this._pstream.reject(callSid);
   }
 
-  reinvite(callSid: string, { sdp }: ReinviteConfig): void {
-    this._pstream.reinvite(sdp, callSid);
+  iceRestart(callSid: string, { mediaHandler }: IceRestartConfig): void {
+    // Call (on PStream) owns offer generation: mediaHandler produces a
+    // fresh-ICE offer; we ship it via the existing reinvite wire.
+    mediaHandler.iceRestart((offerSdp: string) => {
+      this._pstream.reinvite(offerSdp, callSid);
+    });
   }
 
   reconnect(callSid: string, { sdp, reconnectToken }: ReconnectConfig): void {

--- a/lib/twilio/signaling/signalingadapter.ts
+++ b/lib/twilio/signaling/signalingadapter.ts
@@ -26,8 +26,19 @@ export interface HangupConfig {
   message?: string;
 }
 
-export interface ReinviteConfig {
-  sdp: string;
+/**
+ * Narrow view of the media handler that SignalingAdapter.iceRestart()
+ * needs. Satisfied structurally by PeerConnection.
+ */
+export interface IMediaHandler {
+  iceRestart(onOfferReady: (offerSdp: string) => void): void;
+}
+
+export interface IceRestartConfig {
+  // Used by the PStream adapter to generate the fresh-ICE offer; the
+  // SIP adapter ignores it because SIP.js asks the SDH to produce the
+  // offer via session.invite() + offerOptions.iceRestart.
+  mediaHandler: IMediaHandler;
 }
 
 export interface ReconnectConfig {
@@ -63,8 +74,19 @@ export interface SignalingAdapter extends EventEmitter {
   answer(callSid: string, config: AnswerConfig): void;
   hangup(callSid: string, config: HangupConfig): void;
   reject(callSid: string): void;
-  reinvite(callSid: string, config: ReinviteConfig): void;
   reconnect(callSid: string, config: ReconnectConfig): void;
+
+  /**
+   * Trigger an ICE restart for the given call. Each adapter encapsulates
+   * its own offer-generation strategy:
+   *  - PStream: asks config.mediaHandler to generate the offer, then
+   *    ships it via the existing reinvite wire.
+   *  - SIP: calls session.invite() with offerOptions.iceRestart so SIP.js
+   *    asks the SDH to produce the offer itself.
+   * On failure, emits 'hangup' for the callSid so Call can clean up its
+   * reinvite listeners.
+   */
+  iceRestart(callSid: string, config: IceRestartConfig): void;
 
   dtmf(callSid: string, config: DtmfConfig): void;
   sendMessage(callSid: string, config: SendMessageConfig): void;

--- a/lib/twilio/signaling/signalingadapter.ts
+++ b/lib/twilio/signaling/signalingadapter.ts
@@ -26,19 +26,12 @@ export interface HangupConfig {
   message?: string;
 }
 
-/**
- * Narrow view of the media handler that SignalingAdapter.iceRestart()
- * needs. Satisfied structurally by PeerConnection.
- */
-export interface IMediaHandler {
-  iceRestart(onOfferReady: (offerSdp: string) => void): void;
-}
-
 export interface IceRestartConfig {
   // Used by the PStream adapter to generate the fresh-ICE offer; the
   // SIP adapter ignores it because SIP.js asks the SDH to produce the
-  // offer via session.invite() + offerOptions.iceRestart.
-  mediaHandler: IMediaHandler;
+  // offer via session.invite() + offerOptions.iceRestart. Satisfied
+  // structurally by PeerConnection.
+  mediaHandler: { iceRestart(onOfferReady: (offerSdp: string) => void): void };
 }
 
 export interface ReconnectConfig {

--- a/lib/twilio/signaling/signalingadapter.ts
+++ b/lib/twilio/signaling/signalingadapter.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events';
+import type { IMediaHandler } from './mediahandler';
 import type { IPeerConnection } from './sipsessiondescriptionhandler';
 
 export type SignalingAdapterStatus = 'disconnected' | 'connected' | 'ready' | 'offline';
@@ -29,9 +30,8 @@ export interface HangupConfig {
 export interface IceRestartConfig {
   // Used by the PStream adapter to generate the fresh-ICE offer; the
   // SIP adapter ignores it because SIP.js asks the SDH to produce the
-  // offer via session.invite() + offerOptions.iceRestart. Satisfied
-  // structurally by PeerConnection.
-  mediaHandler: { iceRestart(onOfferReady: (offerSdp: string) => void): void };
+  // offer via session.invite() + offerOptions.iceRestart.
+  mediaHandler: IMediaHandler;
 }
 
 export interface ReconnectConfig {

--- a/lib/twilio/signaling/sipsessiondescriptionhandler.ts
+++ b/lib/twilio/signaling/sipsessiondescriptionhandler.ts
@@ -139,6 +139,12 @@ export class SipSessionDescriptionHandler implements SessionDescriptionHandler {
       if (this._iceRestartPending) {
         this._iceRestartPending = false;
         this._failPending(new Error(message || 'PeerConnection failed'));
+        // Skip previousOnFailed: _failPending rejects session.invite(),
+        // the adapter's .catch emits 'hangup', and Call._onHangup handles
+        // the event. Running previousOnFailed here would also trigger
+        // Call._onMediaFailure(ConnectionFailed) — double-dispatch that
+        // kicks off another backoff cycle and emits a duplicate error.
+        return;
       }
       previousOnFailed(message);
     };

--- a/lib/twilio/signaling/sipsessiondescriptionhandler.ts
+++ b/lib/twilio/signaling/sipsessiondescriptionhandler.ts
@@ -11,7 +11,7 @@ import {
  * is fragile across versions. We only need offerOptions for ICE-restart
  * plumbing, so we widen the public type here.
  */
-interface SessionDescriptionHandlerOptions extends BaseSessionDescriptionHandlerOptions {
+export interface SessionDescriptionHandlerOptions extends BaseSessionDescriptionHandlerOptions {
   offerOptions?: RTCOfferOptions;
 }
 
@@ -85,16 +85,20 @@ const APPLICATION_SDP = 'application/sdp';
  * handlers (Call owns them) so Call still emits its error events. The
  * onfailed wrap is scoped: it only rejects pending Promises when the SDH
  * itself initiated an ICE restart, so that runtime ICE failures do not
- * reject unrelated in-flight setDescription Promises.
+ * reject unrelated in-flight get/setDescription Promises.
  */
 export class SipSessionDescriptionHandler implements SessionDescriptionHandler {
   private _cachedAnswer: string | null = null;
   private _hasSentOffer: boolean = false;
   // True while an ICE-restart getDescription() is in flight. Scopes the
   // onfailed wrap: pc.onfailed fires both for createOffer rejection (what
-  // we want to reject the pending Promise for) and for ICE state = failed
-  // at runtime (what we do NOT want to reject unrelated in-flight
-  // setDescription Promises for).
+  // we want to reject the pending getDescription Promise for) and for ICE
+  // state = failed at runtime (what we do NOT want to reject unrelated
+  // in-flight get/setDescription Promises for).
+  //
+  // Invariant: at most one ICE-restart getDescription in flight per SDH.
+  // Enforced by the caller — Call._mediaReconnectBackoff fires serially,
+  // so overlapping ICE restarts cannot reach this SDH.
   private _iceRestartPending: boolean = false;
   // PeerConnection reports failures via onerror, not the success callbacks
   // we pass in. Every in-flight operation adds its reject handler here;
@@ -118,6 +122,10 @@ export class SipSessionDescriptionHandler implements SessionDescriptionHandler {
   ) {
     const previousOnError = this._pc.onerror;
     this._pc.onerror = (error: PeerConnectionError) => {
+      // Clear _iceRestartPending so a later runtime onfailed doesn't re-enter
+      // _failPending. Harmless today (pending set is already drained) but keeps
+      // the flag's meaning ("ICE restart in flight") accurate.
+      this._iceRestartPending = false;
       this._failPending(error?.info?.twilioError || new Error(error?.info?.message || 'PeerConnection error'));
       previousOnError(error);
     };

--- a/lib/twilio/signaling/sipsessiondescriptionhandler.ts
+++ b/lib/twilio/signaling/sipsessiondescriptionhandler.ts
@@ -1,4 +1,19 @@
-import { BodyAndContentType, SessionDescriptionHandler } from 'sip.js';
+import {
+  BodyAndContentType,
+  SessionDescriptionHandler,
+  SessionDescriptionHandlerOptions as BaseSessionDescriptionHandlerOptions,
+} from 'sip.js';
+
+/**
+ * Local extension of SIP.js's public SessionDescriptionHandlerOptions
+ * type. SIP.js's web-platform SDH ships a richer type in a private
+ * subpath (sip.js/lib/platform/web/...), but importing from that path
+ * is fragile across versions. We only need offerOptions for ICE-restart
+ * plumbing, so we widen the public type here.
+ */
+interface SessionDescriptionHandlerOptions extends BaseSessionDescriptionHandlerOptions {
+  offerOptions?: RTCOfferOptions;
+}
 
 /**
  * Shape of error payloads emitted by PeerConnection.onerror.
@@ -15,6 +30,11 @@ interface PeerConnectionError {
  */
 export interface IPeerConnection {
   onerror: (error: PeerConnectionError) => void;
+  // PeerConnection.iceRestart() rejects by calling onfailed(message) with a
+  // plain string, NOT by calling onerror. The SDH wraps this in addition to
+  // onerror so pending getDescription() Promises reject on ICE-restart
+  // failures instead of hanging.
+  onfailed: (message: string) => void;
 
   makeOutgoingCall(
     callSid: string,
@@ -35,6 +55,8 @@ export interface IPeerConnection {
     onMediaStarted: (pc: RTCPeerConnection) => void,
   ): void;
 
+  iceRestart(onOfferReady: (offerSdp: string) => void): void;
+
   close(): void;
 }
 
@@ -53,16 +75,27 @@ const APPLICATION_SDP = 'application/sdp';
  *   Inbound:  setDescription() -> answerIncomingCall consumes offer and
  *                                 produces an answer (cached)
  *             getDescription() -> returns the cached answer
+ *   ICE restart: getDescription({offerOptions:{iceRestart:true}}) -> pc.iceRestart
+ *                produces a fresh-ICE offer; subsequent setDescription
+ *                consumes the remote answer via processAnswer.
  *
- * Error handling: PeerConnection reports failures via its `onerror`
- * callback, not through the success-only callbacks we pass in. While a
- * PeerConnection call is pending, the SDH subscribes to `onerror` and
- * rejects the current Promise if it fires. The previous handler (Call
- * owns it) is still invoked so Call can emit its own error event.
+ * Error handling: PeerConnection reports failures via `onerror` (generic,
+ * rejects whatever is pending) and `onfailed` (ICE-state failures plus
+ * ICE-restart createOffer rejections). We wrap both and call the previous
+ * handlers (Call owns them) so Call still emits its error events. The
+ * onfailed wrap is scoped: it only rejects pending Promises when the SDH
+ * itself initiated an ICE restart, so that runtime ICE failures do not
+ * reject unrelated in-flight setDescription Promises.
  */
 export class SipSessionDescriptionHandler implements SessionDescriptionHandler {
   private _cachedAnswer: string | null = null;
   private _hasSentOffer: boolean = false;
+  // True while an ICE-restart getDescription() is in flight. Scopes the
+  // onfailed wrap: pc.onfailed fires both for createOffer rejection (what
+  // we want to reject the pending Promise for) and for ICE state = failed
+  // at runtime (what we do NOT want to reject unrelated in-flight
+  // setDescription Promises for).
+  private _iceRestartPending: boolean = false;
   // PeerConnection reports failures via onerror, not the success callbacks
   // we pass in. Every in-flight operation adds its reject handler here;
   // the onerror hook in the constructor rejects all of them. SIP.js can
@@ -70,6 +103,14 @@ export class SipSessionDescriptionHandler implements SessionDescriptionHandler {
   // media), so a single-slot field would let earlier Promises hang.
   private _pendingRejects: Set<(error: Error) => void> = new Set();
 
+  /**
+   * Invariant: at most one SipSessionDescriptionHandler exists per
+   * PeerConnection lifetime. The constructor wraps pc.onerror and
+   * pc.onfailed and stores the previous handlers in closures. Creating
+   * a second SDH over the same PC would stack wraps indefinitely and
+   * keep old Promise rejects reachable via closure. Today Call owns one
+   * PC per call and SIP.js memoizes one SDH per Session, so this holds.
+   */
   constructor(
     private _pc: IPeerConnection,
     private _callSid: string,
@@ -80,13 +121,44 @@ export class SipSessionDescriptionHandler implements SessionDescriptionHandler {
       this._failPending(error?.info?.twilioError || new Error(error?.info?.message || 'PeerConnection error'));
       previousOnError(error);
     };
+    const previousOnFailed = this._pc.onfailed;
+    this._pc.onfailed = (message: string) => {
+      // Only reject pending Promises if an ICE restart is in flight —
+      // that's the one case where pc.onfailed carries a createOffer
+      // rejection we need to propagate. Runtime ICE failures (ICE state
+      // = failed with no restart requested) must not reject unrelated
+      // setDescription Promises.
+      if (this._iceRestartPending) {
+        this._iceRestartPending = false;
+        this._failPending(new Error(message || 'PeerConnection failed'));
+      }
+      previousOnFailed(message);
+    };
   }
 
-  getDescription(): Promise<BodyAndContentType> {
+  getDescription(options?: SessionDescriptionHandlerOptions): Promise<BodyAndContentType> {
     if (this._cachedAnswer !== null) {
       const body = this._cachedAnswer;
       this._cachedAnswer = null;
       return Promise.resolve({ body, contentType: APPLICATION_SDP });
+    }
+    // SIP.js forwards sessionDescriptionHandlerOptions from session.invite()
+    // into this options argument. SipSignalingAdapter.iceRestart() sets
+    // offerOptions.iceRestart when Call's media backoff requests a restart;
+    // that routes through pc.iceRestart() (fresh ICE candidates) instead
+    // of pc.makeOutgoingCall().
+    if (options?.offerOptions?.iceRestart) {
+      this._iceRestartPending = true;
+      return this._awaitOperation<BodyAndContentType>((resolve) => {
+        this._pc.iceRestart((offerSdp) => {
+          this._iceRestartPending = false;
+          // Set _hasSentOffer so SIP.js's follow-up setDescription for the
+          // 200 OK's answer routes to processAnswer, matching outbound
+          // offer/answer semantics.
+          this._hasSentOffer = true;
+          resolve({ body: offerSdp, contentType: APPLICATION_SDP });
+        });
+      });
     }
     return this._awaitOperation<BodyAndContentType>((resolve) => {
       this._pc.makeOutgoingCall(this._callSid, this._rtcConfiguration, (offerSdp) => {
@@ -129,6 +201,7 @@ export class SipSessionDescriptionHandler implements SessionDescriptionHandler {
     // teardown paths. SIP.js invokes close() on the SDH at session end —
     // we must NOT close the PC here, or it would be closed twice (risking
     // duplicate close events or log warnings on torn-down handlers).
+    this._iceRestartPending = false;
     this._failPending(new Error('SipSessionDescriptionHandler closed'));
   }
 

--- a/lib/twilio/signaling/sipsignalingadapter.ts
+++ b/lib/twilio/signaling/sipsignalingadapter.ts
@@ -383,6 +383,10 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
     const inviteOptions: IceRestartInviteOptions = {
       requestDelegate: {
         onAccept: () => {
+          // SDP intentionally empty: the SDH consumed the remote answer via
+          // SIP.js's setDescription before this event fires, so Call's
+          // onAnswerOrRinging skips processAnswer on empty SDP. Passing a
+          // real SDP here would trigger a double-processAnswer.
           this.emit('answer', { callsid: callSid, sdp: '' });
         },
         onReject: (response: any) => {
@@ -390,7 +394,7 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
           this._log.warn('ICE-restart re-INVITE rejected', code);
           this.emit('hangup', {
             callsid: callSid,
-            error: { code: code || 31000, message: `ICE-restart re-INVITE rejected (${code || 'unknown'})` },
+            error: { code: code ?? 31000, message: `ICE-restart re-INVITE rejected (${code ?? 'unknown'})` },
           });
         },
       },

--- a/lib/twilio/signaling/sipsignalingadapter.ts
+++ b/lib/twilio/signaling/sipsignalingadapter.ts
@@ -377,10 +377,7 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
     const session = this._getSession(callSid);
     if (!session || session.state !== SessionState.Established) {
       this._log.warn('iceRestart: no established session for callSid', callSid);
-      this.emit('hangup', {
-        callsid: callSid,
-        error: { code: 31000, message: 'No established session for ICE restart' },
-      });
+      this.emit('hangup', { callsid: callSid });
       return;
     }
     const inviteOptions: IceRestartInviteOptions = {

--- a/lib/twilio/signaling/sipsignalingadapter.ts
+++ b/lib/twilio/signaling/sipsignalingadapter.ts
@@ -16,9 +16,9 @@ import {
   AnswerConfig,
   DtmfConfig,
   HangupConfig,
+  IceRestartConfig,
   InviteConfig,
   ReconnectConfig,
-  ReinviteConfig,
   SignalingAdapter,
   SignalingAdapterStatus,
   SendMessageConfig,
@@ -354,23 +354,49 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
     });
   }
 
-  reinvite(callSid: string, config: ReinviteConfig): void {
+  /**
+   * Trigger an ICE restart by sending a re-INVITE with
+   * offerOptions.iceRestart:true. SIP.js asks the SDH to produce the
+   * fresh-ICE offer via getDescription(options), so config.mediaHandler
+   * is unused here (the PStream adapter needs it; we preserve the shared
+   * interface). All failure paths (no session, onReject, catch) emit
+   * 'hangup' for the callSid so Call can clean up its inline re-INVITE
+   * listeners and transition out of the reconnecting state.
+   */
+  iceRestart(callSid: string, _config: IceRestartConfig): void {
     const session = this._getSession(callSid);
     if (!session || session.state !== SessionState.Established) {
-      this._log.warn('reinvite: no established session for callSid', callSid);
+      this._log.warn('iceRestart: no established session for callSid', callSid);
+      this.emit('hangup', {
+        callsid: callSid,
+        error: { code: 31000, message: 'No established session for ICE restart' },
+      });
       return;
     }
-    session.invite({
+    const inviteOptions: any = {
       requestDelegate: {
         onAccept: () => {
           this.emit('answer', { callsid: callSid, sdp: '' });
         },
         onReject: (response: any) => {
-          this._log.warn('re-INVITE rejected', response?.message?.statusCode);
+          const code = response?.message?.statusCode;
+          this._log.warn('ICE-restart re-INVITE rejected', code);
+          this.emit('hangup', {
+            callsid: callSid,
+            error: { code: code || 31000, message: `ICE-restart re-INVITE rejected (${code || 'unknown'})` },
+          });
         },
       },
-    }).catch((error: Error) => {
-      this._log.warn('Failed to send re-INVITE', error);
+      sessionDescriptionHandlerOptions: {
+        offerOptions: { iceRestart: true },
+      },
+    };
+    session.invite(inviteOptions).catch((error: Error) => {
+      this._log.warn('Failed to send ICE-restart re-INVITE', error);
+      this.emit('hangup', {
+        callsid: callSid,
+        error: { code: 31000, message: `Failed to send ICE-restart re-INVITE: ${error.message}` },
+      });
     });
   }
 

--- a/lib/twilio/signaling/sipsignalingadapter.ts
+++ b/lib/twilio/signaling/sipsignalingadapter.ts
@@ -7,6 +7,7 @@ import {
   RegistererState,
   SessionDescriptionHandler,
   Session,
+  SessionInviteOptions,
   SessionState,
   URI,
   UserAgent,
@@ -25,8 +26,17 @@ import {
 } from './signalingadapter';
 import {
   IPeerConnection,
+  SessionDescriptionHandlerOptions,
   SipSessionDescriptionHandler,
 } from './sipsessiondescriptionhandler';
+
+// SIP.js's SessionInviteOptions.sessionDescriptionHandlerOptions is typed
+// as the base SessionDescriptionHandlerOptions, which does not expose
+// offerOptions. Override that field with our SDH's extended type so the
+// iceRestart flag is typechecked at the call site.
+type IceRestartInviteOptions = Omit<SessionInviteOptions, 'sessionDescriptionHandlerOptions'> & {
+  sessionDescriptionHandlerOptions?: SessionDescriptionHandlerOptions;
+};
 
 type SipSendMessageConfig = Pick<SendMessageConfig, 'content' | 'contentType' | 'voiceEventSid'>;
 
@@ -373,7 +383,7 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
       });
       return;
     }
-    const inviteOptions: any = {
+    const inviteOptions: IceRestartInviteOptions = {
       requestDelegate: {
         onAccept: () => {
           this.emit('answer', { callsid: callSid, sdp: '' });

--- a/tests/unit/call.ts
+++ b/tests/unit/call.ts
@@ -2794,11 +2794,18 @@ describe('Call', function() {
       conn = new Call(config, Object.assign(options));
       conn.parameters = { CallSid: 'CAtest' };
       pstream.iceRestart = sinon.stub();
+      // Capture per-event baselines BEFORE the backoff adds its listeners so we
+      // can assert each event's count returns to its baseline after hangup (an
+      // aggregate sum could mask a leak where a listener is added as another
+      // is removed).
+      const answerBaseline = pstream.listenerCount('answer');
+      const hangupBaseline = pstream.listenerCount('hangup');
       conn['_mediaReconnectBackoff'].emit('ready');
-      const before = pstream.listenerCount('answer') + pstream.listenerCount('hangup');
+      assert.strictEqual(pstream.listenerCount('answer'), answerBaseline + 1);
+      assert.strictEqual(pstream.listenerCount('hangup'), hangupBaseline + 1);
       pstream.emit('hangup', { callsid: 'CAtest', error: { code: 488, message: 'rejected' } });
-      const after = pstream.listenerCount('answer') + pstream.listenerCount('hangup');
-      assert.ok(after < before, 'expected listener count to decrease after hangup');
+      assert.strictEqual(pstream.listenerCount('answer'), answerBaseline);
+      assert.strictEqual(pstream.listenerCount('hangup'), hangupBaseline);
     });
   });
 });

--- a/tests/unit/call.ts
+++ b/tests/unit/call.ts
@@ -2772,12 +2772,33 @@ describe('Call', function() {
       sinon.assert.callCount(callback, 1);
     });
 
-    it('should not call reinvite when CallSid is not set', () => {
+    it('should not call adapter.iceRestart when CallSid is not set', () => {
       conn = new Call(config, Object.assign(options));
       conn.parameters = {};
-      mediaHandler.iceRestart = sinon.spy((cb: Function) => cb('offer-sdp'));
+      pstream.iceRestart = sinon.stub();
       conn['_mediaReconnectBackoff'].emit('ready');
-      sinon.assert.notCalled(pstream.reinvite);
+      sinon.assert.notCalled(pstream.iceRestart);
+    });
+
+    it('should call adapter.iceRestart(callSid, {mediaHandler}) when the backoff fires', () => {
+      conn = new Call(config, Object.assign(options));
+      conn.parameters = { CallSid: 'CAtest' };
+      pstream.iceRestart = sinon.stub();
+      conn['_mediaReconnectBackoff'].emit('ready');
+      sinon.assert.calledOnce(pstream.iceRestart);
+      assert.strictEqual(pstream.iceRestart.firstCall.args[0], 'CAtest');
+      assert.deepStrictEqual(pstream.iceRestart.firstCall.args[1], { mediaHandler: conn['_mediaHandler'] });
+    });
+
+    it('self-cleans answer/hangup listeners when adapter emits hangup for the callSid (re-INVITE failure path)', () => {
+      conn = new Call(config, Object.assign(options));
+      conn.parameters = { CallSid: 'CAtest' };
+      pstream.iceRestart = sinon.stub();
+      conn['_mediaReconnectBackoff'].emit('ready');
+      const before = pstream.listenerCount('answer') + pstream.listenerCount('hangup');
+      pstream.emit('hangup', { callsid: 'CAtest', error: { code: 488, message: 'rejected' } });
+      const after = pstream.listenerCount('answer') + pstream.listenerCount('hangup');
+      assert.ok(after < before, 'expected listener count to decrease after hangup');
     });
   });
 });

--- a/tests/unit/call.ts
+++ b/tests/unit/call.ts
@@ -2803,7 +2803,7 @@ describe('Call', function() {
       conn['_mediaReconnectBackoff'].emit('ready');
       assert.strictEqual(pstream.listenerCount('answer'), answerBaseline + 1);
       assert.strictEqual(pstream.listenerCount('hangup'), hangupBaseline + 1);
-      pstream.emit('hangup', { callsid: 'CAtest', error: { code: 488, message: 'rejected' } });
+      pstream.emit('hangup', { callsid: 'CAtest' });
       assert.strictEqual(pstream.listenerCount('answer'), answerBaseline);
       assert.strictEqual(pstream.listenerCount('hangup'), hangupBaseline);
     });

--- a/tests/unit/pstreamsignalingadapter.ts
+++ b/tests/unit/pstreamsignalingadapter.ts
@@ -42,6 +42,21 @@ describe('PStreamSignalingAdapter', () => {
     assert(pstream.reinvite.calledWith('restarted-offer-sdp', 'callSid'));
   });
 
+  it('iceRestart() emits hangup (no error field) when mediaHandler.iceRestart throws synchronously', (done) => {
+    const mediaHandler = {
+      iceRestart: sinon.stub().throws(new Error('boom')),
+    };
+    adapter.on('hangup', (payload: any) => {
+      assert.strictEqual(payload.callsid, 'callSid');
+      // No error field: the media-failure path already surfaces this to the
+      // customer; we just need Call to clean up its inline listeners.
+      assert.strictEqual(payload.error, undefined);
+      done();
+    });
+    adapter.iceRestart('callSid', { mediaHandler });
+    sinon.assert.notCalled(pstream.reinvite);
+  });
+
   it('should delegate invite() to pstream', () => {
     adapter.invite('callSid', { sdp: 'sdp', params: 'params' });
     assert(pstream.invite.calledWith('sdp', 'callSid', 'params'));

--- a/tests/unit/pstreamsignalingadapter.ts
+++ b/tests/unit/pstreamsignalingadapter.ts
@@ -33,6 +33,15 @@ describe('PStreamSignalingAdapter', () => {
     adapter = new PStreamSignalingAdapter(pstream);
   });
 
+  it('iceRestart() asks the mediaHandler for an offer, then ships it via reinvite', () => {
+    const mediaHandler = {
+      iceRestart: sinon.stub().callsFake((cb: (sdp: string) => void) => cb('restarted-offer-sdp')),
+    };
+    adapter.iceRestart('callSid', { mediaHandler });
+    sinon.assert.calledOnce(mediaHandler.iceRestart);
+    assert(pstream.reinvite.calledWith('restarted-offer-sdp', 'callSid'));
+  });
+
   it('should delegate invite() to pstream', () => {
     adapter.invite('callSid', { sdp: 'sdp', params: 'params' });
     assert(pstream.invite.calledWith('sdp', 'callSid', 'params'));
@@ -51,11 +60,6 @@ describe('PStreamSignalingAdapter', () => {
   it('should delegate reject() to pstream', () => {
     adapter.reject('callSid');
     assert(pstream.reject.calledWith('callSid'));
-  });
-
-  it('should delegate reinvite() to pstream', () => {
-    adapter.reinvite('callSid', { sdp: 'sdp' });
-    assert(pstream.reinvite.calledWith('sdp', 'callSid'));
   });
 
   it('should delegate reconnect() to pstream', () => {

--- a/tests/unit/sipsessiondescriptionhandler.ts
+++ b/tests/unit/sipsessiondescriptionhandler.ts
@@ -170,6 +170,16 @@ describe('SipSessionDescriptionHandler', () => {
       sinon.assert.calledOnceWithExactly(previousOnFailed, 'network down');
     });
 
+    it('does NOT invoke previousOnFailed when onfailed fires DURING an ICE restart (avoids double-dispatch with session.invite rejection)', async () => {
+      const previousOnFailed = sinon.spy();
+      const pc = createPeerConnectionStub({ onfailed: previousOnFailed }); // iceRestart stub never calls back
+      const { handler } = createHandler(pc);
+      const pending = (handler.getDescription as any)(ICE_RESTART_OPTS);
+      pc.onfailed('createOffer rejected');
+      await assert.rejects(pending, /createOffer rejected/);
+      sinon.assert.notCalled(previousOnFailed);
+    });
+
     it('does NOT reject a pending setDescription when pc.onfailed fires outside of an ICE restart (runtime ICE failure)', async () => {
       const pc = createPeerConnectionStub(); // answerIncomingCall never calls back
       const { handler } = createHandler(pc);
@@ -184,8 +194,12 @@ describe('SipSessionDescriptionHandler', () => {
       await Promise.resolve();
       await Promise.resolve();
       assert.strictEqual(settled, false);
-      // Clean up the hung Promise so mocha doesn't warn about it.
-      void pending;
+      // Closing the SDH must drain _pendingRejects so the Promise actually
+      // settles — exercises the close() reject path and ensures no Promise
+      // leaks across tests.
+      handler.close();
+      await pending;
+      assert.strictEqual(settled, true);
     });
   });
 

--- a/tests/unit/sipsessiondescriptionhandler.ts
+++ b/tests/unit/sipsessiondescriptionhandler.ts
@@ -11,18 +11,23 @@ const OFFER_SDP = 'v=0\r\no=offerer\r\n';
 const ANSWER_SDP = 'v=0\r\no=answerer\r\n';
 
 interface PcStub extends IPeerConnection {
+  onerror: (error: any) => void;
+  onfailed: (message: string) => void;
   makeOutgoingCall: sinon.SinonStub;
   answerIncomingCall: sinon.SinonStub;
   processAnswer: sinon.SinonStub;
+  iceRestart: sinon.SinonStub;
   close: sinon.SinonStub;
 }
 
 function createPeerConnectionStub(overrides: Partial<PcStub> = {}): PcStub {
   const stub: PcStub = {
     onerror: () => { /* replaced by SDH constructor */ },
+    onfailed: () => { /* replaced by SDH constructor */ },
     makeOutgoingCall: sinon.stub(),
     answerIncomingCall: sinon.stub(),
     processAnswer: sinon.stub(),
+    iceRestart: sinon.stub(),
     close: sinon.stub(),
     ...overrides,
   };
@@ -73,6 +78,115 @@ describe('SipSessionDescriptionHandler', () => {
       assert.deepStrictEqual(description, { body: OFFER_SDP, contentType: APPLICATION_SDP });
     });
 
+  });
+
+  describe('getDescription with ICE restart', () => {
+    const ICE_RESTART_OFFER_SDP = 'v=0\r\no=ice-restart\r\n';
+    const ICE_RESTART_OPTS = { offerOptions: { iceRestart: true } };
+
+    it('routes through pc.iceRestart when options.offerOptions.iceRestart is true', async () => {
+      const pc = createPeerConnectionStub({
+        iceRestart: sinon.stub().callsFake(
+          (cb: (sdp: string) => void) => cb(ICE_RESTART_OFFER_SDP),
+        ) as sinon.SinonStub,
+      });
+      const { handler } = createHandler(pc);
+      const description = await (handler.getDescription as any)(ICE_RESTART_OPTS);
+      assert.deepStrictEqual(description, { body: ICE_RESTART_OFFER_SDP, contentType: APPLICATION_SDP });
+      sinon.assert.calledOnce(pc.iceRestart);
+      sinon.assert.notCalled(pc.makeOutgoingCall);
+    });
+
+    it('falls back to makeOutgoingCall when options does NOT include iceRestart', async () => {
+      const pc = createPeerConnectionStub({
+        makeOutgoingCall: sinon.stub().callsFake(
+          (_sid: string, _cfg: RTCConfiguration, cb: (sdp: string) => void) => cb(OFFER_SDP),
+        ) as sinon.SinonStub,
+      });
+      const { handler } = createHandler(pc);
+      await handler.getDescription();
+      sinon.assert.calledOnce(pc.makeOutgoingCall);
+      sinon.assert.notCalled(pc.iceRestart);
+    });
+
+    it('does NOT leak iceRestart routing across calls (each getDescription reads options independently)', async () => {
+      const pc = createPeerConnectionStub({
+        makeOutgoingCall: sinon.stub().callsFake(
+          (_sid: string, _cfg: RTCConfiguration, cb: (sdp: string) => void) => cb(OFFER_SDP),
+        ) as sinon.SinonStub,
+        iceRestart: sinon.stub().callsFake(
+          (cb: (sdp: string) => void) => cb(ICE_RESTART_OFFER_SDP),
+        ) as sinon.SinonStub,
+        processAnswer: sinon.stub().callsFake(
+          (_sdp: string, cb: (pc: RTCPeerConnection) => void) => cb({} as RTCPeerConnection),
+        ) as sinon.SinonStub,
+      });
+      const { handler } = createHandler(pc);
+      await (handler.getDescription as any)(ICE_RESTART_OPTS);
+      await handler.setDescription(ANSWER_SDP);
+      // No options this time: must fall back to makeOutgoingCall.
+      await handler.getDescription();
+      sinon.assert.calledOnce(pc.iceRestart);
+      sinon.assert.calledOnce(pc.makeOutgoingCall);
+    });
+
+    it('routes the subsequent setDescription through processAnswer (ICE restart has outbound-offer semantics)', async () => {
+      const pc = createPeerConnectionStub({
+        iceRestart: sinon.stub().callsFake(
+          (cb: (sdp: string) => void) => cb(ICE_RESTART_OFFER_SDP),
+        ) as sinon.SinonStub,
+        processAnswer: sinon.stub().callsFake(
+          (_sdp: string, cb: (pc: RTCPeerConnection) => void) => cb({} as RTCPeerConnection),
+        ) as sinon.SinonStub,
+      });
+      const { handler } = createHandler(pc);
+      await (handler.getDescription as any)(ICE_RESTART_OPTS);
+      await handler.setDescription(ANSWER_SDP);
+      sinon.assert.calledOnce(pc.processAnswer);
+      sinon.assert.notCalled(pc.answerIncomingCall);
+    });
+
+    it('rejects the pending getDescription if pc.onerror fires during ICE restart', async () => {
+      const pc = createPeerConnectionStub(); // iceRestart stub never calls back
+      const { handler } = createHandler(pc);
+      const pending = (handler.getDescription as any)(ICE_RESTART_OPTS);
+      pc.onerror({ info: { code: 31000, message: 'ice restart failure' } });
+      await assert.rejects(pending, /ice restart failure/);
+    });
+
+    it('rejects the pending getDescription if pc.onfailed fires during ICE restart (createOffer rejection path)', async () => {
+      const pc = createPeerConnectionStub(); // iceRestart stub never calls back
+      const { handler } = createHandler(pc);
+      const pending = (handler.getDescription as any)(ICE_RESTART_OPTS);
+      pc.onfailed('createOffer rejected');
+      await assert.rejects(pending, /createOffer rejected/);
+    });
+
+    it('still invokes the previous onfailed handler when pc.onfailed fires', () => {
+      const previousOnFailed = sinon.spy();
+      const pc = createPeerConnectionStub({ onfailed: previousOnFailed });
+      createHandler(pc);
+      pc.onfailed('network down');
+      sinon.assert.calledOnceWithExactly(previousOnFailed, 'network down');
+    });
+
+    it('does NOT reject a pending setDescription when pc.onfailed fires outside of an ICE restart (runtime ICE failure)', async () => {
+      const pc = createPeerConnectionStub(); // answerIncomingCall never calls back
+      const { handler } = createHandler(pc);
+      let settled = false;
+      const pending = handler.setDescription(OFFER_SDP).then(
+        () => { settled = true; },
+        () => { settled = true; },
+      );
+      // Simulate runtime ICE failure (no ICE restart requested).
+      pc.onfailed('ICE connection failed');
+      // Yield a microtask or two to let any spurious reject propagate.
+      await Promise.resolve();
+      await Promise.resolve();
+      assert.strictEqual(settled, false);
+      // Clean up the hung Promise so mocha doesn't warn about it.
+      void pending;
+    });
   });
 
   describe('setDescription after offer (outbound answer)', () => {

--- a/tests/unit/sipsessiondescriptionhandler.ts
+++ b/tests/unit/sipsessiondescriptionhandler.ts
@@ -166,6 +166,9 @@ describe('SipSessionDescriptionHandler', () => {
       const previousOnFailed = sinon.spy();
       const pc = createPeerConnectionStub({ onfailed: previousOnFailed });
       createHandler(pc);
+      // _iceRestartPending is false here (no ICE restart in flight), so the
+      // wrap falls through to previousOnFailed. See the next test for the
+      // ICE-restart branch where previousOnFailed is intentionally skipped.
       pc.onfailed('network down');
       sinon.assert.calledOnceWithExactly(previousOnFailed, 'network down');
     });

--- a/tests/unit/sipsignalingadapter.ts
+++ b/tests/unit/sipsignalingadapter.ts
@@ -705,11 +705,14 @@ describe('SipSignalingAdapter', () => {
       rd.onAccept();
     });
 
-    it('emits hangup (with error) when session is not established', (done) => {
+    it('emits hangup WITHOUT an error field when session is not established (Call cleans up listeners silently)', (done) => {
       const { adapter } = createAdapter();
       adapter.on('hangup', (payload: any) => {
         assert.strictEqual(payload.callsid, 'nope');
-        assert.ok(payload.error);
+        // No error field: Call._onHangup would translate `error` into an
+        // emit('error', ConnectionError), which is not wanted for this
+        // benign teardown race.
+        assert.strictEqual(payload.error, undefined);
         done();
       });
       adapter.iceRestart('nope', { mediaHandler: mediaHandlerStub() });

--- a/tests/unit/sipsignalingadapter.ts
+++ b/tests/unit/sipsignalingadapter.ts
@@ -7,9 +7,11 @@ import { IPeerConnection, SipSessionDescriptionHandler } from '../../lib/twilio/
 function createPeerConnectionStub(): IPeerConnection {
   return {
     onerror: () => { /* replaced by SDH constructor when used */ },
+    onfailed: () => { /* replaced by SDH constructor when used */ },
     makeOutgoingCall: sinon.stub(),
     answerIncomingCall: sinon.stub(),
     processAnswer: sinon.stub(),
+    iceRestart: sinon.stub(),
     close: sinon.stub(),
   };
 }
@@ -669,23 +671,28 @@ describe('SipSignalingAdapter', () => {
     });
   });
 
-  describe('reinvite()', () => {
-    it('should call session.invite() for established sessions', () => {
+  describe('iceRestart()', () => {
+    const mediaHandlerStub = () => ({ iceRestart: sinon.stub() });
+
+    it('passes offerOptions.iceRestart:true to session.invite', () => {
       const { adapter, inviterStub } = createAdapter();
       adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: createPeerConnectionStub() });
       inviterStub.state = 'Established';
-      adapter.reinvite('call-1', { sdp: 'new-sdp' });
-      // session.invite is the re-INVITE call (distinct from inviter.invite for initial INVITE)
-      // inviterStub.invite is called once for initial, then once for reinvite = 2 total
-      assert.strictEqual(inviterStub.invite.callCount, 2);
+      adapter.iceRestart('call-1', { mediaHandler: mediaHandlerStub() });
+      const reinviteOpts = inviterStub.invite.lastCall.args[0];
+      assert.strictEqual(reinviteOpts?.sessionDescriptionHandlerOptions?.offerOptions?.iceRestart, true);
     });
 
-    it('should not throw for non-established session', () => {
-      const { adapter } = createAdapter();
-      assert.doesNotThrow(() => adapter.reinvite('unknown', { sdp: 'sdp' }));
+    it('does NOT consult the mediaHandler (SIP SDH generates the offer itself)', () => {
+      const { adapter, inviterStub } = createAdapter();
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: createPeerConnectionStub() });
+      inviterStub.state = 'Established';
+      const mediaHandler = mediaHandlerStub();
+      adapter.iceRestart('call-1', { mediaHandler });
+      sinon.assert.notCalled(mediaHandler.iceRestart);
     });
 
-    it('should emit "answer" on requestDelegate.onAccept', (done) => {
+    it('emits "answer" on requestDelegate.onAccept', (done) => {
       const { adapter, inviterStub } = createAdapter();
       adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: createPeerConnectionStub() });
       inviterStub.state = 'Established';
@@ -693,18 +700,47 @@ describe('SipSignalingAdapter', () => {
         assert.strictEqual(payload.callsid, 'call-1');
         done();
       });
-      adapter.reinvite('call-1', { sdp: 'new-sdp' });
+      adapter.iceRestart('call-1', { mediaHandler: mediaHandlerStub() });
       const rd = inviterStub.invite.lastCall.args[0]?.requestDelegate;
       rd.onAccept();
     });
 
-    it('should warn but not throw on requestDelegate.onReject', () => {
+    it('emits hangup (with error) when session is not established', (done) => {
+      const { adapter } = createAdapter();
+      adapter.on('hangup', (payload: any) => {
+        assert.strictEqual(payload.callsid, 'nope');
+        assert.ok(payload.error);
+        done();
+      });
+      adapter.iceRestart('nope', { mediaHandler: mediaHandlerStub() });
+    });
+
+    it('emits hangup (with status code) on requestDelegate.onReject', (done) => {
       const { adapter, inviterStub } = createAdapter();
       adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: createPeerConnectionStub() });
       inviterStub.state = 'Established';
-      adapter.reinvite('call-1', { sdp: 'new-sdp' });
+      adapter.on('hangup', (payload: any) => {
+        assert.strictEqual(payload.callsid, 'call-1');
+        assert.strictEqual(payload.error.code, 488);
+        done();
+      });
+      adapter.iceRestart('call-1', { mediaHandler: mediaHandlerStub() });
       const rd = inviterStub.invite.lastCall.args[0]?.requestDelegate;
-      assert.doesNotThrow(() => rd.onReject({ message: { statusCode: 488 } }));
+      rd.onReject({ message: { statusCode: 488 } });
+    });
+
+    it('emits hangup when session.invite rejects asynchronously (via .catch)', (done) => {
+      const { adapter, inviterStub } = createAdapter();
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: createPeerConnectionStub() });
+      inviterStub.state = 'Established';
+      // Make session.invite return a rejected Promise on the next call.
+      inviterStub.invite = sinon.stub().returns(Promise.reject(new Error('invite failed')));
+      adapter.on('hangup', (payload: any) => {
+        assert.strictEqual(payload.callsid, 'call-1');
+        assert.ok(payload.error);
+        done();
+      });
+      adapter.iceRestart('call-1', { mediaHandler: mediaHandlerStub() });
     });
   });
 


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

https://twilio-engineering.atlassian.net/browse/VBLOCKS-6375

### Description

  - **Add SDH ICE restart support** so the SIP signaling path can recover media via re-INVITE with fresh ICE, matching the existing PStream behavior
  - **Replace `reinvite()` with `iceRestart()`** on `SignalingAdapter` — each adapter now owns its offer-generation strategy:
    - `PStreamSignalingAdapter`: asks `mediaHandler.iceRestart()` for the offer, ships it via `pstream.reinvite`
    - `SipSignalingAdapter`: calls `session.invite()` with `offerOptions.iceRestart`, letting SIP.js drive the SDH to produce the offer
  - **Wire ICE restart through `SipSessionDescriptionHandler`** — `getDescription({offerOptions:{iceRestart:true}})` routes to `pc.iceRestart()` instead of `pc.makeOutgoingCall()`, and the following `setDescription` goes through
  `processAnswer` (outbound-offer semantics)
  - **Wrap `pc.onfailed`** in the SDH, scoped by an `_iceRestartPending` flag, so `createOffer` rejections reject the pending Promise without breaking unrelated in-flight `setDescription` Promises on runtime ICE failures
  - **Simplify `Call._mediaReconnectBackoff` handler** — delegates offer generation to the adapter and relies on adapter-emitted `hangup` for cleanup on failure
  - **SIP failure paths all emit `hangup`** (no session, `onReject`, async `.catch`) so `Call` can tear down its re-INVITE listeners and exit the reconnecting state

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Ready for review
