### PR TITLE
Fix unhandled NotSupportedError when deleting speakers without setSinkId

### DIFF
--- a/lib/twilio/outputdevicecollection.ts
+++ b/lib/twilio/outputdevicecollection.ts
@@ -34,6 +34,13 @@ export default class OutputDeviceCollection {
    */
   delete(device: MediaDeviceInfo): boolean {
     this._log.debug('.delete', device);
+
+    // Sink selection is impossible on this browser: set() always rejects and
+    // _beforeChange would reject with NotSupportedError. Just drop the device.
+    if (!this._isSupported) {
+      return !!(this._activeDevices.delete(device));
+    }
+
     const wasDeleted: boolean = !!(this._activeDevices.delete(device));
 
     const defaultDevice: MediaDeviceInfo = this._availableDevices.get('default')

--- a/lib/twilio/outputdevicecollection.ts
+++ b/lib/twilio/outputdevicecollection.ts
@@ -35,12 +35,6 @@ export default class OutputDeviceCollection {
   delete(device: MediaDeviceInfo): boolean {
     this._log.debug('.delete', device);
 
-    // Sink selection is impossible on this browser: set() always rejects and
-    // _beforeChange would reject with NotSupportedError. Just drop the device.
-    if (!this._isSupported) {
-      return !!(this._activeDevices.delete(device));
-    }
-
     const wasDeleted: boolean = !!(this._activeDevices.delete(device));
 
     const defaultDevice: MediaDeviceInfo = this._availableDevices.get('default')
@@ -48,6 +42,13 @@ export default class OutputDeviceCollection {
 
     if (!this._activeDevices.size && defaultDevice) {
       this._activeDevices.add(defaultDevice);
+    }
+
+    // Sink selection is impossible on this browser: set() always rejects and
+    // _beforeChange would reject with NotSupportedError. Keep the empty-set
+    // default restore above, but skip the implementation callback.
+    if (!this._isSupported) {
+      return wasDeleted;
     }
 
     // Call _beforeChange so that the implementation can react when a device is

--- a/tests/outputdevicecollection.js
+++ b/tests/outputdevicecollection.js
@@ -47,6 +47,35 @@ describe('OutputDeviceCollection', () => {
         assert.equal(collection.get().size, 0);
         assert.equal(onChange.callCount, 0);
       });
+
+      it('should restore the default device without calling _beforeChange', () => {
+        const onChange = sinon.spy(() => Promise.reject(new Error('should not be called')));
+        const deviceDefault = { deviceId: 'default', kind: 'audiooutput' };
+        const fakeDevice = { deviceId: 'lost' };
+        collection = new OutputDeviceCollection('foo', new Map([['default', deviceDefault]]), onChange, false);
+        collection._activeDevices.add(fakeDevice);
+
+        const wasDeleted = collection.delete(fakeDevice);
+
+        assert.equal(wasDeleted, true);
+        assert.equal(collection.get().size, 1);
+        assert.equal(Array.from(collection.get())[0], deviceDefault);
+        assert.equal(onChange.callCount, 0);
+      });
+
+      it('should restore the first available device when default is missing', () => {
+        const onChange = sinon.spy(() => Promise.reject(new Error('should not be called')));
+        const deviceFoo = { deviceId: 'foo', kind: 'audiooutput' };
+        const fakeDevice = { deviceId: 'lost' };
+        collection = new OutputDeviceCollection('foo', new Map([['foo', deviceFoo]]), onChange, false);
+        collection._activeDevices.add(fakeDevice);
+
+        collection.delete(fakeDevice);
+
+        assert.equal(collection.get().size, 1);
+        assert.equal(Array.from(collection.get())[0], deviceFoo);
+        assert.equal(onChange.callCount, 0);
+      });
     });
   });
 

--- a/tests/outputdevicecollection.js
+++ b/tests/outputdevicecollection.js
@@ -33,6 +33,21 @@ describe('OutputDeviceCollection', () => {
         throw new Error('Promise was unexpectedly fulfilled');
       }, () => { }));
     });
+
+    describe('.delete', () => {
+      it('should remove the device without calling _beforeChange', () => {
+        const onChange = sinon.spy(() => Promise.reject(new Error('should not be called')));
+        collection = new OutputDeviceCollection('foo', new Map(), onChange, false);
+        const fakeDevice = { deviceId: 'lost' };
+        collection._activeDevices.add(fakeDevice);
+
+        const wasDeleted = collection.delete(fakeDevice);
+
+        assert.equal(wasDeleted, true);
+        assert.equal(collection.get().size, 0);
+        assert.equal(onChange.callCount, 0);
+      });
+    });
   });
 
   context('when supported', () => {


### PR DESCRIPTION
## Summary
On browsers without setSinkId support, OutputDeviceCollection.delete still called beforeChange. That path rejects with NotSupportedError, so removing a speaker from an unsupported collection left an unhandled rejection (see #458).

This change removes the device from the active set and returns early when the collection is unsupported, matching how get already behaves. A unit test covers the unsupported delete path.

## Test plan
1. Build constants, then run the outputdevicecollection mocha file with the TypeScript register loader.
2. Confirm the new unsupported delete case passes and existing supported delete cases still pass.

Fixes #458