### PR TITLE
fix: await callee accept in isBusy e2e test

### DIFF
--- a/cypress/e2e/deviceProperties.cy.ts
+++ b/cypress/e2e/deviceProperties.cy.ts
@@ -139,9 +139,12 @@ describe('Device Properties', function() {
 
       assert.strictEqual(device1.isBusy, true);
 
-      const acceptPromise = expectEvent('accept', outgoingCall);
+      // Each Call emits `accept` on its own signaling and media, so the
+      // callee's accept must be awaited before asserting on device2.
+      const outgoingAcceptPromise = expectEvent('accept', outgoingCall);
+      const incomingAcceptPromise = expectEvent('accept', incomingCall);
       incomingCall.accept();
-      await acceptPromise;
+      await Promise.all([outgoingAcceptPromise, incomingAcceptPromise]);
 
       assert.strictEqual(device1.isBusy, true);
       assert.strictEqual(device2.isBusy, true);


### PR DESCRIPTION
## Pull Request Details

### Description

The test awaited `accept` on the caller's call only, then asserted `device2.isBusy`. Each Call emits `accept` on its own signaling and media, so the callee's `accept` is unordered with respect to the caller's and `device2._activeCall` may still be `null` when the assertion runs.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Ready for review
