### PR TITLE
feat: implement OIDC token minting for e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Start Xvfb and dbus
         shell: bash
         run: |
-          set -u
+          set -euo pipefail
           sudo dbus-daemon --system --fork
           Xvfb $DISPLAY -screen 0 1280x1024x24 &
           xvfb_pid=$!

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,72 @@
+name: E2E
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+jobs:
+  e2e:
+    name: e2e (${{ matrix.browser }}, ${{ matrix.bver }})
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest-large
+    container:
+      image: twilio/twilio-video-browsers:${{ matrix.browser }}-${{ matrix.bver }}
+    env:
+      DISPLAY: ':99'
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chrome, firefox]
+        bver: [stable, beta, unstable]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Artifactory OIDC Auth
+        uses: ./.github/actions/artifactory-oidc
+        with:
+          artifactory_url: ${{ vars.ARTIFACTORY_URL }}
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Install Cypress binary
+        run: ./node_modules/.bin/cypress install
+
+      # Container jobs skip the image's own ENTRYPOINT that normally starts these.
+      - name: Start Xvfb and dbus
+        shell: bash
+        run: |
+          sudo dbus-daemon --system --fork
+          Xvfb $DISPLAY -screen 0 1280x1024x24 &
+          sleep 1
+
+      - name: Run e2e integration tests (chrome)
+        if: matrix.browser == 'chrome'
+        env:
+          VENDOR_URL: ${{ vars.VENDOR_URL }}
+          VENDOR_AUDIENCE: ${{ vars.VENDOR_URL }}
+        run: npm run test:integration:chrome
+
+      - name: Run e2e integration tests (firefox)
+        if: matrix.browser == 'firefox'
+        env:
+          VENDOR_URL: ${{ vars.VENDOR_URL }}
+          VENDOR_AUDIENCE: ${{ vars.VENDOR_URL }}
+        run: npm run test:integration:firefox

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -68,9 +68,10 @@ jobs:
           VENDOR_AUDIENCE: ${{ vars.VENDOR_URL }}
         run: npm run test:integration:chrome
 
+      # Cypress can't auto-detect Firefox's beta/nightly builds by name.
       - name: Run e2e integration tests (firefox)
         if: matrix.browser == 'firefox'
         env:
           VENDOR_URL: ${{ vars.VENDOR_URL }}
           VENDOR_AUDIENCE: ${{ vars.VENDOR_URL }}
-        run: npm run test:integration:firefox
+        run: npm run test:integration -- --browser /usr/local/bin/firefox

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,6 +49,10 @@ jobs:
       - name: Install Cypress binary
         run: ./node_modules/.bin/cypress install
 
+      # lib/twilio/constants.ts is gitignored and generated at build time.
+      - name: Build constants
+        run: npm run build:constants
+
       # Container jobs skip the image's own ENTRYPOINT that normally starts these.
       - name: Start Xvfb and dbus
         shell: bash

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,9 +57,17 @@ jobs:
       - name: Start Xvfb and dbus
         shell: bash
         run: |
+          set -u
           sudo dbus-daemon --system --fork
           Xvfb $DISPLAY -screen 0 1280x1024x24 &
-          sleep 1
+          xvfb_pid=$!
+          socket="/tmp/.X11-unix/X${DISPLAY#:}"
+          for _ in $(seq 1 50); do
+            [ -e "$socket" ] && break
+            kill -0 "$xvfb_pid" 2>/dev/null || { echo "Xvfb exited during startup"; exit 1; }
+            sleep 0.2
+          done
+          [ -e "$socket" ] || { echo "Xvfb did not create display $DISPLAY within 10s"; exit 1; }
 
       - name: Run e2e integration tests (chrome)
         if: matrix.browser == 'chrome'

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,14 +1,33 @@
 const { defineConfig } = require('cypress');
 
+/**
+ * Fetch a fresh GitHub Actions OIDC token for calling the e2e credential-vending
+ * Function, or fall back to VENDOR_TOKEN for local development.
+ * @returns {Promise<string>}
+ */
+async function mintVendorToken() {
+  const requestToken = process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
+  const requestUrl = process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
+  if (!requestToken || !requestUrl) {
+    return process.env.VENDOR_TOKEN;
+  }
+  const audience = encodeURIComponent(process.env.VENDOR_AUDIENCE);
+  const response = await fetch(`${requestUrl}&audience=${audience}`, {
+    headers: { Authorization: `bearer ${requestToken}` }
+  });
+  if (!response.ok) {
+    throw new Error(`OIDC token request failed: ${response.status}`);
+  }
+  const body = await response.json();
+  return body.value;
+}
+
 module.exports = defineConfig({
   env: {
-    ACCOUNT_SID: process.env.ACCOUNT_SID,
     AUTH_TOKEN: process.env.AUTH_TOKEN,
-    API_KEY_SECRET: process.env.API_KEY_SECRET,
-    API_KEY_SID: process.env.API_KEY_SID,
-    APPLICATION_SID: process.env.APPLICATION_SID,
-    APPLICATION_SID_STIR: process.env.APPLICATION_SID_STIR,
-    CALLER_ID: process.env.CALLER_ID,
+    VENDOR_URL: process.env.VENDOR_URL,
+    VENDOR_TOKEN: process.env.VENDOR_TOKEN,
+    VENDOR_AUDIENCE: process.env.VENDOR_AUDIENCE,
   },
   e2e: {
     defaultCommandTimeout: 10000,
@@ -25,6 +44,7 @@ module.exports = defineConfig({
           console.log(message);
           return null;
         },
+        mintVendorToken,
       });
     },
     specPattern: 'cypress/e2e/**/*.cy.ts',

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,38 +1,14 @@
 const { defineConfig } = require('cypress');
-
-/**
- * Fetch a fresh GitHub Actions OIDC token for calling the e2e credential-vending
- * Function, or fall back to VENDOR_TOKEN for local development.
- * @returns {Promise<string>}
- */
-async function mintVendorToken() {
-  const requestToken = process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
-  const requestUrl = process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
-  if (!requestToken || !requestUrl) {
-    return process.env.VENDOR_TOKEN;
-  }
-  const audience = encodeURIComponent(process.env.VENDOR_AUDIENCE);
-  const response = await fetch(`${requestUrl}&audience=${audience}`, {
-    headers: { Authorization: `bearer ${requestToken}` }
-  });
-  if (!response.ok) {
-    throw new Error(`OIDC token request failed: ${response.status}`);
-  }
-  const body = await response.json();
-  return body.value;
-}
+const VendorProxy = require('./tests/lib/vendorProxy');
 
 module.exports = defineConfig({
   env: {
     AUTH_TOKEN: process.env.AUTH_TOKEN,
-    VENDOR_URL: process.env.VENDOR_URL,
-    VENDOR_TOKEN: process.env.VENDOR_TOKEN,
-    VENDOR_AUDIENCE: process.env.VENDOR_AUDIENCE,
   },
   e2e: {
     defaultCommandTimeout: 10000,
     supportFile: false,
-    setupNodeEvents(on, config) {
+    async setupNodeEvents(on, config) {
       on('before:browser:launch', (browser, launchOptions) => {
         if (browser.family === 'firefox') {
           launchOptions.preferences['media.navigator.streams.fake'] = true;
@@ -44,8 +20,13 @@ module.exports = defineConfig({
           console.log(message);
           return null;
         },
-        mintVendorToken,
       });
+
+      const vendorProxy = new VendorProxy();
+      config.env.VENDOR_PROXY_URL = await vendorProxy.start();
+      on('after:run', () => vendorProxy.stop());
+
+      return config;
     },
     specPattern: 'cypress/e2e/**/*.cy.ts',
   },

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -24,6 +24,7 @@ module.exports = defineConfig({
 
       const vendorProxy = new VendorProxy();
       config.env.VENDOR_PROXY_URL = await vendorProxy.start();
+      config.env.VENDOR_PROXY_SECRET = vendorProxy.secret;
       on('after:run', () => vendorProxy.stop());
 
       return config;

--- a/cypress/e2e/audioHelper.cy.ts
+++ b/cypress/e2e/audioHelper.cy.ts
@@ -10,7 +10,7 @@ describe('AudioHelper', function() {
 
   beforeEach(async () => {
     const identity = 'id-' + Date.now();
-    const token = generateAccessToken(identity);
+    const token = await generateAccessToken(identity);
     device = new Device(token);
     await device.register();
   });

--- a/cypress/e2e/callEvents.cy.ts
+++ b/cypress/e2e/callEvents.cy.ts
@@ -19,8 +19,8 @@ describe('Call Events', function() {
     before(async () => {
       const identity1 = 'id1-' + Date.now();
       const identity2 = 'id2-' + Date.now();
-      const token1 = generateAccessToken(identity1);
-      const token2 = generateAccessToken(identity2);
+      const token1 = await generateAccessToken(identity1);
+      const token2 = await generateAccessToken(identity2);
       device1 = new Device(token1);
       device2 = new Device(token2);
 
@@ -76,8 +76,8 @@ describe('Call Events', function() {
     before(async () => {
       const identity1 = 'id1-' + Date.now();
       const identity2 = 'id2-' + Date.now();
-      const token1 = generateAccessToken(identity1);
-      const token2 = generateAccessToken(identity2);
+      const token1 = await generateAccessToken(identity1);
+      const token2 = await generateAccessToken(identity2);
       device1 = new Device(token1);
       device2 = new Device(token2);
 
@@ -132,8 +132,8 @@ describe('Call Events', function() {
     before(async () => {
       const identity1 = 'id1-' + Date.now();
       const identity2 = 'id2-' + Date.now();
-      const token1 = generateAccessToken(identity1);
-      const token2 = generateAccessToken(identity2);
+      const token1 = await generateAccessToken(identity1);
+      const token2 = await generateAccessToken(identity2);
       device1 = new Device(token1);
       device2 = new Device(token2);
 

--- a/cypress/e2e/callIgnore.cy.ts
+++ b/cypress/e2e/callIgnore.cy.ts
@@ -16,8 +16,8 @@ describe('Call ignore', function() {
   beforeEach(async () => {
     identity1 = 'id1-' + Date.now();
     identity2 = 'id2-' + Date.now();
-    const token1 = generateAccessToken(identity1);
-    const token2 = generateAccessToken(identity2);
+    const token1 = await generateAccessToken(identity1);
+    const token2 = await generateAccessToken(identity2);
     device1 = new Device(token1);
     device2 = new Device(token2);
 

--- a/cypress/e2e/callMessage/userDefinedMessage.cy.ts
+++ b/cypress/e2e/callMessage/userDefinedMessage.cy.ts
@@ -29,11 +29,11 @@ describe('userDefinedMessage', function() {
     const tokenTtl = 60 * 3; // 3 minute TTL
 
     const aliceId = `client-id-call-message-tests-alice-${Date.now()}`;
-    const aliceToken = generateAccessToken(aliceId, tokenTtl);
+    const aliceToken = await generateAccessToken(aliceId, tokenTtl);
     const aliceDevice = new Device(aliceToken);
 
     const bobId = `client-id-call-message-tests-bob-${Date.now()}`;
-    const bobToken = generateAccessToken(bobId, tokenTtl);
+    const bobToken = await generateAccessToken(bobId, tokenTtl);
     const bobDevice = new Device(bobToken);
 
     await bobDevice.register();

--- a/cypress/e2e/callMute.cy.ts
+++ b/cypress/e2e/callMute.cy.ts
@@ -18,8 +18,8 @@ describe('Call Mute', function() {
   before(async () => {
     identity1 = 'id1-' + Date.now();
     identity2 = 'id2-' + Date.now();
-    const token1 = generateAccessToken(identity1);
-    const token2 = generateAccessToken(identity2);
+    const token1 = await generateAccessToken(identity1);
+    const token2 = await generateAccessToken(identity2);
     device1 = new Device(token1);
     device2 = new Device(token2);
 

--- a/cypress/e2e/callPostFeedback.cy.ts
+++ b/cypress/e2e/callPostFeedback.cy.ts
@@ -18,8 +18,8 @@ describe('Call postFeedback', function() {
   before(async () => {
     identity1 = 'id1-' + Date.now();
     identity2 = 'id2-' + Date.now();
-    const token1 = generateAccessToken(identity1);
-    const token2 = generateAccessToken(identity2);
+    const token1 = await generateAccessToken(identity1);
+    const token2 = await generateAccessToken(identity2);
     device1 = new Device(token1);
     device2 = new Device(token2);
 

--- a/cypress/e2e/callSendDigits.cy.ts
+++ b/cypress/e2e/callSendDigits.cy.ts
@@ -18,8 +18,8 @@ describe('Call sendDigits', function() {
   before(async () => {
     identity1 = 'id1-' + Date.now();
     identity2 = 'id2-' + Date.now();
-    const token1 = generateAccessToken(identity1);
-    const token2 = generateAccessToken(identity2);
+    const token1 = await generateAccessToken(identity1);
+    const token2 = await generateAccessToken(identity2);
     device1 = new Device(token1);
     device2 = new Device(token2);
 

--- a/cypress/e2e/callStatus.cy.ts
+++ b/cypress/e2e/callStatus.cy.ts
@@ -16,8 +16,8 @@ describe('Call Status', function() {
   beforeEach(async () => {
     identity1 = 'id1-' + Date.now();
     identity2 = 'id2-' + Date.now();
-    const token1 = generateAccessToken(identity1);
-    const token2 = generateAccessToken(identity2);
+    const token1 = await generateAccessToken(identity1);
+    const token2 = await generateAccessToken(identity2);
     device1 = new Device(token1);
     device2 = new Device(token2);
 

--- a/cypress/e2e/callStreams.cy.ts
+++ b/cypress/e2e/callStreams.cy.ts
@@ -18,8 +18,8 @@ describe('Call Streams', function() {
   before(async () => {
     identity1 = 'id1-' + Date.now();
     identity2 = 'id2-' + Date.now();
-    const token1 = generateAccessToken(identity1);
-    const token2 = generateAccessToken(identity2);
+    const token1 = await generateAccessToken(identity1);
+    const token2 = await generateAccessToken(identity2);
     device1 = new Device(token1);
     device2 = new Device(token2);
 

--- a/cypress/e2e/connectToken.cy.ts
+++ b/cypress/e2e/connectToken.cy.ts
@@ -26,13 +26,13 @@ describe('connectToken', function() {
   let reconnectDeviceB: Device;
   let identity: string;
 
-  const setupDevices = () => {
+  const setupDevices = async () => {
     identity = 'id2-' + Date.now();
-    const callerTokenA = generateAccessToken();
-    const callerTokenB = generateAccessToken();
-    const receiverDeviceToken = generateAccessToken(identity);
-    const reconnectDeviceTokenA = generateAccessToken(identity);
-    const reconnectDeviceTokenB = generateAccessToken(identity);
+    const callerTokenA = await generateAccessToken();
+    const callerTokenB = await generateAccessToken();
+    const receiverDeviceToken = await generateAccessToken(identity);
+    const reconnectDeviceTokenA = await generateAccessToken(identity);
+    const reconnectDeviceTokenB = await generateAccessToken(identity);
 
     callerDeviceA = new Device(callerTokenA);
     callerDeviceB = new Device(callerTokenB);

--- a/cypress/e2e/device.cy.ts
+++ b/cypress/e2e/device.cy.ts
@@ -13,11 +13,11 @@ describe('Device', function() {
   let token1: string;
   let token2: string;
 
-  before(() => {
+  before(async () => {
     identity1 = 'id1-' + Date.now();
     identity2 = 'id2-' + Date.now();
-    token1 = generateAccessToken(identity1);
-    token2 = generateAccessToken(identity2);
+    token1 = await generateAccessToken(identity1);
+    token2 = await generateAccessToken(identity2);
     device1 = new Device(token1);
     device2 = new Device(token2);
 
@@ -40,23 +40,25 @@ describe('Device', function() {
   });
 
   describe('tokenWillExpire event', () => {
-    const setupDevice = (tokenTtl: number, tokenRefreshMs: number) => {
-      const accessToken = generateAccessToken(`device-tokenWillExpire-${Date.now()}`, tokenTtl);
+    const setupDevice = async (tokenTtl: number, tokenRefreshMs: number) => {
+      const accessToken = await generateAccessToken(`device-tokenWillExpire-${Date.now()}`, tokenTtl);
       const device = new Device(accessToken, { tokenRefreshMs });
       device.on(Device.EventName.Error, () => { /* no-op */ });
       return device;
     };
 
-    it('should emit a "tokenWillExpire" event', (done) => {
-      const device = setupDevice(5, 1000);
-      device.on(Device.EventName.TokenWillExpire, () => {
-        done();
+    it('should emit a "tokenWillExpire" event', async () => {
+      const device = await setupDevice(5, 1000);
+      await new Promise<void>((resolve) => {
+        device.on(Device.EventName.TokenWillExpire, () => {
+          resolve();
+        });
+        device.register();
       });
-      device.register();
     });
 
     it('should not emit a "tokenWillExpire" event early', async () => {
-      const device = setupDevice(10, 1000);
+      const device = await setupDevice(10, 1000);
       await new Promise<void>(async (resolve, reject) => {
         let successTimeout: any = null;
         device.on(Device.EventName.TokenWillExpire, () => {
@@ -76,7 +78,7 @@ describe('Device', function() {
     });
 
     it('should emit a "tokenWillExpire" event as soon as possible if the option is smaller than the ttl', async () => {
-      const device = setupDevice(5, 10000);
+      const device = await setupDevice(5, 10000);
 
       const eventPromises = Promise.all([
         Device.EventName.TokenWillExpire,

--- a/cypress/e2e/deviceLifecycle.cy.ts
+++ b/cypress/e2e/deviceLifecycle.cy.ts
@@ -18,7 +18,7 @@ describe('Device Lifecycle', function() {
 
     it('should transition through registering to registered state', async () => {
       const identity = 'id-' + Date.now();
-      const token = generateAccessToken(identity);
+      const token = await generateAccessToken(identity);
       device = new Device(token);
 
       assert.strictEqual(device.state, Device.State.Unregistered);
@@ -37,7 +37,7 @@ describe('Device Lifecycle', function() {
 
     it('should unregister and emit unregistered event', async () => {
       const identity = 'id-' + Date.now();
-      const token = generateAccessToken(identity);
+      const token = await generateAccessToken(identity);
       device = new Device(token);
 
       await device.register();
@@ -51,7 +51,7 @@ describe('Device Lifecycle', function() {
 
     it('should throw when unregistering a device that is not registered', async () => {
       const identity = 'id-' + Date.now();
-      const token = generateAccessToken(identity);
+      const token = await generateAccessToken(identity);
       device = new Device(token);
 
       try {
@@ -64,7 +64,7 @@ describe('Device Lifecycle', function() {
 
     it('should allow re-registering after unregister', async () => {
       const identity = 'id-' + Date.now();
-      const token = generateAccessToken(identity);
+      const token = await generateAccessToken(identity);
       device = new Device(token);
 
       await device.register();
@@ -79,7 +79,7 @@ describe('Device Lifecycle', function() {
   describe('destroy', () => {
     it('should emit destroyed event and set state to destroyed', async () => {
       const identity = 'id-' + Date.now();
-      const token = generateAccessToken(identity);
+      const token = await generateAccessToken(identity);
       const device = new Device(token);
 
       await device.register();
@@ -92,7 +92,7 @@ describe('Device Lifecycle', function() {
 
     it('should throw when calling register on a destroyed device', async () => {
       const identity = 'id-' + Date.now();
-      const token = generateAccessToken(identity);
+      const token = await generateAccessToken(identity);
       const device = new Device(token);
 
       device.destroy();
@@ -105,9 +105,9 @@ describe('Device Lifecycle', function() {
       }
     });
 
-    it('should throw when calling updateOptions on a destroyed device', () => {
+    it('should throw when calling updateOptions on a destroyed device', async () => {
       const identity = 'id-' + Date.now();
-      const token = generateAccessToken(identity);
+      const token = await generateAccessToken(identity);
       const device = new Device(token);
 
       device.destroy();
@@ -117,14 +117,14 @@ describe('Device Lifecycle', function() {
       });
     });
 
-    it('should throw when calling updateToken on a destroyed device', () => {
+    it('should throw when calling updateToken on a destroyed device', async () => {
       const identity = 'id-' + Date.now();
-      const token = generateAccessToken(identity);
+      const token = await generateAccessToken(identity);
       const device = new Device(token);
 
       device.destroy();
 
-      const newToken = generateAccessToken(identity);
+      const newToken = await generateAccessToken(identity);
       assert.throws(() => device.updateToken(newToken), (err: any) => {
         return err.message.includes('destroyed');
       });
@@ -140,32 +140,32 @@ describe('Device Lifecycle', function() {
       }
     });
 
-    it('should update the token on the device', () => {
+    it('should update the token on the device', async () => {
       const identity = 'id-' + Date.now();
-      const token1 = generateAccessToken(identity);
+      const token1 = await generateAccessToken(identity);
       device = new Device(token1);
 
-      const token2 = generateAccessToken(identity);
+      const token2 = await generateAccessToken(identity);
       device.updateToken(token2);
       assert.strictEqual(device.token, token2);
     });
 
     it('should update the token while registered', async () => {
       const identity = 'id-' + Date.now();
-      const token1 = generateAccessToken(identity);
+      const token1 = await generateAccessToken(identity);
       device = new Device(token1);
 
       await device.register();
 
-      const token2 = generateAccessToken(identity);
+      const token2 = await generateAccessToken(identity);
       device.updateToken(token2);
       assert.strictEqual(device.token, token2);
       assert.strictEqual(device.state, Device.State.Registered);
     });
 
-    it('should throw when passing a non-string token', () => {
+    it('should throw when passing a non-string token', async () => {
       const identity = 'id-' + Date.now();
-      const token = generateAccessToken(identity);
+      const token = await generateAccessToken(identity);
       device = new Device(token);
 
       assert.throws(() => device.updateToken(123 as any), (err: any) => {

--- a/cypress/e2e/deviceOptions.cy.ts
+++ b/cypress/e2e/deviceOptions.cy.ts
@@ -10,11 +10,11 @@ describe('DeviceOptions', function() {
   let identity1: string;
   let identity2: string;
 
-  const setupDevices = (device1Options = {}, device2Options = {}) => {
+  const setupDevices = async (device1Options = {}, device2Options = {}) => {
     identity1 = 'id1-' + Date.now();
     identity2 = 'id2-' + Date.now();
-    const token1 = generateAccessToken(identity1);
-    const token2 = generateAccessToken(identity2);
+    const token1 = await generateAccessToken(identity1);
+    const token2 = await generateAccessToken(identity2);
 
     device1 = new Device(token1, device1Options);
     device2 = new Device(token2, device2Options);

--- a/cypress/e2e/deviceOptionsExtended.cy.ts
+++ b/cypress/e2e/deviceOptionsExtended.cy.ts
@@ -27,11 +27,11 @@ describe('Device Options Extended', function() {
       const callerId1 = 'id-caller1-' + Date.now();
       const callerId2 = 'id-caller2-' + Date.now();
 
-      receiverDevice = new Device(generateAccessToken(receiverId), {
+      receiverDevice = new Device(await generateAccessToken(receiverId), {
         allowIncomingWhileBusy: false,
       });
-      callerDevice = new Device(generateAccessToken(callerId1));
-      callerDevice2 = new Device(generateAccessToken(callerId2));
+      callerDevice = new Device(await generateAccessToken(callerId1));
+      callerDevice2 = new Device(await generateAccessToken(callerId2));
 
       await Promise.all([
         receiverDevice.register(),
@@ -67,11 +67,11 @@ describe('Device Options Extended', function() {
       const callerId1 = 'id-caller1-' + Date.now();
       const callerId2 = 'id-caller2-' + Date.now();
 
-      receiverDevice = new Device(generateAccessToken(receiverId), {
+      receiverDevice = new Device(await generateAccessToken(receiverId), {
         allowIncomingWhileBusy: true,
       });
-      callerDevice = new Device(generateAccessToken(callerId1));
-      callerDevice2 = new Device(generateAccessToken(callerId2));
+      callerDevice = new Device(await generateAccessToken(callerId1));
+      callerDevice2 = new Device(await generateAccessToken(callerId2));
 
       await Promise.all([
         receiverDevice.register(),
@@ -100,9 +100,9 @@ describe('Device Options Extended', function() {
   });
 
   describe('closeProtection', () => {
-    it('should accept closeProtection as a boolean option', () => {
+    it('should accept closeProtection as a boolean option', async () => {
       const identity = 'id-' + Date.now();
-      const token = generateAccessToken(identity);
+      const token = await generateAccessToken(identity);
 
       assert.doesNotThrow(() => {
         const device = new Device(token, { closeProtection: true });
@@ -110,9 +110,9 @@ describe('Device Options Extended', function() {
       });
     });
 
-    it('should accept closeProtection as a string option', () => {
+    it('should accept closeProtection as a string option', async () => {
       const identity = 'id-' + Date.now();
-      const token = generateAccessToken(identity);
+      const token = await generateAccessToken(identity);
 
       assert.doesNotThrow(() => {
         const device = new Device(token, { closeProtection: 'Are you sure you want to leave?' });
@@ -122,9 +122,9 @@ describe('Device Options Extended', function() {
   });
 
   describe('maxCallSignalingTimeoutMs', () => {
-    it('should accept maxCallSignalingTimeoutMs option', () => {
+    it('should accept maxCallSignalingTimeoutMs option', async () => {
       const identity = 'id-' + Date.now();
-      const token = generateAccessToken(identity);
+      const token = await generateAccessToken(identity);
 
       assert.doesNotThrow(() => {
         const device = new Device(token, { maxCallSignalingTimeoutMs: 15000 });
@@ -132,9 +132,9 @@ describe('Device Options Extended', function() {
       });
     });
 
-    it('should accept maxCallSignalingTimeoutMs as 0 (no timeout)', () => {
+    it('should accept maxCallSignalingTimeoutMs as 0 (no timeout)', async () => {
       const identity = 'id-' + Date.now();
-      const token = generateAccessToken(identity);
+      const token = await generateAccessToken(identity);
 
       assert.doesNotThrow(() => {
         const device = new Device(token, { maxCallSignalingTimeoutMs: 0 });
@@ -162,8 +162,8 @@ describe('Device Options Extended', function() {
       const identity1 = 'id1-' + Date.now();
       const identity2 = 'id2-' + Date.now();
 
-      dscpDevice1 = new Device(generateAccessToken(identity1), { dscp: true });
-      dscpDevice2 = new Device(generateAccessToken(identity2), { dscp: true });
+      dscpDevice1 = new Device(await generateAccessToken(identity1), { dscp: true });
+      dscpDevice2 = new Device(await generateAccessToken(identity2), { dscp: true });
 
       await Promise.all([dscpDevice1.register(), dscpDevice2.register()]);
 
@@ -183,8 +183,8 @@ describe('Device Options Extended', function() {
       const identity1 = 'id1-' + Date.now();
       const identity2 = 'id2-' + Date.now();
 
-      dscpDevice1 = new Device(generateAccessToken(identity1), { dscp: false });
-      dscpDevice2 = new Device(generateAccessToken(identity2), { dscp: false });
+      dscpDevice1 = new Device(await generateAccessToken(identity1), { dscp: false });
+      dscpDevice2 = new Device(await generateAccessToken(identity2), { dscp: false });
 
       await Promise.all([dscpDevice1.register(), dscpDevice2.register()]);
 
@@ -201,9 +201,9 @@ describe('Device Options Extended', function() {
   });
 
   describe('enableImprovedSignalingErrorPrecision', () => {
-    it('should accept enableImprovedSignalingErrorPrecision option', () => {
+    it('should accept enableImprovedSignalingErrorPrecision option', async () => {
       const identity = 'id-' + Date.now();
-      const token = generateAccessToken(identity);
+      const token = await generateAccessToken(identity);
 
       assert.doesNotThrow(() => {
         const device = new Device(token, { enableImprovedSignalingErrorPrecision: true });
@@ -213,9 +213,9 @@ describe('Device Options Extended', function() {
   });
 
   describe('sounds', () => {
-    it('should accept custom sound URLs without throwing', () => {
+    it('should accept custom sound URLs without throwing', async () => {
       const identity = 'id-' + Date.now();
-      const token = generateAccessToken(identity);
+      const token = await generateAccessToken(identity);
 
       assert.doesNotThrow(() => {
         const device = new Device(token, {

--- a/cypress/e2e/deviceProperties.cy.ts
+++ b/cypress/e2e/deviceProperties.cy.ts
@@ -35,9 +35,9 @@ describe('Device Properties', function() {
       }
     });
 
-    it('should have identity set to null before registration', () => {
+    it('should have identity set to null before registration', async () => {
       const identity = 'id-' + Date.now();
-      const token = generateAccessToken(identity);
+      const token = await generateAccessToken(identity);
       device = new Device(token);
 
       assert.strictEqual(device.identity, null);
@@ -45,7 +45,7 @@ describe('Device Properties', function() {
 
     it('should have identity populated after registration', async () => {
       const identity = 'id-' + Date.now();
-      const token = generateAccessToken(identity);
+      const token = await generateAccessToken(identity);
       device = new Device(token);
 
       await device.register();
@@ -54,7 +54,7 @@ describe('Device Properties', function() {
 
     it('should have edge set after registration', async () => {
       const identity = 'id-' + Date.now();
-      const token = generateAccessToken(identity);
+      const token = await generateAccessToken(identity);
       device = new Device(token, { edge: 'ashburn' });
 
       await device.register();
@@ -63,7 +63,7 @@ describe('Device Properties', function() {
 
     it('should have home set after registration', async () => {
       const identity = 'id-' + Date.now();
-      const token = generateAccessToken(identity);
+      const token = await generateAccessToken(identity);
       device = new Device(token);
 
       await device.register();
@@ -71,9 +71,9 @@ describe('Device Properties', function() {
       assert(device.home!.length > 0, 'home should not be empty');
     });
 
-    it('should have token set', () => {
+    it('should have token set', async () => {
       const identity = 'id-' + Date.now();
-      const token = generateAccessToken(identity);
+      const token = await generateAccessToken(identity);
       device = new Device(token);
 
       assert.strictEqual(device.token, token);
@@ -81,7 +81,7 @@ describe('Device Properties', function() {
 
     it('should have isBusy as false when not on a call', async () => {
       const identity = 'id-' + Date.now();
-      const token = generateAccessToken(identity);
+      const token = await generateAccessToken(identity);
       device = new Device(token);
 
       await device.register();
@@ -90,7 +90,7 @@ describe('Device Properties', function() {
 
     it('should have audio (AudioHelper) available after registration', async () => {
       const identity = 'id-' + Date.now();
-      const token = generateAccessToken(identity);
+      const token = await generateAccessToken(identity);
       device = new Device(token);
 
       await device.register();
@@ -99,7 +99,7 @@ describe('Device Properties', function() {
 
     it('should have calls as an empty array by default', async () => {
       const identity = 'id-' + Date.now();
-      const token = generateAccessToken(identity);
+      const token = await generateAccessToken(identity);
       device = new Device(token);
 
       await device.register();
@@ -126,8 +126,8 @@ describe('Device Properties', function() {
     it('should be true when on an active call and false after disconnect', async () => {
       const identity1 = 'id1-' + Date.now();
       const identity2 = 'id2-' + Date.now();
-      const token1 = generateAccessToken(identity1);
-      const token2 = generateAccessToken(identity2);
+      const token1 = await generateAccessToken(identity1);
+      const token2 = await generateAccessToken(identity2);
       device1 = new Device(token1);
       device2 = new Device(token2);
 

--- a/cypress/e2e/edges.cy.ts
+++ b/cypress/e2e/edges.cy.ts
@@ -13,11 +13,11 @@ describe('Edges', function() {
       let token1: string;
       let token2: string;
 
-      before(() => {
+      before(async () => {
         identity1 = 'id1-' + Date.now();
         identity2 = 'id2-' + Date.now();
-        token1 = generateAccessToken(identity1);
-        token2 = generateAccessToken(identity2);
+        token1 = await generateAccessToken(identity1);
+        token2 = await generateAccessToken(identity2);
         device1 = new Device(token1, { edge });
         device2 = new Device(token2, { edge });
 

--- a/cypress/e2e/icenomination.cy.ts
+++ b/cypress/e2e/icenomination.cy.ts
@@ -27,11 +27,11 @@ maybeSkip('ICE Nomination', function() {
   let lowDelayDuration: number;
   let highDelayDuration: number;
 
-  const setupDevices = () => {
+  const setupDevices = async () => {
     identity1 = 'id1-' + Date.now();
     identity2 = 'id2-' + Date.now();
-    const token1 = generateAccessToken(identity1);
-    const token2 = generateAccessToken(identity2);
+    const token1 = await generateAccessToken(identity1);
+    const token2 = await generateAccessToken(identity2);
 
     device1 = new Device(token1, device1Options);
     device2 = new Device(token2, device2Options);

--- a/cypress/e2e/loggerOptions.cy.ts
+++ b/cypress/e2e/loggerOptions.cy.ts
@@ -15,9 +15,9 @@ describe('Logger', function() {
     assert(typeof Logger.setLevel === 'function', 'setLevel should be a function');
   });
 
-  it('should be configurable via Device options logLevel', () => {
+  it('should be configurable via Device options logLevel', async () => {
     const identity = 'id-' + Date.now();
-    const token = generateAccessToken(identity);
+    const token = await generateAccessToken(identity);
 
     // Should not throw when setting various log levels
     assert.doesNotThrow(() => {
@@ -41,9 +41,9 @@ describe('Logger', function() {
     });
   });
 
-  it('should accept numeric log levels via Device options', () => {
+  it('should accept numeric log levels via Device options', async () => {
     const identity = 'id-' + Date.now();
-    const token = generateAccessToken(identity);
+    const token = await generateAccessToken(identity);
 
     // loglevel uses numeric levels: 0=TRACE, 1=DEBUG, 2=INFO, 3=WARN, 4=ERROR, 5=SILENT
     assert.doesNotThrow(() => {

--- a/cypress/e2e/mutableOptions.cy.ts
+++ b/cypress/e2e/mutableOptions.cy.ts
@@ -12,9 +12,9 @@ describe('mutable options', function() {
   let device: Device | null = null;
   let token: string;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     const id = `device-id-${Date.now()}`;
-    token = generateAccessToken(id);
+    token = await generateAccessToken(id);
   });
 
   afterEach(() => {
@@ -94,7 +94,7 @@ describe('mutable options', function() {
         [receiver, receiverId, receiverToken],
       ] = await Promise.all(['caller', 'receiver'].map(async (n): Promise<[Device, string, string]> => {
         const id = `device-${n}-${timestamp}`;
-        const t = generateAccessToken(id);
+        const t = await generateAccessToken(id);
         const dev = new Device(t);
         await dev.register();
         return [dev, id, t];

--- a/cypress/e2e/opus.cy.ts
+++ b/cypress/e2e/opus.cy.ts
@@ -16,11 +16,11 @@ describe('Opus', function() {
   let token1: string;
   let token2: string;
 
-  before(() => {
+  before(async () => {
     identity1 = 'id1-' + Date.now();
     identity2 = 'id2-' + Date.now();
-    token1 = generateAccessToken(identity1);
-    token2 = generateAccessToken(identity2);
+    token1 = await generateAccessToken(identity1);
+    token2 = await generateAccessToken(identity2);
     options = {
       codecPreferences: [Call.Codec.Opus, Call.Codec.PCMU],
     };

--- a/cypress/e2e/preflight.cy.ts
+++ b/cypress/e2e/preflight.cy.ts
@@ -5,10 +5,15 @@ import { EventEmitter } from 'events';
 import { PreflightTest } from '../../lib/twilio/preflight/preflight';
 import Call from '../../lib/twilio/call';
 import { TwilioError } from '../../lib/twilio/errors';
+import { Edge, regionShortcodes, regionToEdge } from '../../lib/twilio/regions';
 
 const DURATION_PADDING = 3000;
 const EVENT_TIMEOUT = 30000;
 const MAX_TIMEOUT = 300000;
+
+// The public edges roaming can resolve to. regionShortcodes covers exactly the
+// regions geo-routing can place a client in, so Interconnect edges are excluded.
+const ROAMING_EDGES: Edge[] = Object.values(regionShortcodes).map(region => regionToEdge[region]);
 
 describe('Preflight Test', function() {
   this.timeout(MAX_TIMEOUT);
@@ -171,10 +176,13 @@ describe('Preflight Test', function() {
 
   describe('when using non-default edge options', () => {
     [
-      ['roaming', 'ashburn'],
-      ['ashburn', 'ashburn'],
-      ['dublin', 'dublin'],
-    ].forEach(([selectedEdge, edge]) => {
+      // Roaming does not map to a fixed edge. It is resolved at connect time to
+      // the public edge nearest the client, so any of ROAMING_EDGES is correct
+      // and which one it is depends on where the test runs.
+      { selectedEdge: 'roaming', expectedEdges: ROAMING_EDGES },
+      { selectedEdge: 'ashburn', expectedEdges: [Edge.Ashburn] },
+      { selectedEdge: 'dublin', expectedEdges: [Edge.Dublin] },
+    ].forEach(({ selectedEdge, expectedEdges }) => {
       describe(selectedEdge, () => {
         let report: PreflightTest.Report | undefined;
 
@@ -207,7 +215,10 @@ describe('Preflight Test', function() {
 
         it('should use edge passed in', () => {
           assert.equal(report?.selectedEdge, selectedEdge);
-          assert.equal(report?.edge, edge);
+          assert(
+            expectedEdges.includes(report?.edge as Edge),
+            `expected one of ${expectedEdges.join(', ')}, got ${report?.edge}`,
+          );
         });
       });
     });

--- a/cypress/e2e/preflight.cy.ts
+++ b/cypress/e2e/preflight.cy.ts
@@ -40,8 +40,8 @@ describe('Preflight Test', function() {
     receiverIdentity = 'id1-' + Date.now();
     callerIdentity = 'id2-' + Date.now();
 
-    const receiverToken = generateAccessToken(receiverIdentity);
-    callerToken = generateAccessToken(callerIdentity);
+    const receiverToken = await generateAccessToken(receiverIdentity);
+    callerToken = await generateAccessToken(callerIdentity);
     receiverDevice = new Device(receiverToken);
     receiverDevice.on('error', () => { });
     await receiverDevice.register();

--- a/cypress/e2e/stirshaken.cy.ts
+++ b/cypress/e2e/stirshaken.cy.ts
@@ -2,7 +2,6 @@ import * as assert from 'assert';
 import { EventEmitter } from 'events';
 import Call from '../../lib/twilio/call';
 import Device from '../../lib/twilio/device';
-import * as env from '../../tests/env';
 import { generateAccessToken } from '../../tests/lib/token';
 
 describe('SHAKEN/STIR', function() {
@@ -15,11 +14,11 @@ describe('SHAKEN/STIR', function() {
   let token1: string;
   let token2: string;
 
-  before(() => {
+  before(async () => {
     identity1 = 'id1-' + Date.now();
     identity2 = 'aliceStir';
-    token1 = generateAccessToken(identity1, undefined, (env as any).appSidStir);
-    token2 = generateAccessToken(identity2, undefined, (env as any).appSidStir);
+    token1 = await generateAccessToken(identity1, undefined, undefined, 'stir');
+    token2 = await generateAccessToken(identity2, undefined, undefined, 'stir');
     device1 = new Device(token1);
     device2 = new Device(token2);
 
@@ -47,11 +46,14 @@ describe('SHAKEN/STIR', function() {
       let call1: Call;
       let call2: Call;
 
-      before(() => new Promise<void>(async resolve => {
-        device2.once(Device.EventName.Incoming, (call: Call) => {
-          resolve();
-          call2 = call;
+      before(async () => {
+        const incomingPromise = new Promise<void>(resolve => {
+          device2.once(Device.EventName.Incoming, (call: Call) => {
+            call2 = call;
+            resolve();
+          });
         });
+
         const devShim = device2 as any;
         devShim._stream.transport.__onSocketMessage = devShim._stream.transport._onSocketMessage;
         devShim._stream.transport._onSocketMessage = (message: any) => {
@@ -67,10 +69,10 @@ describe('SHAKEN/STIR', function() {
           return devShim._stream.transport.__onSocketMessage(message);
         };
 
-        call1 = await (device1['connect'] as any)({
-          params: { CallerId: (env as any).callerId },
-        });
-      }));
+        call1 = await (device1['connect'] as any)();
+
+        await incomingPromise;
+      });
 
       describe('and device 2 accepts', () => {
         beforeEach(() => {

--- a/cypress/e2e/stirshaken.cy.ts
+++ b/cypress/e2e/stirshaken.cy.ts
@@ -86,6 +86,7 @@ describe('SHAKEN/STIR', function() {
         });
 
         it('should show isVerified on aliceStir call', () => {
+          assert.notEqual(call2!.callerInfo, null, 'callerInfo is null - STIR attestation did not fire');
           assert.equal(call2!.callerInfo!.isVerified, true);
         });
 

--- a/cypress/e2e/twilioErrorScenarios.cy.ts
+++ b/cypress/e2e/twilioErrorScenarios.cy.ts
@@ -78,7 +78,7 @@ describe('TwilioError Scenarios', function() {
   it('should emit an error event for an expired token', async () => {
     // Generate a token with 1 second TTL
     const identity = 'id-expired-' + Date.now();
-    const token = generateAccessToken(identity, 1);
+    const token = await generateAccessToken(identity, 1);
     const device = new Device(token);
 
     // Wait for the token to expire before trying to register

--- a/tests/env.js
+++ b/tests/env.js
@@ -4,10 +4,6 @@
 const processEnv = {
   ACCOUNT_SID: Cypress.env('ACCOUNT_SID'),
   APPLICATION_SID: Cypress.env('APPLICATION_SID'),
-  APPLICATION_SID_STIR: Cypress.env('APPLICATION_SID_STIR'),
-  CALLER_ID: Cypress.env('CALLER_ID'),
-  API_KEY_SID: Cypress.env('API_KEY_SID'),
-  API_KEY_SECRET: Cypress.env('API_KEY_SECRET'),
   AUTH_TOKEN: Cypress.env('AUTH_TOKEN'),
 };
 
@@ -15,10 +11,6 @@ const processEnv = {
 const env = [
   ['ACCOUNT_SID', 'accountSid'],
   ['APPLICATION_SID', 'appSid'],
-  ['APPLICATION_SID_STIR', 'appSidStir'],
-  ['CALLER_ID', 'callerId'],
-  ['API_KEY_SECRET', 'apiKeySecret'],
-  ['API_KEY_SID', 'apiKeySid'],
   ['AUTH_TOKEN', 'authToken'],
 ].reduce((env, [processEnvKey, envKey]) => {
   if (processEnvKey in processEnv) {
@@ -31,10 +23,6 @@ const env = [
 [
   'accountSid',
   'appSid',
-  'appSidStir',
-  'callerId',
-  'apiKeySid',
-  'apiKeySecret',
   'authToken',
 ].forEach(function forEachRequiredKey(key) {
   if (!(key in env)) {

--- a/tests/lib/token.js
+++ b/tests/lib/token.js
@@ -1,18 +1,15 @@
 const Twilio = require('twilio');
 const env = require('../env.js');
+const callVendor = require('./vendor');
 
-function generateAccessToken(identity, ttl, appSid) {
-  const accessToken = new Twilio.jwt.AccessToken(env.accountSid,
-    env.apiKeySid,
-    env.apiKeySecret,
-    { ttl: ttl || 300, identity });
-
-  accessToken.addGrant(new Twilio.jwt.AccessToken.VoiceGrant({
-    incomingAllow: true,
-    outgoingApplicationSid: appSid || env.appSid,
-  }));
-
-  return accessToken.toJwt();
+async function generateAccessToken(identity, ttl, appSid, variant) {
+  const { token } = await callVendor('mint-voice-token', {
+    identity,
+    ttl: ttl || 300,
+    outgoingApplicationSid: appSid,
+    variant,
+  });
+  return token;
 }
 
 function generateCapabilityToken() {

--- a/tests/lib/vendor.js
+++ b/tests/lib/vendor.js
@@ -1,0 +1,76 @@
+'use strict';
+
+// GitHub Actions OIDC tokens are valid for ~5 minutes; a 4-min ceiling leaves a
+// 1-min margin so a multi-minute spec file never signs with a stale token.
+const TOKEN_MAX_AGE_MS = 4 * 60 * 1000;
+
+// Cypress re-evaluates this module per spec file, so these always start unset.
+let cachedToken = null;
+let cachedTokenMintedAt = 0;
+let cachedTokenPromise = null;
+
+/**
+ * @returns {Promise<string>} a vendor OIDC token no older than TOKEN_MAX_AGE_MS
+ */
+function getVendorToken() {
+  if (cachedTokenPromise) {
+    return cachedTokenPromise;
+  }
+  if (cachedToken && Date.now() - cachedTokenMintedAt <= TOKEN_MAX_AGE_MS) {
+    return Promise.resolve(cachedToken);
+  }
+  // Cache the in-flight promise so concurrent callers (e.g. minting two tokens
+  // via Promise.all) share one mint instead of racing to mint their own.
+  cachedTokenPromise = cy.task('mintVendorToken').then(token => {
+    cachedToken = token;
+    cachedTokenMintedAt = Date.now();
+    cachedTokenPromise = null;
+    return token;
+  }, error => {
+    cachedTokenPromise = null;
+    throw error;
+  });
+  return cachedTokenPromise;
+}
+
+/**
+ * Call the e2e credential-vending Function.
+ * @param {string} action
+ * @param {object} params
+ * @returns {Promise<*>} the parsed JSON response body
+ */
+async function callVendor(action, params) {
+  const vendorUrl = Cypress.env('VENDOR_URL');
+
+  if (!vendorUrl) {
+    throw new Error('callVendor: VENDOR_URL is not set');
+  }
+
+  const vendorToken = await getVendorToken();
+
+  const body = JSON.stringify(Object.assign({ action }, params));
+
+  const response = await fetch(vendorUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${vendorToken}`
+    },
+    body
+  });
+
+  const text = await response.text();
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch (e) {
+    throw new Error(`callVendor: non-JSON response from vendor: ${text}`);
+  }
+
+  if (!response.ok) {
+    throw new Error(`callVendor: ${action} failed (${response.status}): ${parsed.error || JSON.stringify(parsed)}`);
+  }
+  return parsed;
+}
+
+module.exports = callVendor;

--- a/tests/lib/vendor.js
+++ b/tests/lib/vendor.js
@@ -9,29 +9,36 @@
  */
 async function callVendor(action, params) {
   const proxyUrl = Cypress.env('VENDOR_PROXY_URL');
+  const proxySecret = Cypress.env('VENDOR_PROXY_SECRET');
 
   if (!proxyUrl) {
     throw new Error('callVendor: VENDOR_PROXY_URL is not set');
   }
 
+  if (!proxySecret) {
+    throw new Error('callVendor: VENDOR_PROXY_SECRET is not set');
+  }
+
   const response = await fetch(proxyUrl, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Vendor-Proxy-Secret': proxySecret,
+    },
     body: JSON.stringify(Object.assign({ action }, params)),
   });
 
   const text = await response.text();
-  let parsed;
+
+  if (!response.ok) {
+    throw new Error(`callVendor: ${action} failed (${response.status}): ${text}`);
+  }
+
   try {
-    parsed = JSON.parse(text);
+    return JSON.parse(text);
   } catch (e) {
     throw new Error(`callVendor: non-JSON response from vendor: ${text}`);
   }
-
-  if (!response.ok) {
-    throw new Error(`callVendor: ${action} failed (${response.status}): ${parsed.error || JSON.stringify(parsed)}`);
-  }
-  return parsed;
 }
 
 module.exports = callVendor;

--- a/tests/lib/vendor.js
+++ b/tests/lib/vendor.js
@@ -1,62 +1,23 @@
 'use strict';
 
-// GitHub Actions OIDC tokens are valid for ~5 minutes; a 4-min ceiling leaves a
-// 1-min margin so a multi-minute spec file never signs with a stale token.
-const TOKEN_MAX_AGE_MS = 4 * 60 * 1000;
-
-// Cypress re-evaluates this module per spec file, so these always start unset.
-let cachedToken = null;
-let cachedTokenMintedAt = 0;
-let cachedTokenPromise = null;
-
 /**
- * @returns {Promise<string>} a vendor OIDC token no older than TOKEN_MAX_AGE_MS
- */
-function getVendorToken() {
-  if (cachedTokenPromise) {
-    return cachedTokenPromise;
-  }
-  if (cachedToken && Date.now() - cachedTokenMintedAt <= TOKEN_MAX_AGE_MS) {
-    return Promise.resolve(cachedToken);
-  }
-  // Cache the in-flight promise so concurrent callers (e.g. minting two tokens
-  // via Promise.all) share one mint instead of racing to mint their own.
-  cachedTokenPromise = cy.task('mintVendorToken').then(token => {
-    cachedToken = token;
-    cachedTokenMintedAt = Date.now();
-    cachedTokenPromise = null;
-    return token;
-  }, error => {
-    cachedTokenPromise = null;
-    throw error;
-  });
-  return cachedTokenPromise;
-}
-
-/**
- * Call the e2e credential-vending Function.
+ * Call the credential vending Function through the local proxy started by
+ * cypress.config.ts. See tests/lib/vendorProxy.js.
  * @param {string} action
  * @param {object} params
  * @returns {Promise<*>} the parsed JSON response body
  */
 async function callVendor(action, params) {
-  const vendorUrl = Cypress.env('VENDOR_URL');
+  const proxyUrl = Cypress.env('VENDOR_PROXY_URL');
 
-  if (!vendorUrl) {
-    throw new Error('callVendor: VENDOR_URL is not set');
+  if (!proxyUrl) {
+    throw new Error('callVendor: VENDOR_PROXY_URL is not set');
   }
 
-  const vendorToken = await getVendorToken();
-
-  const body = JSON.stringify(Object.assign({ action }, params));
-
-  const response = await fetch(vendorUrl, {
+  const response = await fetch(proxyUrl, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${vendorToken}`
-    },
-    body
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(Object.assign({ action }, params)),
   });
 
   const text = await response.text();

--- a/tests/lib/vendorProxy.js
+++ b/tests/lib/vendorProxy.js
@@ -1,0 +1,158 @@
+'use strict';
+
+const http = require('http');
+
+// GitHub Actions OIDC tokens are valid for ~5 minutes; a 4-min ceiling leaves a
+// 1-min margin so a long-running spec file never signs with a stale token.
+const TOKEN_MAX_AGE_MS = 4 * 60 * 1000;
+
+/**
+ * Provides a local webserver interface to the credential vending Function.
+ * Runs in the Cypress Node process and adds the authorization header, so tests
+ * running in browser do not handle credentials.
+ *
+ * Tests POST to /vend with the vending request body. The status code and body
+ * of the vending response are returned as-is.
+*/
+class VendorProxy {
+  constructor() {
+    this._server = null;
+    this._cachedToken = null;
+    this._cachedTokenMintedAt = 0;
+    this._cachedTokenPromise = null;
+  }
+
+  /**
+   * Start listening on an OS-assigned port on the loopback interface.
+   * @returns {Promise<string>} the URL specs should POST to
+   */
+  start() {
+    this._server = http.createServer((req, res) => this._handleRequest(req, res));
+    return new Promise((resolve, reject) => {
+      this._server.once('error', reject);
+      this._server.listen(0, '127.0.0.1', () => {
+        resolve(`http://127.0.0.1:${this._server.address().port}/vend`);
+      });
+    });
+  }
+
+  /**
+   * Stop listening. Safe to call when not started.
+   */
+  stop() {
+    if (this._server) {
+      this._server.close();
+      this._server = null;
+    }
+  }
+
+  async _handleRequest(req, res) {
+    // This port is a different origin than the page Cypress serves.
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+
+    if (req.method !== 'POST' || req.url !== '/vend') {
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'not found' }));
+      return;
+    }
+
+    try {
+      const body = await readBody(req);
+      const { status, text } = await this._forward(body);
+      res.writeHead(status, { 'Content-Type': 'application/json' });
+      res.end(text);
+    } catch (error) {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: error.message }));
+    }
+  }
+
+  async _forward(body) {
+    const vendorUrl = process.env.VENDOR_URL;
+    if (!vendorUrl) {
+      throw new Error('VENDOR_URL is not set');
+    }
+
+    const token = await this._getToken();
+    const response = await fetch(vendorUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`,
+      },
+      body,
+    });
+
+    return { status: response.status, text: await response.text() };
+  }
+
+  _getToken() {
+    if (this._cachedTokenPromise) {
+      return this._cachedTokenPromise;
+    }
+    if (this._cachedToken && Date.now() - this._cachedTokenMintedAt <= TOKEN_MAX_AGE_MS) {
+      return Promise.resolve(this._cachedToken);
+    }
+    // Cache the in-flight promise so concurrent requests (e.g. a spec minting
+    // two access tokens via Promise.all) share one mint instead of racing.
+    this._cachedTokenPromise = mintToken().then(token => {
+      this._cachedToken = token;
+      this._cachedTokenMintedAt = Date.now();
+      this._cachedTokenPromise = null;
+      return token;
+    }, error => {
+      this._cachedTokenPromise = null;
+      throw error;
+    });
+    return this._cachedTokenPromise;
+  }
+}
+
+/**
+ * Mint a GitHub Actions OIDC token, or use VENDOR_TOKEN for local runs.
+ * @returns {Promise<string>}
+ */
+async function mintToken() {
+  const requestToken = process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
+  const requestUrl = process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
+
+  if (!requestToken || !requestUrl) {
+    if (!process.env.VENDOR_TOKEN) {
+      throw new Error('Set VENDOR_TOKEN to run outside of GitHub Actions');
+    }
+    return process.env.VENDOR_TOKEN;
+  }
+
+  const audience = process.env.VENDOR_AUDIENCE;
+  if (!audience) {
+    throw new Error('VENDOR_AUDIENCE is not set');
+  }
+
+  const response = await fetch(`${requestUrl}&audience=${encodeURIComponent(audience)}`, {
+    headers: { Authorization: `bearer ${requestToken}` },
+  });
+  if (!response.ok) {
+    throw new Error(`OIDC token request failed: ${response.status}`);
+  }
+
+  const body = await response.json();
+  return body.value;
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', chunk => { data += chunk; });
+    req.on('end', () => resolve(data));
+    req.on('error', reject);
+  });
+}
+
+module.exports = VendorProxy;

--- a/tests/lib/vendorProxy.js
+++ b/tests/lib/vendorProxy.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const crypto = require('crypto');
 const http = require('http');
 
 // GitHub Actions OIDC tokens are valid for ~5 minutes; a 4-min ceiling leaves a
@@ -11,15 +12,25 @@ const TOKEN_MAX_AGE_MS = 4 * 60 * 1000;
  * Runs in the Cypress Node process and adds the authorization header, so tests
  * running in browser do not handle credentials.
  *
- * Tests POST to /vend with the vending request body. The status code and body
- * of the vending response are returned as-is.
+ * Tests POST to /vend with the vending request body and the per-run secret in
+ * the X-Vendor-Proxy-Secret header. The status code and body of the vending
+ * response are returned as-is.
 */
 class VendorProxy {
   constructor() {
     this._server = null;
+    this._secret = crypto.randomUUID();
     this._cachedToken = null;
     this._cachedTokenMintedAt = 0;
     this._cachedTokenPromise = null;
+  }
+
+  /**
+   * @returns {string} the per-run secret /vend requires, for injection into the
+   *   Cypress test env
+   */
+  get secret() {
+    return this._secret;
   }
 
   /**
@@ -49,7 +60,7 @@ class VendorProxy {
   async _handleRequest(req, res) {
     // This port is a different origin than the page Cypress serves.
     res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, X-Vendor-Proxy-Secret');
 
     if (req.method === 'OPTIONS') {
       res.writeHead(204);
@@ -63,14 +74,23 @@ class VendorProxy {
       return;
     }
 
+    if (req.headers['x-vendor-proxy-secret'] !== this._secret) {
+      res.writeHead(403, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'forbidden' }));
+      return;
+    }
+
     try {
       const body = await readBody(req);
       const { status, text } = await this._forward(body);
       res.writeHead(status, { 'Content-Type': 'application/json' });
       res.end(text);
     } catch (error) {
+      // Cypress surfaces this process's stderr in the run output, which is the
+      // only place the cause is visible; the response body stays generic.
+      console.error('[vendorProxy] /vend failed', error);
       res.writeHead(500, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: error.message }));
+      res.end(JSON.stringify({ error: 'internal error' }));
     }
   }
 


### PR DESCRIPTION
## Summary
Adds `.github/workflows/e2e.yml`, running the integration suite (`test:integration`) in GitHub Actions across Chrome and Firefox and each browser's stable/beta/unstable channels.

`tests/lib/token.js` is refactored to route through a new `tests/lib/vendor.js` client so the same test code works unchanged in the new workflow. Long-lived API key secrets are removed from the Cypress environment; the workflow authenticates with a GitHub Actions OIDC token instead.