### PR TITLE
[VBLOCKS-6980] fix: bfcache restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 :warning: **Important**: If you are upgrading to version 2.3.0 or later and have firewall rules or network configuration that blocks any unknown traffic by default, you need to update your configuration to allow connections to the new DNS names and IP addresses. Please refer to this [changelog](#230-january-23-2023) for more details.
 
+2.18.4 (Work in progress)
+===================
+
+Bug Fixes
+---------
+
+- Fixed an [issue](https://github.com/twilio/twilio-voice.js/issues/446) where the `Device` was permanently destroyed when Chrome restored a page from the back/forward cache (BFCache) in Chrome 149+. The SDK now inspects `PageTransitionEvent.persisted`: on a persisted `pagehide` (no active calls) it quiesces the signaling connection instead of destroying the `Device`, and on a persisted `pageshow` it re-establishes signaling and re-registers if the `Device` was previously registered. Normal (non-persisted) page unloads continue to destroy the `Device`, and an explicitly destroyed `Device` is not revived. Thanks @anene for reporting this.
+
 2.18.3 (May 11, 2026)
 =====================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 Bug Fixes
 ---------
 
-- Fixed an [issue](https://github.com/twilio/twilio-voice.js/issues/446) where the `Device` was permanently destroyed when Chrome restored a page from the back/forward cache (BFCache) in Chrome 149+. The SDK now inspects `PageTransitionEvent.persisted`: on a persisted `pagehide` (no active calls) it quiesces the signaling connection instead of destroying the `Device`, and on a persisted `pageshow` it re-establishes signaling and re-registers if the `Device` was previously registered. Normal (non-persisted) page unloads continue to destroy the `Device`, and an explicitly destroyed `Device` is not revived. Thanks @anene for reporting this.
+- Fixed an [issue](https://github.com/twilio/twilio-voice.js/issues/446) where the `Device` was permanently destroyed when Chrome restored a page from the back/forward cache (BFCache) in Chrome 149+. When a page is cached (and no calls are active), the `Device` now closes its signaling connection instead of destroying itself, and reconnects and re-registers when the page is restored. Normal page unloads still destroy the `Device`, and a `Device` you destroy yourself is never revived. Thanks @anene for reporting this.
+
+  Note: during a BFCache round-trip, the `Device` emits `unregistered` when the page is cached and `registered` again when it is restored. If your app shows registration status in the UI, expect it to briefly flip to unregistered and back.
 
 2.18.3 (May 11, 2026)
 =====================

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -298,6 +298,16 @@ class Device extends EventEmitter {
   private _boundDestroy: typeof Device.prototype.destroy;
 
   /**
+   * {@link Device._onPageHide} bound to the specific {@link Device} instance.
+   */
+  private _boundOnPageHide: typeof Device.prototype._onPageHide;
+
+  /**
+   * {@link Device._onPageShow} bound to the specific {@link Device} instance.
+   */
+  private _boundOnPageShow: typeof Device.prototype._onPageShow;
+
+  /**
    * An audio input MediaStream to pass to new {@link Call} instances.
    */
   private _callInputStream: MediaStream | null = null;
@@ -514,9 +524,12 @@ class Device extends EventEmitter {
 
     this._boundDestroy = this.destroy.bind(this);
     this._boundConfirmClose = this._confirmClose.bind(this);
+    this._boundOnPageHide = this._onPageHide.bind(this);
+    this._boundOnPageShow = this._onPageShow.bind(this);
 
     if (typeof window !== 'undefined' && window.addEventListener) {
-      window.addEventListener('pagehide', this._boundDestroy);
+      window.addEventListener('pagehide', this._boundOnPageHide);
+      window.addEventListener('pageshow', this._boundOnPageShow);
     }
 
     this.updateOptions(options);
@@ -628,7 +641,8 @@ class Device extends EventEmitter {
 
     if (typeof window !== 'undefined' && window.removeEventListener) {
       window.removeEventListener('beforeunload', this._boundConfirmClose);
-      window.removeEventListener('pagehide', this._boundDestroy);
+      window.removeEventListener('pagehide', this._boundOnPageHide);
+      window.removeEventListener('pageshow', this._boundOnPageShow);
     }
 
     this._setState(Device.State.Destroyed);
@@ -1163,6 +1177,46 @@ class Device extends EventEmitter {
   private _maybeStopIncomingSound(): void {
     if (!this._calls.length) {
       this._soundcache.get(Device.SoundName.Incoming).stop();
+    }
+  }
+
+  /**
+   * Called on the window's `pagehide` event. When the page is entering the
+   * back/forward cache (`event.persisted === true`) and there are no active
+   * calls, the signaling connection is quiesced without permanently destroying
+   * the {@link Device}, so it can be restored on `pageshow`. Otherwise the
+   * {@link Device} is destroyed, preserving the historical behavior (a normal
+   * page unload, or a persisted transition while media is active and cannot
+   * survive the cache).
+   */
+  private _onPageHide(event?: PageTransitionEvent): void {
+    if (event && event.persisted && this._calls.length === 0) {
+      this._log.debug('Page entering BFCache; quiescing signaling');
+      this._stopRegistrationTimer();
+      this._destroyStream();
+    } else {
+      this.destroy();
+    }
+  }
+
+  /**
+   * Called on the window's `pageshow` event. When the page is restored from the
+   * back/forward cache (`event.persisted === true`), re-register if the
+   * {@link Device} was registered before entering the cache. A previously
+   * destroyed or unregistered {@link Device} is left untouched.
+   */
+  private _onPageShow(event?: PageTransitionEvent): void {
+    if (!event || !event.persisted) {
+      return;
+    }
+    if (this.state === Device.State.Destroyed) {
+      return;
+    }
+    if (this._shouldReRegister && this.state === Device.State.Unregistered) {
+      this._log.debug('Page restored from BFCache; re-registering');
+      this.register().catch((error: any) => {
+        this._log.warn('Failed to re-register after BFCache restore', error);
+      });
     }
   }
 

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -1184,7 +1184,7 @@ class Device extends EventEmitter {
    * survive the cache).
    */
   private _onPageHide(event?: PageTransitionEvent): void {
-    if (event && event.persisted && this._calls.length === 0) {
+    if (event && event.persisted && this._calls.length === 0 && !this._activeCall && !this._makeCallPromise) {
       this._log.debug('Page entering BFCache; quiescing signaling');
       this._stopRegistrationTimer();
       this._destroyStream();

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -293,11 +293,6 @@ class Device extends EventEmitter {
   private _boundConfirmClose: typeof Device.prototype._confirmClose;
 
   /**
-   * {@link Device.destroy} bound to the specific {@link Device} instance.
-   */
-  private _boundDestroy: typeof Device.prototype.destroy;
-
-  /**
    * {@link Device._onPageHide} bound to the specific {@link Device} instance.
    */
   private _boundOnPageHide: typeof Device.prototype._onPageHide;
@@ -522,7 +517,6 @@ class Device extends EventEmitter {
       }
     }
 
-    this._boundDestroy = this.destroy.bind(this);
     this._boundConfirmClose = this._confirmClose.bind(this);
     this._boundOnPageHide = this._onPageHide.bind(this);
     this._boundOnPageShow = this._onPageShow.bind(this);

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -9,8 +9,12 @@ root.resetEvents = () => { handlers = {}; };
 root.WebSocket = WebSocket;
 root.window = {
   addEventListener: (name: string, func: Function) => { (handlers as any)[name] = func; },
-  dispatchEvent: (name: string) => {
-    (handlers as any)[name]();
+  dispatchEvent: (name: string, event?: any) => {
+    const handler = (handlers as any)[name];
+    if (!handler) {
+      return;
+    }
+    handler(event);
   },
   navigator: { userAgent: '' },
   removeEventListener: (name: string) => { delete (handlers as any)[name]; },

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -1814,15 +1814,105 @@ describe('Device', function() {
             });
           });
 
-          describe('on pagehide', () => {
-            it('should call destroy once on pagehide', () => {
-              stub = sinon.createStubInstance(Device);
-              Device.prototype.constructor.call(stub, token);
-              root.window.dispatchEvent('pagehide');
-              sinon.assert.calledOnce(stub.destroy);
-            });
-          });
         });
+      });
+    });
+
+    describe('page lifecycle (BFCache)', () => {
+      const registerFromScratch = async () => {
+        await setupStream();
+        const regPromise = device.register();
+        await clock.tickAsync(0);
+        pstream.emit('ready');
+        await regPromise;
+      };
+
+      // Drives the async register() started inside _onPageShow to completion by
+      // resolving the freshly created signaling stream.
+      const driveReregister = async () => {
+        await clock.tickAsync(0);
+        pstream.emit('connected', { region: 'US_EAST_VIRGINIA' });
+        await clock.tickAsync(0);
+        pstream.emit('ready');
+        await clock.tickAsync(0);
+      };
+
+      it('should destroy the device on a normal (no-arg) pagehide', () => {
+        const spy = device.destroy = sinon.spy(device.destroy);
+        root.window.dispatchEvent('pagehide');
+        sinon.assert.calledOnce(spy);
+        assert.equal(device.state, Device.State.Destroyed);
+      });
+
+      it('should destroy the device on a non-persisted pagehide', () => {
+        root.window.dispatchEvent('pagehide', { persisted: false });
+        assert.equal(device.state, Device.State.Destroyed);
+      });
+
+      it('should not destroy the device on a persisted pagehide', async () => {
+        await registerFromScratch();
+        root.window.dispatchEvent('pagehide', { persisted: true });
+        assert.notEqual(device.state, Device.State.Destroyed);
+        assert.equal(device.state, Device.State.Unregistered);
+        assert.equal(device['_shouldReRegister'], true);
+        sinon.assert.calledOnce(pstream.destroy);
+      });
+
+      it('should re-register exactly once after BFCache restore if previously registered', async () => {
+        await registerFromScratch();
+        root.window.dispatchEvent('pagehide', { persisted: true });
+        root.window.dispatchEvent('pageshow', { persisted: true });
+        await driveReregister();
+        assert.equal(device.state, Device.State.Registered);
+        // One stream for the initial registration, one for the restore.
+        sinon.assert.calledTwice(PStream);
+        // The fresh stream is registered exactly once.
+        sinon.assert.calledOnce(pstream.register);
+      });
+
+      it('should remain unregistered after BFCache restore if not previously registered', async () => {
+        const spy = device.register = sinon.spy(device.register);
+        root.window.dispatchEvent('pagehide', { persisted: true });
+        root.window.dispatchEvent('pageshow', { persisted: true });
+        await clock.tickAsync(0);
+        assert.equal(device.state, Device.State.Unregistered);
+        assert.equal(device['_shouldReRegister'], false);
+        sinon.assert.notCalled(spy);
+      });
+
+      it('should not duplicate streams or registrations across repeated BFCache cycles', async () => {
+        await registerFromScratch();
+        for (let i = 0; i < 2; i++) {
+          const streamsBefore = PStream.callCount;
+          root.window.dispatchEvent('pagehide', { persisted: true });
+          root.window.dispatchEvent('pageshow', { persisted: true });
+          await driveReregister();
+          // Exactly one new stream and one registration per restore.
+          assert.equal(PStream.callCount - streamsBefore, 1);
+          sinon.assert.calledOnce(pstream.register);
+          assert.equal(device.state, Device.State.Registered);
+        }
+      });
+
+      it('should not revive an explicitly destroyed device on pageshow', async () => {
+        await registerFromScratch();
+        device.destroy();
+        assert.equal(device.state, Device.State.Destroyed);
+
+        const spy = device.register = sinon.spy(device.register);
+        // The listener was removed by destroy(), so a dispatched pageshow is a
+        // no-op; the state guard also prevents revival if invoked directly.
+        root.window.dispatchEvent('pageshow', { persisted: true });
+        device['_onPageShow']({ persisted: true } as any);
+        assert.equal(device.state, Device.State.Destroyed);
+        sinon.assert.notCalled(spy);
+      });
+
+      it('should destroy the device on a persisted pagehide when a call is active', async () => {
+        await registerFromScratch();
+        device['_calls'].push({ reject: sinon.stub(), disconnect: sinon.stub() } as any);
+        root.window.dispatchEvent('pagehide', { persisted: true });
+        assert.equal(device.state, Device.State.Destroyed);
       });
     });
   });

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -1914,6 +1914,29 @@ describe('Device', function() {
         root.window.dispatchEvent('pagehide', { persisted: true });
         assert.equal(device.state, Device.State.Destroyed);
       });
+
+      it('should destroy the device on a persisted pagehide when a call has been accepted', async () => {
+        await registerFromScratch();
+        device['_activeCall'] = { reject: sinon.stub(), disconnect: sinon.stub() } as any;
+        root.window.dispatchEvent('pagehide', { persisted: true });
+        assert.equal(device.state, Device.State.Destroyed);
+      });
+
+      it('should destroy the device on a persisted pagehide when a call is mid-setup (connect() in flight)', async () => {
+        await registerFromScratch();
+        const connectPromise = device.connect();
+        root.window.dispatchEvent('pagehide', { persisted: true });
+        assert.equal(device.state, Device.State.Destroyed);
+        await assert.rejects(() => connectPromise);
+      });
+
+      it('should destroy the device on a persisted pagehide when an incoming call is mid-setup', async () => {
+        await registerFromScratch();
+        pstream.emit('invite', { callsid: 'foo', sdp: 'bar' });
+        assert(!!device['_makeCallPromise']);
+        root.window.dispatchEvent('pagehide', { persisted: true });
+        assert.equal(device.state, Device.State.Destroyed);
+      });
     });
   });
 });


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

https://twilio-engineering.atlassian.net/browse/VBLOCKS-6980

Issue: https://github.com/twilio/twilio-voice.js/issues/446

### Description

- Chrome 149+ lets pages with an active WebSocket enter the back/forward cache, but the SDK unconditionally destroyed the Device on pagehide, leaving restored pages with a permanently dead Device.

- This now quiesces signaling on a persisted pagehide (instead of destroying) and reconnects/re-registers on pageshow, while normal unloads and explicit destroy() calls behave as before.

- Verified with new unit tests (8 cases) and manually in Chrome 150 via the DevTools BFCache tester
- tested e2e locally

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review
