### PR TITLE
[VBLOCKS-7102] fix: register retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Bug Fixes
 
   Note: on browsers without audio output selection, `device.audio.speakerDevices.get()` and `ringtoneDevices.get()` now stay empty after a device is lost instead of reporting `default`.
 
+- Fixed an issue where the SDK emitted a false `AccessTokenInvalid (20101)` error on a still valid access token after the signaling WebSocket dropped. Registration messages that failed to send while the connection was down were queued and replayed immediately after reconnecting, before the server had validated the token, and the server rejected them with error `31204`. Registration messages are no longer queued, and a re-registration that fails because the connection dropped again is now logged as a warning instead of surfacing as an unhandled promise rejection. The `Device` already re-registers once the signaling connection is re-established, so registration recovery is unchanged.
+
 2.18.4 (August 31, 2026)
 ========================
 

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -1262,7 +1262,9 @@ class Device extends EventEmitter {
     // The signaling stream emits a `connected` event after reconnection, if the
     // device was registered before this, then register again.
     if (this._shouldReRegister) {
-      this.register();
+      this.register().catch((error: any) => {
+        this._log.warn('Failed to re-register after signaling reconnect', error);
+      });
     }
   }
 

--- a/lib/twilio/pstream.ts
+++ b/lib/twilio/pstream.ts
@@ -214,7 +214,9 @@ PStream.prototype.sendMessage = function(
 
 PStream.prototype.register = function(mediaCapabilities) {
   const regPayload = { media: mediaCapabilities };
-  this._publish('register', regPayload, true);
+  // A queued register is replayed alongside `listen`, before the server
+  // validates the token, and earns a 31204. Re-register on `connected` covers it.
+  this._publish('register', regPayload, false);
 };
 
 PStream.prototype.invite = function(sdp, callsid, params) {

--- a/tests/pstream.js
+++ b/tests/pstream.js
@@ -379,6 +379,25 @@ describe('PStream', () => {
         assert.equal(pstream._messageQueue.length, 0);
       });
     });
+
+    context('when a register fails to send', () => {
+      beforeEach(() => {
+        pstream.transport.send = sinon.spy(() => false);
+      });
+
+      it('should not queue the register', () => {
+        pstream.register({ audio: true });
+        assert.equal(pstream._messageQueue.length, 0);
+      });
+
+      it('should only send a listen when the transport reopens', () => {
+        pstream.register({ audio: true });
+        pstream.transport.send = sinon.spy(() => true);
+        pstream.transport.emit('open');
+        assert.equal(pstream.transport.send.callCount, 1);
+        assert.equal(JSON.parse(pstream.transport.send.args[0][0]).type, 'listen');
+      });
+    });
   });
 
   [
@@ -455,7 +474,7 @@ describe('PStream', () => {
     ]],
   ].forEach(([method, type, scenarios]) => {
     describe(method, () => {
-      const shouldRetry = method !== 'reinvite';
+      const shouldRetry = !['register', 'reinvite'].includes(method);
       scenarios.forEach(({ args, payload, scenario }) => {
         context(scenario, () => {
           it('should return undefined', () => {

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -815,6 +815,23 @@ describe('Device', function() {
           sinon.assert.calledOnce(spy);
         });
 
+        it('should not reject when the stream goes offline before the re-register completes', async () => {
+          await registerDevice();
+
+          const warnStub = device['_log'].warn = sinon.stub();
+          pstream.emit('offline');
+          await clock.tickAsync(0);
+          pstream.emit('connected', { region: 'EU_IRELAND' });
+          await clock.tickAsync(0);
+
+          // A second drop before the server `ready` rejects the re-register.
+          pstream.emit('offline');
+          await clock.tickAsync(0);
+
+          sinon.assert.calledOnce(warnStub);
+          assert.equal(device.state, Device.State.Unregistered);
+        });
+
         it('should update the preferred uri', () => {
           pstream.emit('connected', { region: 'EU_IRELAND', edge: Edge.Dublin });
           assert.equal(device['_preferredURI'], ['wss://voice-js.dublin.twilio.com/signal']);

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -815,6 +815,26 @@ describe('Device', function() {
           sinon.assert.calledOnce(spy);
         });
 
+        it('should attempt a re-register if the stream dropped while registering', async () => {
+          // Never send `ready`, so the device is still registering when the
+          // stream drops.
+          const registerPromise = device.register();
+          const didReject = registerPromise.then(() => false, () => true);
+          await clock.tickAsync(0);
+          assert.equal(device.state, Device.State.Registering);
+
+          pstream.register.resetHistory();
+          pstream.emit('offline');
+          await clock.tickAsync(0);
+          assert.equal(await didReject, true);
+          assert.equal(device.state, Device.State.Unregistered);
+
+          pstream.emit('connected', { region: 'EU_IRELAND' });
+          await clock.tickAsync(0);
+
+          sinon.assert.calledOnce(pstream.register);
+        });
+
         it('should not reject when the stream goes offline before the re-register completes', async () => {
           await registerDevice();
 

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -819,7 +819,7 @@ describe('Device', function() {
           // Never send `ready`, so the device is still registering when the
           // stream drops.
           const registerPromise = device.register();
-          const didReject = registerPromise.then(() => false, () => true);
+          const didReject = registerPromise.then(() => false).catch(() => true);
           await clock.tickAsync(0);
           assert.equal(device.state, Device.State.Registering);
 


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

https://twilio-engineering.atlassian.net/browse/VBLOCKS-7102

### Description

Fix reconnect race surfaces false 20101 AccessTokenInvalid after transport drop

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Ready for review
