### PR TITLE
[VBLOCKS-7064] fix: output device unhandled promise rejection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 :warning: **Important**: If you are upgrading to version 2.3.0 or later and have firewall rules or network configuration that blocks any unknown traffic by default, you need to update your configuration to allow connections to the new DNS names and IP addresses. Please refer to this [changelog](#230-january-23-2023) for more details.
 
+2.18.5 (Work in progress)
+=========================
+
+Bug Fixes
+---------
+
+- Fixed an [issue](https://github.com/twilio/twilio-voice.js/issues/458) where losing an audio output device during a call caused an unhandled promise rejection. On browsers without audio output selection, such as Chrome on Android, `OutputDeviceCollection.delete()` attempted a sink change that can never apply there, raising `NotSupportedError` without affecting call audio; it no longer attempts one. On browsers that do support selection, a failed switch to the fallback device is now logged as a warning. Thanks @ifabijanovic for reporting this.
+
+  Note: on browsers without audio output selection, `device.audio.speakerDevices.get()` and `ringtoneDevices.get()` now stay empty after a device is lost instead of reporting `default`.
+
 2.18.4 (August 31, 2026)
 ========================
 

--- a/lib/twilio/outputdevicecollection.ts
+++ b/lib/twilio/outputdevicecollection.ts
@@ -28,13 +28,19 @@ export default class OutputDeviceCollection {
   /**
    * Delete a device from the collection. If no devices remain, the 'default'
    * device will be added as the sole device. If no `default` device exists,
-   * the first available device will be used.
+   * the first available device will be used. On browsers without output
+   * selection, the collection is left empty.
    * @param device - The device to delete from the collection
    * @returns whether the device was present before it was deleted
    */
   delete(device: MediaDeviceInfo): boolean {
     this._log.debug('.delete', device);
     const wasDeleted: boolean = !!(this._activeDevices.delete(device));
+
+    // Without sink support _beforeChange rejects, and nothing can catch it.
+    if (!this._isSupported) {
+      return wasDeleted;
+    }
 
     const defaultDevice: MediaDeviceInfo = this._availableDevices.get('default')
       || Array.from(this._availableDevices.values())[0];
@@ -47,8 +53,15 @@ export default class OutputDeviceCollection {
     // removed or lost.
     const deviceIds = Array.from(this._activeDevices.values()).map(deviceInfo => deviceInfo.deviceId);
 
-    this._beforeChange(this._name, deviceIds);
-    return !!wasDeleted;
+    // Nothing can await a synchronous method. The wrapper also tolerates a
+    // _beforeChange that returns a non-promise or throws.
+    new Promise(resolve => {
+      resolve(this._beforeChange(this._name, deviceIds));
+    }).catch(reason => {
+      this._log.warn(`Unable to update audio output devices. ${reason}`);
+    });
+
+    return wasDeleted;
   }
 
   /**

--- a/tests/audiohelper.js
+++ b/tests/audiohelper.js
@@ -1123,6 +1123,26 @@ describe('AudioHelper', () => {
       });
     });
 
+    context('when output selection is not supported', () => {
+      beforeEach(async () => {
+        onActiveOutputsChanged = sinon.spy(() => Promise.resolve());
+        audio = new AudioHelper(onActiveOutputsChanged, null, {
+          getUserMedia,
+          mediaDevices,
+          setSinkId: undefined,
+        });
+        await new Promise(resolve => setTimeout(resolve));
+      });
+
+      it('should not trigger onActiveOutputsChanged when an output device is lost', async () => {
+        assert.equal(audio.isOutputSelectionSupported, false);
+        availableDevices.splice(1, 1);
+        handlers.get('devicechange')();
+        await new Promise(resolve => setTimeout(resolve));
+        assert.equal(onActiveOutputsChanged.callCount, 0);
+      });
+    });
+
     describe('_destroyRemoteProcessedStream', () => {
       it('should destroy and stop remote processed tracks', async () => {
         remoteProcessedStreamStopStub = sinon.stub();

--- a/tests/outputdevicecollection.js
+++ b/tests/outputdevicecollection.js
@@ -33,6 +33,30 @@ describe('OutputDeviceCollection', () => {
         throw new Error('Promise was unexpectedly fulfilled');
       }, () => { }));
     });
+
+    describe('#delete', () => {
+      it('should remove the device from the active set', () => {
+        const fakeDevice = { deviceId: 'foo' };
+        collection._activeDevices.add(fakeDevice);
+        assert.equal(collection.delete(fakeDevice), true);
+        assert.equal(collection.get().size, 0);
+      });
+
+      it('should not add the default device', () => {
+        const deviceDefault = { deviceId: 'default', kind: 'audiooutput' };
+        collection = new OutputDeviceCollection('foo',
+          new Map([['default', deviceDefault]]), () => { }, false);
+        collection.delete({ deviceId: 'foo' });
+        assert.equal(collection.get().size, 0);
+      });
+
+      it('should not trigger _beforeChange', () => {
+        const onChange = sinon.spy();
+        collection = new OutputDeviceCollection('foo', new Map(), onChange, false);
+        collection.delete({ deviceId: 'foo' });
+        assert.equal(onChange.callCount, 0);
+      });
+    });
   });
 
   context('when supported', () => {
@@ -175,6 +199,27 @@ describe('OutputDeviceCollection', () => {
           collection.delete(fakeDevice1);
           assert.equal(collection.get().size, 1);
           assert(collection.get().has(fakeDevice2));
+        });
+      });
+
+      context('when _beforeChange fails', () => {
+        beforeEach(() => {
+          collection._log = { debug: sinon.stub(), warn: sinon.stub() };
+        });
+
+        it('should log a warning when it rejects', async () => {
+          collection._beforeChange = () => Promise.reject(new Error('expected'));
+          collection._activeDevices.add(deviceFoo);
+          collection.delete(deviceFoo);
+          await new Promise(resolve => setTimeout(resolve));
+          assert.equal(collection._log.warn.callCount, 1);
+          assert(/expected/.test(collection._log.warn.args[0][0]));
+        });
+
+        it('should not throw when it throws synchronously', () => {
+          collection._beforeChange = () => { throw new Error('expected'); };
+          collection._activeDevices.add(deviceFoo);
+          assert.doesNotThrow(() => collection.delete(deviceFoo));
         });
       });
     });


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

https://twilio-engineering.atlassian.net/browse/VBLOCKS-7064

### Description

Fixes: https://github.com/twilio/twilio-voice.js/issues/458

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Ready for review
