### PR TITLE
[VBLOCKS-6983] fix: senddigits 500ms pause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 Bug Fixes
 ---------
 
+- Fixed an [issue](https://github.com/twilio/twilio-voice.js/issues/272) where the local DTMF tones played back to the caller by `call.sendDigits()` advanced a pause character (`w`) after only 200ms instead of the full 500ms pause. This made the caller hear a shorter pause than the recipient received, and the gap accumulated with each `w`. Local playback now uses the same 500ms pause duration as the DTMF sent over the wire, so both ends stay in sync. Thanks @a-lindsay for reporting this.
+
 - Fixed an [issue](https://github.com/twilio/twilio-voice.js/issues/446) where the `Device` was permanently destroyed when Chrome restored a page from the back/forward cache (BFCache) in Chrome 149+. When a page is cached (and no calls are active), the `Device` now closes its signaling connection instead of destroying itself, and reconnects and re-registers when the page is restored. Normal page unloads still destroy the `Device`, and a `Device` you destroy yourself is never revived. Thanks @anene for reporting this.
 
   Note: during a BFCache round-trip, the `Device` emits `unregistered` when the page is cached and `registered` again when it is restored. If your app shows registration status in the UI, expect it to briefly flip to unregistered and back.

--- a/cypress/e2e/callSendDigits.cy.ts
+++ b/cypress/e2e/callSendDigits.cy.ts
@@ -61,6 +61,38 @@ describe('Call sendDigits', function() {
     assert.doesNotThrow(() => call1.sendDigits('1w2'));
   });
 
+  it('should pause local DTMF playback for the full pause duration on "w"', () => {
+    // Regression test for https://github.com/twilio/twilio-voice.js/issues/272.
+    // Local playback (what the caller hears) must advance a pause ('w') after the
+    // full 500ms pause, not the 200ms tone gap. For '7w8' that puts the gap
+    // between the two tones at ~700ms (200ms tone gap + 500ms pause); the old bug
+    // advanced after ~400ms. Digits 7 and 8 are unique to this test so pending
+    // playback timers from other tests cannot contaminate the timing.
+    const dialtonePlayer = (call1 as any)._options.dialtonePlayer;
+    if (!dialtonePlayer) {
+      // No AudioContext-backed dialtone player in this environment; nothing to measure.
+      return;
+    }
+
+    const start = Date.now();
+    const first: { [sound: string]: number } = {};
+    cy.stub(dialtonePlayer, 'play').callsFake((sound: string) => {
+      if (!(sound in first)) {
+        first[sound] = Date.now() - start;
+      }
+    });
+
+    call1.sendDigits('7w8');
+
+    // Wait past the full sequence (~700ms) with a buffer, then assert timing.
+    cy.wait(1500).then(() => {
+      assert.ok(first.dtmf7 !== undefined, 'dtmf7 should have played');
+      assert.ok(first.dtmf8 !== undefined, 'dtmf8 should have played');
+      const gap = first.dtmf8 - first.dtmf7;
+      assert.ok(gap >= 600, `expected pause gap >= 600ms but was ${gap}ms`);
+    });
+  });
+
   it('should throw on invalid characters', () => {
     assert.throws(() => call1.sendDigits('abc'), (err: any) => {
       return err.name === 'InvalidArgumentError';

--- a/lib/twilio/call.ts
+++ b/lib/twilio/call.ts
@@ -855,7 +855,11 @@ class Call extends EventEmitter {
         }
       }
       if (sequence.length) {
-        setTimeout(() => playNextDigit(), 200);
+        // NOTE: A pause ('w') maps to an empty string in the sequence and plays
+        // no sound. Wait the full pause duration so local playback stays in sync
+        // with the DTMF sent over the wire, which pauses for DTMF_PAUSE_DURATION.
+        const delay = digit ? 200 : DTMF_PAUSE_DURATION;
+        setTimeout(() => playNextDigit(), delay);
       }
     };
     playNextDigit();

--- a/tests/unit/call.ts
+++ b/tests/unit/call.ts
@@ -1302,7 +1302,7 @@ describe('Call', function() {
           clock.tick(1);
           digits.split('').forEach((digit) => {
             if (digit === 'w') {
-              clock.tick(200);
+              clock.tick(500);
               return;
             }
             let dtmf = `dtmf${digit}`;
@@ -1314,6 +1314,29 @@ describe('Call', function() {
           });
         });
       })
+    });
+
+    it('should pause local playback for the full pause duration on "w"', () => {
+      const dialtonePlayer: any = { play: sinon.stub() };
+      options.dialtonePlayer = dialtonePlayer;
+      conn = new Call(config, options);
+
+      const sender = { insertDTMF: sinon.spy() };
+      mediaHandler.getOrCreateDTMFSender = () => sender;
+      conn.sendDigits('1w2');
+
+      clock.tick(1);
+      sinon.assert.calledWithExactly(dialtonePlayer.play, 'dtmf1');
+      sinon.assert.neverCalledWith(dialtonePlayer.play, 'dtmf2');
+
+      // '2' plays after the 200ms tone gap plus the 500ms pause (t=700). Just
+      // before that, it must not have played -- proving the pause is 500ms and
+      // not the 200ms tone gap.
+      clock.tick(698);
+      sinon.assert.neverCalledWith(dialtonePlayer.play, 'dtmf2');
+
+      clock.tick(1);
+      sinon.assert.calledWithExactly(dialtonePlayer.play, 'dtmf2');
     });
 
     it('should call pstream.dtmf if connected', () => {


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

https://twilio-engineering.atlassian.net/browse/VBLOCKS-6983

https://github.com/twilio/twilio-voice.js/issues/272

### Description

- Root cause: In call.sendDigits(), local tone playback (what the caller hears) advanced every 200ms for all characters, including pause w — but the DTMF sent over the wire pauses 500ms per w, so the caller heard shorter pauses than the recipient, and the gap grew with each w.
- Fix (lib/twilio/call.ts): local playback now waits DTMF_PAUSE_DURATION (500ms) on a pause and keeps 200ms for tone digits, so both ends stay in sync.
- Tests (tests/unit/call.ts): updated existing playback test to 500ms on w; added a regression test proving a pause holds the next tone for the full 500ms.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [x] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review
