### PR TITLE
[VBLOCKS-7005] fix: remote re-invite, pc handler restore, cachedAnswer leak

### DIFF
--- a/lib/twilio/rtc/peerconnection.ts
+++ b/lib/twilio/rtc/peerconnection.ts
@@ -840,23 +840,38 @@ PeerConnection.prototype.processAnswer = function(sdp, onMediaStarted) {
   });
 };
 /**
- * Answers a remote offer on an open connection (SIP re-INVITE). Skips
- * _initializeMediaStream, which no-ops on an open PC and would replace it.
+ * Answers a remote offer on an established dialog (SIP re-INVITE). Deliberately
+ * mirrors answerIncomingCall minus _initializeMediaStream: that returns false
+ * without calling back once status is 'open' (the caller then waits forever),
+ * and while status is still 'connecting' it rebuilds this.version, discarding
+ * the live connection.
  * @private
  */
 PeerConnection.prototype.processOffer = function(sdp, onAnswerReady, onMediaStarted) {
+  const self = this;
+  function onAnswerError(err) {
+    const errMsg = err.message || err;
+    self.onerror({ info: {
+      code: 31000,
+      message: `Error processing offer: ${errMsg}`,
+      twilioError: new MediaErrors.ClientRemoteDescFailed(),
+    } });
+  }
+
+  // Returning silently would hang the caller: SIP.js blocks on the answer,
+  // and onerror is the only channel that reaches it.
   if (this.status === 'closed') {
+    onAnswerError(new Error('Connection is closed'));
     return;
   }
 
   const processedSdp = this._maybeSetIceAggressiveNomination(sdp);
   this._answerSdp = processedSdp;
 
-  const self = this;
   function onAnswerSuccess() {
-    // close() may have landed while createAnswer was in flight, which nulls
-    // version.pc, so getSDP() would throw. Mirrors answerIncomingCall.
+    // close() nulls version.pc, so getSDP() would throw.
     if (self.status === 'closed') {
+      onAnswerError(new Error('Connection closed while creating the answer'));
       return;
     }
 
@@ -867,18 +882,9 @@ PeerConnection.prototype.processOffer = function(sdp, onAnswerReady, onMediaStar
     onMediaStarted(self.version.pc);
   }
 
-  function onAnswerError(err) {
-    const errMsg = err.message || err;
-    self.onerror({ info: {
-      code: 31000,
-      message: `Error processing offer: ${errMsg}`,
-      twilioError: new MediaErrors.ClientRemoteDescFailed(),
-    } });
-  }
-
-  // NOTE(VBLOCKS-7005): no a=setup:actpass -> passive rewrite here. The DTLS
-  // role was fixed by the initial exchange; a renegotiation must not restate
-  // it. _setupRTCDtlsTransportListener is likewise already installed.
+  // NOTE(VBLOCKS-7005): no a=setup:actpass -> passive rewrite, unlike
+  // answerIncomingCall. There it only lands in _answerSdp, which nothing
+  // reads, so it never reached WebRTC.
   this.version.processSDP(this.options.maxAverageBitrate, this.codecPreferences, processedSdp, { audio: true }, onAnswerSuccess, onAnswerError);
 };
 PeerConnection.prototype.answerIncomingCall = function(callSid, sdp, rtcConfiguration, onAnswerReady, onMediaStarted) {

--- a/lib/twilio/rtc/peerconnection.ts
+++ b/lib/twilio/rtc/peerconnection.ts
@@ -839,6 +839,48 @@ PeerConnection.prototype.processAnswer = function(sdp, onMediaStarted) {
     } });
   });
 };
+/**
+ * Answers a remote offer on an open connection (SIP re-INVITE). Skips
+ * _initializeMediaStream, which no-ops on an open PC and would replace it.
+ * @private
+ */
+PeerConnection.prototype.processOffer = function(sdp, onAnswerReady, onMediaStarted) {
+  if (this.status === 'closed') {
+    return;
+  }
+
+  const processedSdp = this._maybeSetIceAggressiveNomination(sdp);
+  this._answerSdp = processedSdp;
+
+  const self = this;
+  function onAnswerSuccess() {
+    // close() may have landed while createAnswer was in flight, which nulls
+    // version.pc, so getSDP() would throw. Mirrors answerIncomingCall.
+    if (self.status === 'closed') {
+      return;
+    }
+
+    onAnswerReady(self.version.getSDP());
+    if (self.options) {
+      self._setEncodingParameters(self.options.dscp);
+    }
+    onMediaStarted(self.version.pc);
+  }
+
+  function onAnswerError(err) {
+    const errMsg = err.message || err;
+    self.onerror({ info: {
+      code: 31000,
+      message: `Error processing offer: ${errMsg}`,
+      twilioError: new MediaErrors.ClientRemoteDescFailed(),
+    } });
+  }
+
+  // NOTE(VBLOCKS-7005): no a=setup:actpass -> passive rewrite here. The DTLS
+  // role was fixed by the initial exchange; a renegotiation must not restate
+  // it. _setupRTCDtlsTransportListener is likewise already installed.
+  this.version.processSDP(this.options.maxAverageBitrate, this.codecPreferences, processedSdp, { audio: true }, onAnswerSuccess, onAnswerError);
+};
 PeerConnection.prototype.answerIncomingCall = function(callSid, sdp, rtcConfiguration, onAnswerReady, onMediaStarted) {
   if (!this._initializeMediaStream(rtcConfiguration)) {
     return;

--- a/lib/twilio/signaling/signalingadapter.ts
+++ b/lib/twilio/signaling/signalingadapter.ts
@@ -29,8 +29,7 @@ export interface HangupConfig {
 
 export interface IceRestartConfig {
   // Used by the PStream adapter to generate the fresh-ICE offer; the
-  // SIP adapter ignores it because SIP.js asks the SDH to produce the
-  // offer via session.invite() + offerOptions.iceRestart.
+  // SIP adapter ignores it because its SDH produces the offer itself.
   mediaHandler: IMediaHandler;
 }
 
@@ -74,8 +73,8 @@ export interface SignalingAdapter extends EventEmitter {
    * its own offer-generation strategy:
    *  - PStream: asks config.mediaHandler to generate the offer, then
    *    ships it via the existing reinvite wire.
-   *  - SIP: calls session.invite() with offerOptions.iceRestart so SIP.js
-   *    asks the SDH to produce the offer itself.
+   *  - SIP: arms the SDH via requestIceRestart(), then sends a re-INVITE;
+   *    the SDH produces the offer when SIP.js asks it for one.
    * On failure, emits 'hangup' for the callSid so Call can clean up its
    * reinvite listeners.
    */

--- a/lib/twilio/signaling/sipsessiondescriptionhandler.ts
+++ b/lib/twilio/signaling/sipsessiondescriptionhandler.ts
@@ -153,6 +153,10 @@ export class SipSessionDescriptionHandler implements SessionDescriptionHandler {
     this._iceRestartRequested = true;
   }
 
+  cancelIceRestart(): void {
+    this._iceRestartRequested = false;
+  }
+
   getDescription(): Promise<BodyAndContentType> {
     if (this._closed) {
       return Promise.reject(new Error(CLOSED_ERROR_MESSAGE));

--- a/lib/twilio/signaling/sipsessiondescriptionhandler.ts
+++ b/lib/twilio/signaling/sipsessiondescriptionhandler.ts
@@ -1,19 +1,7 @@
 import {
   BodyAndContentType,
   SessionDescriptionHandler,
-  SessionDescriptionHandlerOptions as BaseSessionDescriptionHandlerOptions,
 } from 'sip.js';
-
-/**
- * Local extension of SIP.js's public SessionDescriptionHandlerOptions
- * type. SIP.js's web-platform SDH ships a richer type in a private
- * subpath (sip.js/lib/platform/web/...), but importing from that path
- * is fragile across versions. We only need offerOptions for ICE-restart
- * plumbing, so we widen the public type here.
- */
-export interface SessionDescriptionHandlerOptions extends BaseSessionDescriptionHandlerOptions {
-  offerOptions?: RTCOfferOptions;
-}
 
 /**
  * Shape of error payloads emitted by PeerConnection.onerror.
@@ -84,7 +72,7 @@ const CLOSED_ERROR_MESSAGE = 'SipSessionDescriptionHandler closed';
  *   Inbound:  setDescription() -> answerIncomingCall consumes offer and
  *                                 produces an answer (cached)
  *             getDescription() -> returns the cached answer
- *   ICE restart: getDescription({offerOptions:{iceRestart:true}}) -> pc.iceRestart
+ *   ICE restart: requestIceRestart() then getDescription() -> pc.iceRestart
  *                produces a fresh-ICE offer; subsequent setDescription
  *                consumes the remote answer via processAnswer.
  *   Remote re-INVITE: once the initial exchange has completed, SIP.js drives
@@ -95,9 +83,9 @@ const CLOSED_ERROR_MESSAGE = 'SipSessionDescriptionHandler closed';
  * rejects whatever is pending) and `onfailed` (ICE-state failures plus
  * ICE-restart createOffer rejections). We wrap both and call the previous
  * handlers (Call owns them) so Call still emits its error events. The
- * onfailed wrap is scoped: it only rejects pending Promises when the SDH
- * itself initiated an ICE restart, so that runtime ICE failures do not
- * reject unrelated in-flight get/setDescription Promises.
+ * onfailed wrap is scoped: it only rejects pending Promises while an ICE
+ * restart is in flight, so that runtime ICE failures do not reject
+ * unrelated in-flight get/setDescription Promises.
  */
 export class SipSessionDescriptionHandler implements SessionDescriptionHandler {
   private _cachedAnswer: string | null = null;
@@ -108,21 +96,16 @@ export class SipSessionDescriptionHandler implements SessionDescriptionHandler {
   // arriving after this point is a server-initiated re-INVITE.
   private _hasNegotiated: boolean = false;
   private _hasSentOffer: boolean = false;
-  // True while an ICE-restart getDescription() is in flight. Scopes the
-  // onfailed wrap: pc.onfailed fires both for createOffer rejection (what
-  // we want to reject the pending getDescription Promise for) and for ICE
-  // state = failed at runtime (what we do NOT want to reject unrelated
-  // in-flight get/setDescription Promises for).
-  //
-  // Invariant: at most one ICE-restart getDescription in flight per SDH.
-  // Enforced by the caller — Call._mediaReconnectBackoff fires serially,
-  // so overlapping ICE restarts cannot reach this SDH.
+  // One shot, set by requestIceRestart(). SIP.js persists invite options across
+  // the dialog, so the intent cannot be read back from them.
+  private _iceRestartRequested: boolean = false;
+  // pc.onfailed reports both a createOffer rejection during our restart and a
+  // runtime ICE failure. Only the first should reject the pending Promise.
+  // Call._mediaReconnectBackoff fires serially, so at most one is in flight.
   private _iceRestartPending: boolean = false;
-  // PeerConnection reports failures via onerror, not the success callbacks
-  // we pass in. Every in-flight operation adds its reject handler here;
-  // the onerror hook in the constructor rejects all of them. SIP.js can
-  // issue overlapping setDescription calls (e.g. PRACK/UPDATE during early
-  // media), so a single-slot field would let earlier Promises hang.
+  // PeerConnection reports failures through onerror, not the callbacks we pass
+  // it, so every in-flight operation parks its reject here. A Set because SIP.js
+  // can overlap setDescription calls (PRACK/UPDATE during early media).
   private _pendingRejects: Set<(error: Error) => void> = new Set();
 
   // Call's pc.onerror / pc.onfailed, captured before the constructor wraps
@@ -166,7 +149,11 @@ export class SipSessionDescriptionHandler implements SessionDescriptionHandler {
     };
   }
 
-  getDescription(options?: SessionDescriptionHandlerOptions): Promise<BodyAndContentType> {
+  requestIceRestart(): void {
+    this._iceRestartRequested = true;
+  }
+
+  getDescription(): Promise<BodyAndContentType> {
     if (this._closed) {
       return Promise.reject(new Error(CLOSED_ERROR_MESSAGE));
     }
@@ -175,12 +162,8 @@ export class SipSessionDescriptionHandler implements SessionDescriptionHandler {
       this._cachedAnswer = null;
       return Promise.resolve({ body, contentType: APPLICATION_SDP });
     }
-    // SIP.js forwards sessionDescriptionHandlerOptions from session.invite()
-    // into this options argument. SipSignalingAdapter.iceRestart() sets
-    // offerOptions.iceRestart when Call's media backoff requests a restart;
-    // that routes through pc.iceRestart() (fresh ICE candidates) instead
-    // of pc.makeOutgoingCall().
-    if (options?.offerOptions?.iceRestart) {
+    if (this._iceRestartRequested) {
+      this._iceRestartRequested = false;
       this._iceRestartPending = true;
       return this._awaitOperation<BodyAndContentType>((resolve) => {
         this._pc.iceRestart((offerSdp) => {

--- a/lib/twilio/signaling/sipsessiondescriptionhandler.ts
+++ b/lib/twilio/signaling/sipsessiondescriptionhandler.ts
@@ -55,12 +55,21 @@ export interface IPeerConnection {
     onMediaStarted: (pc: RTCPeerConnection) => void,
   ): void;
 
+  // answerIncomingCall cannot be reused here: it re-initializes the media
+  // stream, which no-ops without calling back once the PC is open.
+  processOffer(
+    sdp: string,
+    onAnswerReady: (answerSdp: string) => void,
+    onMediaStarted: (pc: RTCPeerConnection) => void,
+  ): void;
+
   iceRestart(onOfferReady: (offerSdp: string) => void): void;
 
   close(): void;
 }
 
 const APPLICATION_SDP = 'application/sdp';
+const CLOSED_ERROR_MESSAGE = 'SipSessionDescriptionHandler closed';
 
 /**
  * Bridges SIP.js's SessionDescriptionHandler interface to the SDK's
@@ -78,6 +87,9 @@ const APPLICATION_SDP = 'application/sdp';
  *   ICE restart: getDescription({offerOptions:{iceRestart:true}}) -> pc.iceRestart
  *                produces a fresh-ICE offer; subsequent setDescription
  *                consumes the remote answer via processAnswer.
+ *   Remote re-INVITE: once the initial exchange has completed, SIP.js drives
+ *                setDescription(remote offer) -> pc.processOffer, then
+ *                getDescription() -> the answer processOffer cached.
  *
  * Error handling: PeerConnection reports failures via `onerror` (generic,
  * rejects whatever is pending) and `onfailed` (ICE-state failures plus
@@ -89,6 +101,12 @@ const APPLICATION_SDP = 'application/sdp';
  */
 export class SipSessionDescriptionHandler implements SessionDescriptionHandler {
   private _cachedAnswer: string | null = null;
+  // SIP.js can still call in after close(), which already unwrapped
+  // pc.onerror, so a new operation would never settle. Reject up front.
+  private _closed: boolean = false;
+  // True once the initial offer/answer exchange has completed. A remote offer
+  // arriving after this point is a server-initiated re-INVITE.
+  private _hasNegotiated: boolean = false;
   private _hasSentOffer: boolean = false;
   // True while an ICE-restart getDescription() is in flight. Scopes the
   // onfailed wrap: pc.onfailed fires both for createOffer rejection (what
@@ -107,20 +125,18 @@ export class SipSessionDescriptionHandler implements SessionDescriptionHandler {
   // media), so a single-slot field would let earlier Promises hang.
   private _pendingRejects: Set<(error: Error) => void> = new Set();
 
-  /**
-   * Invariant: at most one SipSessionDescriptionHandler exists per
-   * PeerConnection lifetime. The constructor wraps pc.onerror and
-   * pc.onfailed and stores the previous handlers in closures. Creating
-   * a second SDH over the same PC would stack wraps indefinitely and
-   * keep old Promise rejects reachable via closure. Today Call owns one
-   * PC per call and SIP.js memoizes one SDH per Session, so this holds.
-   */
+  // Call's pc.onerror / pc.onfailed, captured before the constructor wraps
+  // them. close() puts them back, so Call keeps receiving errors after the
+  // Session is disposed and a recreated Session re-wraps instead of stacking.
+  private _previousOnError: (error: PeerConnectionError) => void;
+  private _previousOnFailed: (message: string) => void;
+
   constructor(
     private _pc: IPeerConnection,
     private _callSid: string,
     private _rtcConfiguration: RTCConfiguration = {},
   ) {
-    const previousOnError = this._pc.onerror;
+    const previousOnError = this._previousOnError = this._pc.onerror;
     this._pc.onerror = (error: PeerConnectionError) => {
       // Clear _iceRestartPending so a later runtime onfailed doesn't re-enter
       // _failPending. Harmless today (pending set is already drained) but keeps
@@ -129,7 +145,7 @@ export class SipSessionDescriptionHandler implements SessionDescriptionHandler {
       this._failPending(error?.info?.twilioError || new Error(error?.info?.message || 'PeerConnection error'));
       previousOnError(error);
     };
-    const previousOnFailed = this._pc.onfailed;
+    const previousOnFailed = this._previousOnFailed = this._pc.onfailed;
     this._pc.onfailed = (message: string) => {
       // Only reject pending Promises if an ICE restart is in flight —
       // that's the one case where pc.onfailed carries a createOffer
@@ -151,6 +167,9 @@ export class SipSessionDescriptionHandler implements SessionDescriptionHandler {
   }
 
   getDescription(options?: SessionDescriptionHandlerOptions): Promise<BodyAndContentType> {
+    if (this._closed) {
+      return Promise.reject(new Error(CLOSED_ERROR_MESSAGE));
+    }
     if (this._cachedAnswer !== null) {
       const body = this._cachedAnswer;
       this._cachedAnswer = null;
@@ -174,6 +193,12 @@ export class SipSessionDescriptionHandler implements SessionDescriptionHandler {
         });
       });
     }
+    if (this._hasNegotiated) {
+      // Offerless re-INVITE. Falling through would hang: makeOutgoingCall
+      // no-ops on an open PC. Rejecting makes SIP.js respond 488 and keep
+      // the call up. Supporting it also means answering from the ACK.
+      return Promise.reject(new Error('Offerless re-INVITE is not supported'));
+    }
     return this._awaitOperation<BodyAndContentType>((resolve) => {
       this._pc.makeOutgoingCall(this._callSid, this._rtcConfiguration, (offerSdp) => {
         this._hasSentOffer = true;
@@ -187,16 +212,31 @@ export class SipSessionDescriptionHandler implements SessionDescriptionHandler {
   }
 
   setDescription(sdp: string): Promise<void> {
+    if (this._closed) {
+      return Promise.reject(new Error(CLOSED_ERROR_MESSAGE));
+    }
     if (this._hasSentOffer) {
       return this._awaitOperation<void>((resolve) => {
         this._pc.processAnswer(sdp, () => {
           // Outbound offer/answer exchange complete. Clear the flag so a
           // subsequent re-INVITE on the same session (SIP.js memoizes the
-          // SDH per Session) can route correctly — inbound re-INVITE must
-          // go down answerIncomingCall, outbound must set the flag again.
+          // SDH per Session) can route correctly. A remote re-INVITE must
+          // go down processOffer, outbound must set the flag again.
           this._hasSentOffer = false;
+          this._hasNegotiated = true;
           resolve();
         });
+      });
+    }
+    if (this._hasNegotiated) {
+      // Server-initiated re-INVITE carrying an offer. SIP.js follows this
+      // with a getDescription() that collects the cached answer.
+      return this._awaitOperation<void>((resolve) => {
+        this._pc.processOffer(
+          sdp,
+          (answerSdp) => { this._cachedAnswer = answerSdp; },
+          () => resolve(),
+        );
       });
     }
     return this._awaitOperation<void>((resolve) => {
@@ -205,7 +245,10 @@ export class SipSessionDescriptionHandler implements SessionDescriptionHandler {
         sdp,
         this._rtcConfiguration,
         (answerSdp) => { this._cachedAnswer = answerSdp; },
-        () => resolve(),
+        () => {
+          this._hasNegotiated = true;
+          resolve();
+        },
       );
     });
   }
@@ -215,8 +258,15 @@ export class SipSessionDescriptionHandler implements SessionDescriptionHandler {
     // teardown paths. SIP.js invokes close() on the SDH at session end —
     // we must NOT close the PC here, or it would be closed twice (risking
     // duplicate close events or log warnings on torn-down handlers).
+    this._closed = true;
     this._iceRestartPending = false;
-    this._failPending(new Error('SipSessionDescriptionHandler closed'));
+    // Also drops the PC's last reference to this SDH.
+    this._pc.onerror = this._previousOnError;
+    this._pc.onfailed = this._previousOnFailed;
+    // Drop any answer produced but never collected, e.g. onAnswerReady fired
+    // and the operation was cancelled before SIP.js called getDescription().
+    this._cachedAnswer = null;
+    this._failPending(new Error(CLOSED_ERROR_MESSAGE));
   }
 
   sendDtmf(_tones: string): boolean {

--- a/lib/twilio/signaling/sipsignalingadapter.ts
+++ b/lib/twilio/signaling/sipsignalingadapter.ts
@@ -505,7 +505,7 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
     // Arm the SDH directly. Invite options stick to the dialog and replay
     // onto later server-initiated re-INVITEs.
     const sdh = session.sessionDescriptionHandler as
-      Partial<SipSessionDescriptionHandler> | undefined;
+      SipSessionDescriptionHandler | undefined;
     if (typeof sdh?.requestIceRestart !== 'function') {
       this._log.warn('iceRestart: no usable description handler for callSid', callSid);
       this.emit('hangup', { callsid: callSid });
@@ -549,6 +549,7 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
       // the in-flight re-INVITE has a chance to succeed or surface the real
       // failure (timeout, reject, etc.).
       if (error instanceof RequestPendingError) {
+        sdh.cancelIceRestart();
         this._log.info('iceRestart skipped: previous re-INVITE still pending');
         return;
       }

--- a/lib/twilio/signaling/sipsignalingadapter.ts
+++ b/lib/twilio/signaling/sipsignalingadapter.ts
@@ -29,7 +29,6 @@ import {
 } from './signalingadapter';
 import {
   IPeerConnection,
-  SessionDescriptionHandlerOptions,
   SipSessionDescriptionHandler,
 } from './sipsessiondescriptionhandler';
 import { CloseCodeRecorder, installCloseCodeHook } from './sipclosecodehook';
@@ -57,14 +56,6 @@ const CONNECT_SUCCESS_TIMEOUT_MS = 10000;
 // Close codes meaning the server was unreachable rather than shut down
 // cleanly. 1006: abnormal close. 1015: TLS handshake failure.
 const ABNORMAL_CLOSE_CODES = [1006, 1015];
-
-// SIP.js's SessionInviteOptions.sessionDescriptionHandlerOptions is typed
-// as the base SessionDescriptionHandlerOptions, which does not expose
-// offerOptions. Override that field with our SDH's extended type so the
-// iceRestart flag is typechecked at the call site.
-type IceRestartInviteOptions = Omit<SessionInviteOptions, 'sessionDescriptionHandlerOptions'> & {
-  sessionDescriptionHandlerOptions?: SessionDescriptionHandlerOptions;
-};
 
 type SipSendMessageConfig = Pick<SendMessageConfig, 'content' | 'contentType' | 'voiceEventSid'>;
 
@@ -493,11 +484,9 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
   }
 
   /**
-   * Re-INVITE with offerOptions.iceRestart:true. SIP.js asks the SDH for the
-   * fresh-ICE offer, so config.mediaHandler is unused here (kept for the
-   * shared interface). Every failure path emits 'hangup' so Call can drop its
-   * inline listeners, except while reconnecting, which defers to
-   * 'iceRestartNeeded'.
+   * Re-INVITE for a fresh-ICE offer, which the armed SDH produces (so
+   * _config is unused). Failures emit 'hangup' so Call can drop its inline
+   * listeners, except while reconnecting, which defers to 'iceRestartNeeded'.
    */
   iceRestart(callSid: string, _config: IceRestartConfig): void {
     const session = this._getSession(callSid);
@@ -513,9 +502,20 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
       this._pendingIceRestartRecovery.add(callSid);
       return;
     }
+    // Arm the SDH directly. Invite options stick to the dialog and replay
+    // onto later server-initiated re-INVITEs.
+    const sdh = session.sessionDescriptionHandler as
+      Partial<SipSessionDescriptionHandler> | undefined;
+    if (typeof sdh?.requestIceRestart !== 'function') {
+      this._log.warn('iceRestart: no usable description handler for callSid', callSid);
+      this.emit('hangup', { callsid: callSid });
+      return;
+    }
+    sdh.requestIceRestart();
+
     const inflight: InflightIceRestart = { callSid, stale: false };
     this._inFlightIceRestarts.add(inflight);
-    const inviteOptions: IceRestartInviteOptions = {
+    const inviteOptions: SessionInviteOptions = {
       requestDelegate: {
         onAccept: () => {
           this._inFlightIceRestarts.delete(inflight);
@@ -540,9 +540,6 @@ export class SipSignalingAdapter extends EventEmitter implements SignalingAdapte
             error: { code: code ?? 31000, message: `ICE-restart re-INVITE rejected (${code ?? 'unknown'})` },
           });
         },
-      },
-      sessionDescriptionHandlerOptions: {
-        offerOptions: { iceRestart: true },
       },
     };
     session.invite(inviteOptions).catch((error: Error) => {

--- a/tests/peerconnection.js
+++ b/tests/peerconnection.js
@@ -745,12 +745,16 @@ describe('PeerConnection', () => {
       sinon.assert.notCalled(context._initializeMediaStream);
     });
 
-    it('Should not call processSDP when status is closed', () => {
+    it('Should call onerror and not processSDP when status is closed', () => {
       context.status = 'closed';
       toTest = METHOD.bind(context, SDP, onAnswerReady, onMediaStarted);
       toTest();
       assert.equal(version.processSDP.called, false);
       assert.equal(context._answerSdp, null);
+      assert(context.onerror.calledWithMatch({info: {
+        code: 31000,
+        message: 'Error processing offer: Connection is closed',
+      }}));
     });
 
     it('Should call _maybeSetIceAggressiveNomination with the sdp and set _answerSdp', () => {
@@ -782,7 +786,7 @@ describe('PeerConnection', () => {
       sinon.assert.calledWithExactly(context._setEncodingParameters, true);
     });
 
-    it('Should not call back when the connection closes while createAnswer is in flight', () => {
+    it('Should call onerror when the connection closes while createAnswer is in flight', () => {
       toTest();
       // close() lands after processSDP was called but before it succeeds.
       context.status = 'closed';
@@ -791,6 +795,10 @@ describe('PeerConnection', () => {
       sinon.assert.notCalled(version.getSDP);
       sinon.assert.notCalled(onAnswerReady);
       sinon.assert.notCalled(onMediaStarted);
+      assert(context.onerror.calledWithMatch({info: {
+        code: 31000,
+        message: 'Error processing offer: Connection closed while creating the answer',
+      }}));
     });
 
     it('Should call onerror when processSDP calls error callback with Error object', () => {

--- a/tests/peerconnection.js
+++ b/tests/peerconnection.js
@@ -703,6 +703,112 @@ describe('PeerConnection', () => {
     });
   });
 
+  context('PeerConnection.prototype.processOffer', () => {
+    const METHOD = PeerConnection.prototype.processOffer;
+    const EXPECTED_PROCESSING_ERROR = {info: {code: 31000, message: 'Error processing offer: error message'}};
+    const ERROR_MESSAGE = 'error message';
+    const ERROR = new Error(ERROR_MESSAGE);
+    const SDP = 'sdp payload';
+    const ANSWER_SDP = 'answer sdp payload';
+
+    let context = null;
+    let version = null;
+    let onAnswerReady = null;
+    let onMediaStarted = null;
+    let toTest = null;
+
+    beforeEach(() => {
+      onAnswerReady = sinon.stub();
+      onMediaStarted = sinon.stub();
+      version = {
+        pc: 'peer connection',
+        getSDP: sinon.stub().returns(ANSWER_SDP),
+        processSDP: sinon.stub()
+      };
+      context = {
+        _initializeMediaStream: sinon.stub().returns(true),
+        _maybeSetIceAggressiveNomination: (sdp) => sdp,
+        _setEncodingParameters: sinon.stub(),
+        _setupRTCDtlsTransportListener: sinon.stub(),
+        _answerSdp: null,
+        version,
+        status: 'open',
+        onerror: sinon.stub(),
+        options: { dscp: true, maxAverageBitrate: undefined },
+        codecPreferences: undefined,
+      };
+      toTest = METHOD.bind(context, SDP, onAnswerReady, onMediaStarted);
+    });
+
+    it('Should not re-initialize the media stream', () => {
+      toTest();
+      sinon.assert.notCalled(context._initializeMediaStream);
+    });
+
+    it('Should not call processSDP when status is closed', () => {
+      context.status = 'closed';
+      toTest = METHOD.bind(context, SDP, onAnswerReady, onMediaStarted);
+      toTest();
+      assert.equal(version.processSDP.called, false);
+      assert.equal(context._answerSdp, null);
+    });
+
+    it('Should call _maybeSetIceAggressiveNomination with the sdp and set _answerSdp', () => {
+      context._maybeSetIceAggressiveNomination = sinon.stub().returns(SDP);
+      toTest = METHOD.bind(context, SDP, onAnswerReady, onMediaStarted);
+      toTest();
+      sinon.assert.calledWithExactly(context._maybeSetIceAggressiveNomination, SDP);
+      assert.equal(context._answerSdp, SDP);
+    });
+
+    it('Should call version.processSDP with the processed sdp', () => {
+      toTest();
+      assert(version.processSDP.calledWithExactly(undefined, undefined, SDP, {audio: true}, sinon.match.func, sinon.match.func));
+      assert(version.processSDP.calledOn(version));
+    });
+
+    it('Should call onAnswerReady and onMediaStarted when processSDP succeeds', () => {
+      version.processSDP.callsArgWith(4);
+      toTest();
+      assert.equal(context.onerror.called, false);
+      assert(onAnswerReady.calledWithExactly(ANSWER_SDP));
+      assert(onMediaStarted.calledWithExactly(version.pc));
+    });
+
+    it('Should call _setEncodingParameters when processSDP succeeds and options exist', () => {
+      version.processSDP.callsArgWith(4);
+      toTest();
+      sinon.assert.calledOnce(context._setEncodingParameters);
+      sinon.assert.calledWithExactly(context._setEncodingParameters, true);
+    });
+
+    it('Should not call back when the connection closes while createAnswer is in flight', () => {
+      toTest();
+      // close() lands after processSDP was called but before it succeeds.
+      context.status = 'closed';
+      const onSuccess = version.processSDP.firstCall.args[4];
+      onSuccess();
+      sinon.assert.notCalled(version.getSDP);
+      sinon.assert.notCalled(onAnswerReady);
+      sinon.assert.notCalled(onMediaStarted);
+    });
+
+    it('Should call onerror when processSDP calls error callback with Error object', () => {
+      version.processSDP.callsArgWith(5, ERROR);
+      toTest();
+      assert(context.onerror.calledWithMatch(EXPECTED_PROCESSING_ERROR));
+      sinon.assert.notCalled(onAnswerReady);
+      sinon.assert.notCalled(onMediaStarted);
+    });
+
+    it('Should call onerror when processSDP calls error callback with string', () => {
+      version.processSDP.callsArgWith(5, ERROR_MESSAGE);
+      toTest();
+      assert(context.onerror.calledWithMatch(EXPECTED_PROCESSING_ERROR));
+      sinon.assert.notCalled(context._setEncodingParameters);
+    });
+  });
+
   context('PeerConnection.prototype.processAnswer', () => {
     const METHOD = PeerConnection.prototype.processAnswer;
     const EXPECTED_PROCESSING_ERROR = {info: {code: 31000, message: 'Error processing answer: error message'}};

--- a/tests/unit/sipsessiondescriptionhandler.ts
+++ b/tests/unit/sipsessiondescriptionhandler.ts
@@ -405,6 +405,25 @@ describe('SipSessionDescriptionHandler', () => {
       await assert.rejects(pending, /Error processing offer: boom/);
     });
 
+    it('cancelIceRestart() disarms the request', async () => {
+      const pc = createPeerConnectionStub({
+        makeOutgoingCall: stubMakeOutgoingCall(),
+        processAnswer: stubProcessAnswer(),
+        iceRestart: sinon.stub().callsFake(
+          (cb: (sdp: string) => void) => cb(REOFFER_SDP),
+        ) as sinon.SinonStub,
+      });
+      const { handler } = createHandler(pc);
+      await handler.getDescription();
+      await handler.setDescription(ANSWER_SDP);
+
+      handler.requestIceRestart();
+      handler.cancelIceRestart();
+
+      await assert.rejects(handler.getDescription(), /Offerless re-INVITE is not supported/);
+      sinon.assert.notCalled(pc.iceRestart);
+    });
+
     it('rejects an offerless re-INVITE that follows an ICE restart', async () => {
       // SIP.js persists session.invite()'s sessionDescriptionHandlerOptions into
       // sessionDescriptionHandlerOptionsReInvite and replays it on every later

--- a/tests/unit/sipsessiondescriptionhandler.ts
+++ b/tests/unit/sipsessiondescriptionhandler.ts
@@ -9,6 +9,8 @@ const APPLICATION_SDP = 'application/sdp';
 const CALL_SID = 'CA1234567890';
 const OFFER_SDP = 'v=0\r\no=offerer\r\n';
 const ANSWER_SDP = 'v=0\r\no=answerer\r\n';
+const REOFFER_SDP = 'v=0\r\no=reofferer\r\n';
+const REANSWER_SDP = 'v=0\r\no=reanswerer\r\n';
 
 interface PcStub extends IPeerConnection {
   onerror: (error: any) => void;
@@ -16,6 +18,7 @@ interface PcStub extends IPeerConnection {
   makeOutgoingCall: sinon.SinonStub;
   answerIncomingCall: sinon.SinonStub;
   processAnswer: sinon.SinonStub;
+  processOffer: sinon.SinonStub;
   iceRestart: sinon.SinonStub;
   close: sinon.SinonStub;
 }
@@ -27,11 +30,56 @@ function createPeerConnectionStub(overrides: Partial<PcStub> = {}): PcStub {
     makeOutgoingCall: sinon.stub(),
     answerIncomingCall: sinon.stub(),
     processAnswer: sinon.stub(),
+    processOffer: sinon.stub(),
     iceRestart: sinon.stub(),
     close: sinon.stub(),
     ...overrides,
   };
   return stub;
+}
+
+/** makeOutgoingCall that immediately hands back OFFER_SDP. */
+function stubMakeOutgoingCall(offer: string = OFFER_SDP): sinon.SinonStub {
+  return sinon.stub().callsFake(
+    (_sid: string, _cfg: RTCConfiguration, cb: (sdp: string) => void) => cb(offer),
+  );
+}
+
+/** processAnswer that immediately reports media started. */
+function stubProcessAnswer(): sinon.SinonStub {
+  return sinon.stub().callsFake(
+    (_sdp: string, cb: (pc: RTCPeerConnection) => void) => cb({} as RTCPeerConnection),
+  );
+}
+
+/** answerIncomingCall that immediately produces an answer and starts media. */
+function stubAnswerIncomingCall(answer: string = ANSWER_SDP): sinon.SinonStub {
+  return sinon.stub().callsFake(
+    (
+      _sid: string,
+      _sdp: string,
+      _cfg: RTCConfiguration,
+      onAnswerReady: (a: string) => void,
+      onMediaStarted: (pc: RTCPeerConnection) => void,
+    ) => {
+      onAnswerReady(answer);
+      onMediaStarted({} as RTCPeerConnection);
+    },
+  );
+}
+
+/** processOffer that immediately produces an answer and starts media. */
+function stubProcessOffer(answer: string = REANSWER_SDP): sinon.SinonStub {
+  return sinon.stub().callsFake(
+    (
+      _sdp: string,
+      onAnswerReady: (a: string) => void,
+      onMediaStarted: (pc: RTCPeerConnection) => void,
+    ) => {
+      onAnswerReady(answer);
+      onMediaStarted({} as RTCPeerConnection);
+    },
+  );
 }
 
 function createHandler(pc?: PcStub, rtcConfig: RTCConfiguration = {}) {
@@ -122,12 +170,21 @@ describe('SipSessionDescriptionHandler', () => {
         ) as sinon.SinonStub,
       });
       const { handler } = createHandler(pc);
-      await (handler.getDescription as any)(ICE_RESTART_OPTS);
-      await handler.setDescription(ANSWER_SDP);
-      // No options this time: must fall back to makeOutgoingCall.
+      // No options: the initial offer must go through makeOutgoingCall.
       await handler.getDescription();
-      sinon.assert.calledOnce(pc.iceRestart);
+      await handler.setDescription(ANSWER_SDP);
+      // Options present: must route to iceRestart, not makeOutgoingCall again.
+      await (handler.getDescription as any)(ICE_RESTART_OPTS);
       sinon.assert.calledOnce(pc.makeOutgoingCall);
+      sinon.assert.calledOnce(pc.iceRestart);
+
+      // And the routing does not stick: a later no-options getDescription is an
+      // offerless re-INVITE, which is rejected rather than re-run as an ICE
+      // restart or a (hanging) makeOutgoingCall on the open PC.
+      await handler.setDescription(ANSWER_SDP);
+      await assert.rejects(handler.getDescription(), /Offerless re-INVITE is not supported/);
+      sinon.assert.calledOnce(pc.makeOutgoingCall);
+      sinon.assert.calledOnce(pc.iceRestart);
     });
 
     it('routes the subsequent setDescription through processAnswer (ICE restart has outbound-offer semantics)', async () => {
@@ -223,38 +280,6 @@ describe('SipSessionDescriptionHandler', () => {
       assert.strictEqual(pc.processAnswer.firstCall.args[0], ANSWER_SDP);
       sinon.assert.notCalled(pc.answerIncomingCall);
     });
-
-    it('routes a subsequent inbound re-INVITE through answerIncomingCall (hasSentOffer resets after exchange)', async () => {
-      // SIP.js memoizes the SDH on the Session, so the same SDH may see a
-      // follow-up inbound re-INVITE after an outbound exchange completes.
-      const pc = createPeerConnectionStub({
-        makeOutgoingCall: sinon.stub().callsFake(
-          (_sid: string, _cfg: RTCConfiguration, cb: (sdp: string) => void) => cb(OFFER_SDP),
-        ) as sinon.SinonStub,
-        processAnswer: sinon.stub().callsFake(
-          (_sdp: string, cb: (pc: RTCPeerConnection) => void) => cb({} as RTCPeerConnection),
-        ) as sinon.SinonStub,
-        answerIncomingCall: sinon.stub().callsFake(
-          (
-            _sid: string,
-            _sdp: string,
-            _cfg: RTCConfiguration,
-            onAnswerReady: (answer: string) => void,
-            onMediaStarted: (pc: RTCPeerConnection) => void,
-          ) => {
-            onAnswerReady(ANSWER_SDP);
-            onMediaStarted({} as RTCPeerConnection);
-          },
-        ) as sinon.SinonStub,
-      });
-      const { handler } = createHandler(pc);
-      // Outbound exchange: offer -> answer.
-      await handler.getDescription();
-      await handler.setDescription(ANSWER_SDP);
-      // Simulated inbound re-INVITE: remote sends us an offer.
-      await handler.setDescription(OFFER_SDP);
-      sinon.assert.calledOnce(pc.answerIncomingCall);
-    });
   });
 
   describe('setDescription without prior offer (inbound)', () => {
@@ -305,6 +330,111 @@ describe('SipSessionDescriptionHandler', () => {
     });
   });
 
+  describe('remote re-INVITE (renegotiation)', () => {
+    // SIP.js memoizes the SDH on the Session, so the same SDH sees any
+    // follow-up in-dialog INVITE. Session.onInviteRequest drives
+    // setOfferAndGetAnswer: setDescription(remote offer) then getDescription().
+
+    it('routes a re-INVITE after an outbound call through pc.processOffer', async () => {
+      const pc = createPeerConnectionStub({
+        makeOutgoingCall: stubMakeOutgoingCall(),
+        processAnswer: stubProcessAnswer(),
+        processOffer: stubProcessOffer(),
+      });
+      const { handler } = createHandler(pc);
+      await handler.getDescription();
+      await handler.setDescription(ANSWER_SDP);
+
+      await handler.setDescription(REOFFER_SDP);
+
+      sinon.assert.calledOnce(pc.processOffer);
+      assert.strictEqual(pc.processOffer.firstCall.args[0], REOFFER_SDP);
+      // The live PeerConnection must not be re-initialized.
+      sinon.assert.notCalled(pc.answerIncomingCall);
+    });
+
+    it('routes a re-INVITE after an inbound call through pc.processOffer', async () => {
+      const pc = createPeerConnectionStub({
+        answerIncomingCall: stubAnswerIncomingCall(),
+        processOffer: stubProcessOffer(),
+      });
+      const { handler } = createHandler(pc);
+      await handler.setDescription(OFFER_SDP);
+      await handler.getDescription();
+
+      await handler.setDescription(REOFFER_SDP);
+
+      sinon.assert.calledOnce(pc.processOffer);
+      sinon.assert.calledOnce(pc.answerIncomingCall);
+    });
+
+    it('serves the renegotiated answer to the getDescription that follows', async () => {
+      const pc = createPeerConnectionStub({
+        makeOutgoingCall: stubMakeOutgoingCall(),
+        processAnswer: stubProcessAnswer(),
+        processOffer: stubProcessOffer(),
+      });
+      const { handler } = createHandler(pc);
+      await handler.getDescription();
+      await handler.setDescription(ANSWER_SDP);
+
+      // Full setOfferAndGetAnswer sequence.
+      await handler.setDescription(REOFFER_SDP);
+      const description = await handler.getDescription();
+
+      assert.deepStrictEqual(description, { body: REANSWER_SDP, contentType: APPLICATION_SDP });
+      sinon.assert.calledOnce(pc.makeOutgoingCall);
+    });
+
+    it('rejects the pending setDescription if pc.onerror fires during processOffer', async () => {
+      const pc = createPeerConnectionStub({
+        answerIncomingCall: stubAnswerIncomingCall(),
+        // processOffer never calls back
+      });
+      const { handler } = createHandler(pc);
+      await handler.setDescription(OFFER_SDP);
+      await handler.getDescription();
+
+      const pending = handler.setDescription(REOFFER_SDP);
+      pc.onerror({ info: { code: 31000, message: 'Error processing offer: boom' } });
+
+      await assert.rejects(pending, /Error processing offer: boom/);
+    });
+
+    it('rejects an offerless re-INVITE instead of hanging on makeOutgoingCall', async () => {
+      // Stable dialog + no SDP body: SIP.js asks for a fresh local offer.
+      // makeOutgoingCall would no-op on the open PC and never call back.
+      const pc = createPeerConnectionStub({
+        answerIncomingCall: stubAnswerIncomingCall(),
+        makeOutgoingCall: stubMakeOutgoingCall(),
+      });
+      const { handler } = createHandler(pc);
+      await handler.setDescription(OFFER_SDP);
+      await handler.getDescription();
+
+      await assert.rejects(handler.getDescription(), /Offerless re-INVITE is not supported/);
+      sinon.assert.notCalled(pc.makeOutgoingCall);
+    });
+
+    it('still routes an ICE-restart getDescription through pc.iceRestart after establishment', async () => {
+      const pc = createPeerConnectionStub({
+        makeOutgoingCall: stubMakeOutgoingCall(),
+        processAnswer: stubProcessAnswer(),
+        iceRestart: sinon.stub().callsFake(
+          (cb: (sdp: string) => void) => cb(REOFFER_SDP),
+        ) as sinon.SinonStub,
+      });
+      const { handler } = createHandler(pc);
+      await handler.getDescription();
+      await handler.setDescription(ANSWER_SDP);
+
+      const description = await handler.getDescription({ offerOptions: { iceRestart: true } });
+
+      sinon.assert.calledOnce(pc.iceRestart);
+      assert.deepStrictEqual(description, { body: REOFFER_SDP, contentType: APPLICATION_SDP });
+    });
+  });
+
   describe('close', () => {
     it('does not close the PeerConnection (Call owns its lifecycle)', () => {
       const pc = createPeerConnectionStub();
@@ -319,6 +449,59 @@ describe('SipSessionDescriptionHandler', () => {
       const pending = handler.getDescription();
       handler.close();
       await assert.rejects(pending, /closed/);
+    });
+
+    it('restores the original pc.onerror and pc.onfailed', () => {
+      const originalOnError = () => { /* Call's handler */ };
+      const originalOnFailed = () => { /* Call's handler */ };
+      const pc = createPeerConnectionStub({
+        onerror: originalOnError,
+        onfailed: originalOnFailed,
+      });
+      const { handler } = createHandler(pc);
+      // Constructor wrapped both.
+      assert.notStrictEqual(pc.onerror, originalOnError);
+      assert.notStrictEqual(pc.onfailed, originalOnFailed);
+
+      handler.close();
+
+      assert.strictEqual(pc.onerror, originalOnError);
+      assert.strictEqual(pc.onfailed, originalOnFailed);
+    });
+
+    it('does not stack wraps when a second handler is created over the same pc', () => {
+      const originalOnError = () => { /* Call's handler */ };
+      const pc = createPeerConnectionStub({ onerror: originalOnError });
+      const first = createHandler(pc).handler;
+      first.close();
+
+      const second = createHandler(pc).handler;
+      second.close();
+
+      assert.strictEqual(pc.onerror, originalOnError);
+    });
+
+    it('clears the cached answer', async () => {
+      const pc = createPeerConnectionStub({ answerIncomingCall: stubAnswerIncomingCall() });
+      const { handler } = createHandler(pc);
+      await handler.setDescription(OFFER_SDP);
+      assert.strictEqual((handler as any)._cachedAnswer, ANSWER_SDP);
+
+      handler.close();
+
+      assert.strictEqual((handler as any)._cachedAnswer, null);
+    });
+
+    it('rejects operations started after close instead of hanging', async () => {
+      // SIP.js does not drop its SDH reference on close, so late calls land here.
+      const pc = createPeerConnectionStub();
+      const { handler } = createHandler(pc);
+      handler.close();
+
+      await assert.rejects(handler.getDescription(), /closed/);
+      await assert.rejects(handler.setDescription(OFFER_SDP), /closed/);
+      sinon.assert.notCalled(pc.makeOutgoingCall);
+      sinon.assert.notCalled(pc.answerIncomingCall);
     });
   });
 

--- a/tests/unit/sipsessiondescriptionhandler.ts
+++ b/tests/unit/sipsessiondescriptionhandler.ts
@@ -130,22 +130,21 @@ describe('SipSessionDescriptionHandler', () => {
 
   describe('getDescription with ICE restart', () => {
     const ICE_RESTART_OFFER_SDP = 'v=0\r\no=ice-restart\r\n';
-    const ICE_RESTART_OPTS = { offerOptions: { iceRestart: true } };
-
-    it('routes through pc.iceRestart when options.offerOptions.iceRestart is true', async () => {
+    it('routes through pc.iceRestart after requestIceRestart()', async () => {
       const pc = createPeerConnectionStub({
         iceRestart: sinon.stub().callsFake(
           (cb: (sdp: string) => void) => cb(ICE_RESTART_OFFER_SDP),
         ) as sinon.SinonStub,
       });
       const { handler } = createHandler(pc);
-      const description = await (handler.getDescription as any)(ICE_RESTART_OPTS);
+      handler.requestIceRestart();
+      const description = await handler.getDescription();
       assert.deepStrictEqual(description, { body: ICE_RESTART_OFFER_SDP, contentType: APPLICATION_SDP });
       sinon.assert.calledOnce(pc.iceRestart);
       sinon.assert.notCalled(pc.makeOutgoingCall);
     });
 
-    it('falls back to makeOutgoingCall when options does NOT include iceRestart', async () => {
+    it('falls back to makeOutgoingCall when no restart was requested', async () => {
       const pc = createPeerConnectionStub({
         makeOutgoingCall: sinon.stub().callsFake(
           (_sid: string, _cfg: RTCConfiguration, cb: (sdp: string) => void) => cb(OFFER_SDP),
@@ -157,7 +156,7 @@ describe('SipSessionDescriptionHandler', () => {
       sinon.assert.notCalled(pc.iceRestart);
     });
 
-    it('does NOT leak iceRestart routing across calls (each getDescription reads options independently)', async () => {
+    it('does NOT leak iceRestart routing across calls (the request is one shot)', async () => {
       const pc = createPeerConnectionStub({
         makeOutgoingCall: sinon.stub().callsFake(
           (_sid: string, _cfg: RTCConfiguration, cb: (sdp: string) => void) => cb(OFFER_SDP),
@@ -174,7 +173,8 @@ describe('SipSessionDescriptionHandler', () => {
       await handler.getDescription();
       await handler.setDescription(ANSWER_SDP);
       // Options present: must route to iceRestart, not makeOutgoingCall again.
-      await (handler.getDescription as any)(ICE_RESTART_OPTS);
+      handler.requestIceRestart();
+      await handler.getDescription();
       sinon.assert.calledOnce(pc.makeOutgoingCall);
       sinon.assert.calledOnce(pc.iceRestart);
 
@@ -197,7 +197,8 @@ describe('SipSessionDescriptionHandler', () => {
         ) as sinon.SinonStub,
       });
       const { handler } = createHandler(pc);
-      await (handler.getDescription as any)(ICE_RESTART_OPTS);
+      handler.requestIceRestart();
+      await handler.getDescription();
       await handler.setDescription(ANSWER_SDP);
       sinon.assert.calledOnce(pc.processAnswer);
       sinon.assert.notCalled(pc.answerIncomingCall);
@@ -206,7 +207,8 @@ describe('SipSessionDescriptionHandler', () => {
     it('rejects the pending getDescription if pc.onerror fires during ICE restart', async () => {
       const pc = createPeerConnectionStub(); // iceRestart stub never calls back
       const { handler } = createHandler(pc);
-      const pending = (handler.getDescription as any)(ICE_RESTART_OPTS);
+      handler.requestIceRestart();
+      const pending = handler.getDescription();
       pc.onerror({ info: { code: 31000, message: 'ice restart failure' } });
       await assert.rejects(pending, /ice restart failure/);
     });
@@ -214,7 +216,8 @@ describe('SipSessionDescriptionHandler', () => {
     it('rejects the pending getDescription if pc.onfailed fires during ICE restart (createOffer rejection path)', async () => {
       const pc = createPeerConnectionStub(); // iceRestart stub never calls back
       const { handler } = createHandler(pc);
-      const pending = (handler.getDescription as any)(ICE_RESTART_OPTS);
+      handler.requestIceRestart();
+      const pending = handler.getDescription();
       pc.onfailed('createOffer rejected');
       await assert.rejects(pending, /createOffer rejected/);
     });
@@ -234,7 +237,8 @@ describe('SipSessionDescriptionHandler', () => {
       const previousOnFailed = sinon.spy();
       const pc = createPeerConnectionStub({ onfailed: previousOnFailed }); // iceRestart stub never calls back
       const { handler } = createHandler(pc);
-      const pending = (handler.getDescription as any)(ICE_RESTART_OPTS);
+      handler.requestIceRestart();
+      const pending = handler.getDescription();
       pc.onfailed('createOffer rejected');
       await assert.rejects(pending, /createOffer rejected/);
       sinon.assert.notCalled(previousOnFailed);
@@ -401,6 +405,30 @@ describe('SipSessionDescriptionHandler', () => {
       await assert.rejects(pending, /Error processing offer: boom/);
     });
 
+    it('rejects an offerless re-INVITE that follows an ICE restart', async () => {
+      // SIP.js persists session.invite()'s sessionDescriptionHandlerOptions into
+      // sessionDescriptionHandlerOptionsReInvite and replays it on every later
+      // in-dialog request, so the restart intent must not be read back from it.
+      const pc = createPeerConnectionStub({
+        makeOutgoingCall: stubMakeOutgoingCall(),
+        processAnswer: stubProcessAnswer(),
+        iceRestart: sinon.stub().callsFake(
+          (cb: (sdp: string) => void) => cb(REOFFER_SDP),
+        ) as sinon.SinonStub,
+      });
+      const { handler } = createHandler(pc);
+      await handler.getDescription();
+      await handler.setDescription(ANSWER_SDP);
+
+      handler.requestIceRestart();
+      await handler.getDescription();
+      await handler.setDescription(ANSWER_SDP);
+
+      await assert.rejects(handler.getDescription(), /Offerless re-INVITE is not supported/);
+      sinon.assert.calledOnce(pc.iceRestart);
+      sinon.assert.calledOnce(pc.makeOutgoingCall);
+    });
+
     it('rejects an offerless re-INVITE instead of hanging on makeOutgoingCall', async () => {
       // Stable dialog + no SDP body: SIP.js asks for a fresh local offer.
       // makeOutgoingCall would no-op on the open PC and never call back.
@@ -428,7 +456,8 @@ describe('SipSessionDescriptionHandler', () => {
       await handler.getDescription();
       await handler.setDescription(ANSWER_SDP);
 
-      const description = await handler.getDescription({ offerOptions: { iceRestart: true } });
+      handler.requestIceRestart();
+      const description = await handler.getDescription();
 
       sinon.assert.calledOnce(pc.iceRestart);
       assert.deepStrictEqual(description, { body: REOFFER_SDP, contentType: APPLICATION_SDP });

--- a/tests/unit/sipsignalingadapter.ts
+++ b/tests/unit/sipsignalingadapter.ts
@@ -52,6 +52,7 @@ function createSessionStub(initialState: string = 'Initial') {
     bye: sinon.stub().resolves(),
     cancel: sinon.stub().resolves(),
     invite: sinon.stub().resolves(),
+    sessionDescriptionHandler: { requestIceRestart: sinon.stub() },
     info: sinon.stub().resolves(),
     message: sinon.stub().resolves(),
     _simulateState(state: string) {
@@ -702,13 +703,54 @@ describe('SipSignalingAdapter', () => {
   describe('iceRestart()', () => {
     const mediaHandlerStub = () => ({ iceRestart: sinon.stub() });
 
-    it('passes offerOptions.iceRestart:true to session.invite', () => {
+    it('arms the session description handler for an ICE restart', () => {
       const { adapter, inviterStub } = createAdapter();
       adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: createPeerConnectionStub() });
       inviterStub.state = 'Established';
       adapter.iceRestart('call-1', { mediaHandler: mediaHandlerStub() });
+      sinon.assert.calledOnce(inviterStub.sessionDescriptionHandler.requestIceRestart);
+      // Passing it as an invite option would stick on the SIP.js Session and
+      // replay onto later server-initiated re-INVITEs.
       const reinviteOpts = inviterStub.invite.lastCall.args[0];
-      assert.strictEqual(reinviteOpts?.sessionDescriptionHandlerOptions?.offerOptions?.iceRestart, true);
+      assert.strictEqual(reinviteOpts?.sessionDescriptionHandlerOptions, undefined);
+    });
+
+    it('hangs up when the session fell back to the unbound SDH', () => {
+      // createUnboundSdh() is returned when a session has no PeerConnection
+      // binding. It has no requestIceRestart, so the restart cannot proceed.
+      const { adapter, inviterStub } = createAdapter();
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: createPeerConnectionStub() });
+      inviterStub.state = 'Established';
+      (inviterStub as any).sessionDescriptionHandler = {
+        getDescription: () => Promise.reject(new Error('unbound')),
+        hasDescription: () => false,
+        setDescription: () => Promise.reject(new Error('unbound')),
+        sendDtmf: () => false,
+        close: () => { /* no-op */ },
+      };
+      const hangupSpy = sinon.spy();
+      adapter.on('hangup', hangupSpy);
+
+      adapter.iceRestart('call-1', { mediaHandler: mediaHandlerStub() });
+
+      sinon.assert.calledOnceWithExactly(hangupSpy, { callsid: 'call-1' });
+      // Only the initial INVITE; no re-INVITE was sent.
+      sinon.assert.calledOnce(inviterStub.invite);
+    });
+
+    it('hangs up when the session has no usable description handler', () => {
+      const { adapter, inviterStub } = createAdapter();
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: createPeerConnectionStub() });
+      inviterStub.state = 'Established';
+      (inviterStub as any).sessionDescriptionHandler = undefined;
+      const hangupSpy = sinon.spy();
+      adapter.on('hangup', hangupSpy);
+
+      adapter.iceRestart('call-1', { mediaHandler: mediaHandlerStub() });
+
+      sinon.assert.calledOnceWithExactly(hangupSpy, { callsid: 'call-1' });
+      // Only the initial INVITE; no re-INVITE was sent.
+      sinon.assert.calledOnce(inviterStub.invite);
     });
 
     it('does NOT consult the mediaHandler (SIP SDH generates the offer itself)', () => {

--- a/tests/unit/sipsignalingadapter.ts
+++ b/tests/unit/sipsignalingadapter.ts
@@ -13,6 +13,7 @@ function createPeerConnectionStub(): IPeerConnection {
     makeOutgoingCall: sinon.stub(),
     answerIncomingCall: sinon.stub(),
     processAnswer: sinon.stub(),
+    processOffer: sinon.stub(),
     iceRestart: sinon.stub(),
     close: sinon.stub(),
   };

--- a/tests/unit/sipsignalingadapter.ts
+++ b/tests/unit/sipsignalingadapter.ts
@@ -52,7 +52,10 @@ function createSessionStub(initialState: string = 'Initial') {
     bye: sinon.stub().resolves(),
     cancel: sinon.stub().resolves(),
     invite: sinon.stub().resolves(),
-    sessionDescriptionHandler: { requestIceRestart: sinon.stub() },
+    sessionDescriptionHandler: {
+      requestIceRestart: sinon.stub(),
+      cancelIceRestart: sinon.stub(),
+    },
     info: sinon.stub().resolves(),
     message: sinon.stub().resolves(),
     _simulateState(state: string) {
@@ -713,6 +716,20 @@ describe('SipSignalingAdapter', () => {
       // replay onto later server-initiated re-INVITEs.
       const reinviteOpts = inviterStub.invite.lastCall.args[0];
       assert.strictEqual(reinviteOpts?.sessionDescriptionHandlerOptions, undefined);
+    });
+
+    it('disarms the SDH when the invite is skipped as RequestPending', async () => {
+      const { adapter, inviterStub } = createAdapter();
+      adapter.invite('call-1', { sdp: 'sdp', params: 'To=bob', peerConnection: createPeerConnectionStub() });
+      inviterStub.state = 'Established';
+      inviterStub.invite = sinon.stub().rejects(new RequestPendingError('pending'));
+
+      adapter.iceRestart('call-1', { mediaHandler: mediaHandlerStub() });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      sinon.assert.calledOnce(inviterStub.sessionDescriptionHandler.requestIceRestart);
+      sinon.assert.calledOnce(inviterStub.sessionDescriptionHandler.cancelIceRestart);
     });
 
     it('hangs up when the session fell back to the unbound SDH', () => {


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

https://twilio-engineering.atlassian.net/browse/VBLOCKS-7005

### Description
https://github.com/twilio-internal/voice-video-sdks-eng-docs/blob/main/investigations/voice/browser/sip-jssdk-action-items.md
- Item 22: added PeerConnection.processOffer() and a _hasNegotiated routing branch so a server re-INVITE renegotiates on the live PC instead of hanging forever
- Item 23: close() restores Call's original pc.onerror/pc.onfailed, plus a _closed guard so post-close calls reject rather than hang
- Item 24: close() clears _cachedAnswer
- Offerless re-INVITE rejects cleanly so sip.js answers 488 instead of stalling

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Ready for review
