### PR TITLE
[VBLOCKS-7102] fix: stop registration timer when signaling offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Bug Fixes
 
 - Fixed an issue where the SDK emitted a false `AccessTokenInvalid (20101)` error on a still valid access token after the signaling WebSocket dropped. Registration messages that failed to send while the connection was down were queued and replayed immediately after reconnecting, before the server had validated the token, and the server rejected them with error `31204`. Registration messages are no longer queued, and a re-registration that fails because the connection dropped again is now logged as a warning instead of surfacing as an unhandled promise rejection. The `Device` already re-registers once the signaling connection is re-established, so registration recovery is unchanged.
 
+- Fixed an issue where the periodic registration timer kept running while the signaling connection was down. A registration that fired after the WebSocket reopened but before the server validated the access token was rejected with error `31204` and surfaced as a false `AccessTokenInvalid (20101)`, the same symptom as the issue above. The timer now stops when the signaling stream goes offline, and re-registering on reconnect restarts it, so the registration cadence is unchanged.
+
 2.18.4 (August 31, 2026)
 ========================
 

--- a/cypress/e2e/deviceLifecycle.cy.ts
+++ b/cypress/e2e/deviceLifecycle.cy.ts
@@ -163,6 +163,42 @@ describe('Device Lifecycle', function() {
       assert.strictEqual(device.state, Device.State.Registered);
     });
 
+    it('should not register while the signaling stream is offline', async function() {
+      // One registration interval plus reconnect time.
+      this.timeout(120000);
+
+      const identity = 'id-' + Date.now();
+      const token = await generateAccessToken(identity);
+      device = new Device(token);
+
+      const errorCodes: number[] = [];
+      device.on(Device.EventName.Error, (error: any) => errorCodes.push(error.code));
+      await device.register();
+
+      const transport = (device as any)._stream.transport;
+      const connect = transport._connect;
+
+      // Drop the socket and block reconnects so the outage outlasts the 30s
+      // registration interval.
+      const unregisteredPromise = expectEvent(Device.EventName.Unregistered, device);
+      transport._connect = () => { /* no-op */ };
+      transport._socket.close();
+      await unregisteredPromise;
+
+      // Presence is the only thing publishing on an idle device, so a 31009
+      // here means a registration went out over the closed transport.
+      errorCodes.length = 0;
+      await new Promise(resolve => setTimeout(resolve, 35000));
+      assert.ok(!errorCodes.includes(31009), `registered while offline: ${errorCodes}`);
+
+      const registeredPromise = expectEvent(Device.EventName.Registered, device);
+      transport._connect = connect;
+      transport.open();
+      await registeredPromise;
+
+      assert.ok(!errorCodes.includes(20101), `false AccessTokenInvalid: ${errorCodes}`);
+    });
+
     it('should throw when passing a non-string token', async () => {
       const identity = 'id-' + Date.now();
       const token = await generateAccessToken(identity);

--- a/lib/twilio/device.ts
+++ b/lib/twilio/device.ts
@@ -1385,6 +1385,9 @@ class Device extends EventEmitter {
     this._edge = null;
     this._region = null;
 
+    // A tick landing before the server validates the token earns a 31204.
+    this._stopRegistrationTimer();
+
     this._shouldReRegister = this.state !== Device.State.Unregistered;
 
     this._setState(Device.State.Unregistered);

--- a/tests/unit/device.ts
+++ b/tests/unit/device.ts
@@ -835,6 +835,39 @@ describe('Device', function() {
           sinon.assert.calledOnce(pstream.register);
         });
 
+        it('should stop the registration timer when the stream goes offline', async () => {
+          await registerDevice();
+
+          pstream.register.resetHistory();
+          pstream.emit('offline');
+          await clock.tickAsync(0);
+
+          // The timer would otherwise fire mid-outage, or in the window after
+          // the socket reopens but before the server validates the token.
+          await clock.tickAsync(90000);
+          sinon.assert.notCalled(pstream.register);
+
+          pstream.emit('connected', { region: 'ie1' });
+          await clock.tickAsync(0);
+
+          sinon.assert.calledOnce(pstream.register);
+        });
+
+        it('should resume the registration cadence after reconnecting', async () => {
+          await registerDevice();
+
+          pstream.emit('offline');
+          await clock.tickAsync(0);
+          pstream.emit('connected', { region: 'ie1' });
+          await clock.tickAsync(0);
+          pstream.emit('ready');
+          await clock.tickAsync(0);
+
+          pstream.register.resetHistory();
+          await clock.tickAsync(30000 + 1);
+          sinon.assert.calledOnce(pstream.register);
+        });
+
         it('should not reject when the stream goes offline before the re-register completes', async () => {
           await registerDevice();
 


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

https://twilio-engineering.atlassian.net/browse/VBLOCKS-7149

### Description

- The 30 second registration timer is never stopped when the stream goes offline, so a tick landing after the socket reopens but before the gateway replies `connected` sends a `register` early resulting in a `31204`.


## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Ready for review
