### PR TITLE
chore: changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 :warning: **Important**: If you are upgrading to version 2.3.0 or later and have firewall rules or network configuration that blocks any unknown traffic by default, you need to update your configuration to allow connections to the new DNS names and IP addresses. Please refer to this [changelog](#230-january-23-2023) for more details.
 
-2.18.5 (Work in progress)
-=========================
+2.18.5 (September 10, 2026)
+===========================
 
 Bug Fixes
 ---------


### PR DESCRIPTION
Stamps the 2.18.5 release date on the changelog ahead of cutting the final release, matching #468 for 2.18.4.

```
-2.18.5 (Work in progress)
+2.18.5 (September 10, 2026)
```

The three bug fix entries under it are already on master, one each for VBLOCKS-7064, VBLOCKS-7102 and VBLOCKS-7149. No other changes.

Merge this before dispatching Prepare Release with `2.18.5` / `2.18.6-dev`.