### PR TITLE
fix(device): do not re-register while already registered on stream reconnect

### DIFF
--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -1260,9 +1260,14 @@ class Device extends EventEmitter {
     }
 
     // The signaling stream emits a `connected` event after reconnection, if the
-    // device was registered before this, then register again.
-    if (this._shouldReRegister) {
-      this.register();
+    // device was registered before this, then register again. `register()`
+    // rejects unless the device is `unregistered`, and nothing awaits the
+    // promise here, so guard the state and log a failure rather than letting it
+    // surface as an unhandled rejection the application cannot intercept.
+    if (this._shouldReRegister && this.state === Device.State.Unregistered) {
+      this.register().catch((error: any) => {
+        this._log.warn('Failed to re-register after the stream reconnected', error);
+      });
     }
   }
 

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -815,6 +815,35 @@ describe('Device', function() {
           sinon.assert.calledOnce(spy);
         });
 
+        it('should not attempt a re-register while the device is already registered', async () => {
+          await registerDevice();
+
+          // The stream drops. `_shouldReRegister` latches, and the device is
+          // moved to `unregistered`.
+          pstream.emit('offline');
+          await clock.tickAsync(0);
+          assert.equal(device['_shouldReRegister'], true);
+
+          // The stream comes back and the server restores presence on its own,
+          // so the device is `registered` again without `register()` running
+          // (which is what would have cleared `_shouldReRegister`).
+          pstream.emit('ready');
+          await clock.tickAsync(0);
+          assert.equal(device.state, Device.State.Registered);
+          assert.equal(device['_shouldReRegister'], true);
+
+          const spy = device.register = sinon.spy(device.register);
+
+          pstream.emit('connected', { region: 'EU_IRELAND' });
+          await clock.tickAsync(0);
+
+          // `register()` rejects with an `InvalidStateError` unless the device
+          // is `unregistered`, and nothing here awaits it, so calling it would
+          // surface as an unhandled rejection the application cannot intercept.
+          sinon.assert.notCalled(spy);
+          assert.equal(device.state, Device.State.Registered);
+        });
+
         it('should update the preferred uri', () => {
           pstream.emit('connected', { region: 'EU_IRELAND', edge: Edge.Dublin });
           assert.equal(device['_preferredURI'], ['wss://voice-js.dublin.twilio.com/signal']);


### PR DESCRIPTION
Fixes #465.

### Problem

`_onSignalingConnected` re-registers on the application's behalf:

```ts
if (this._shouldReRegister) {
  this.register();
}
```

Two things are missing here: a state check, and handling of the returned promise. `register()` rejects with an `InvalidStateError` unless the device is `unregistered`:

```ts
async register(): Promise<void> {
  if (this.state !== Device.State.Unregistered) {
    throw new InvalidStateError(
      `Attempt to register when device is in state "${this.state}". ` +
      `Must be "${Device.State.Unregistered}".`,
    );
  }
  ...
}
```

`_shouldReRegister` is set in exactly one place — `_onSignalingOffline` — and is only cleared by `register()` and `unregister()`. So if the backend restores presence on its own after a reconnect (a `ready` event puts the device back in `registered` without `register()` ever running), the flag stays latched. The following `connected` event then calls `register()` on an already-registered device.

Because nothing awaits or catches that promise, the rejection escapes as an **unhandled rejection** that the application has no way to intercept — and since the flag is still never cleared, it repeats on every subsequent reconnect for the life of the session.

### Fix

Guard on the state and log a failure rather than discarding the promise. This mirrors what the sibling handler `_onPageShow` already does for the BFCache restore path (`lib/twilio/device.ts:1209-1214`), so the two re-registration paths now behave consistently.

The guard is deliberately narrow: it only skips the call in the case where `register()` would have thrown synchronously anyway, so the normal reconnect flow (device is `unregistered` after `offline`) is unchanged.

### Tests

Added `should not attempt a re-register while the device is already registered` next to the existing `on signaling.connected` re-register tests. It reproduces the exact ordering: `offline` → `_shouldReRegister` latches → `ready` restores `registered` without clearing the flag → `connected`.

I verified it is a real regression test — reverting only the `lib/twilio/device.ts` change makes it fail with:

```
AssertError: expected register to not have been called but was called once
```

Validation on this branch:

- `npx mocha -r ts-node/register ./tests/index.ts` → **1583 passing, 6 pending, 0 failing**
- `npm run lint` (tslint) → clean

No public API or behavioural change for correctly-sequenced reconnects.
